### PR TITLE
Fix regexp for virtual interfaces

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -497,6 +497,11 @@ func getNetworkAddresses() ([]Address, error) {
 		if mac == "" {
 			continue
 		}
+
+		if utils.VirtualIfacePattern.MatchString(iface.Name) {
+			continue
+		}
+
 		addrs, err := iface.Addrs()
 		if err != nil {
 			return nil, err

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -55,7 +55,7 @@ var (
 	mmcDiskPattern       = regexp.MustCompile(`^(mmcblk\d+)(p\d+)?$`)
 	lvmDiskPattern       = regexp.MustCompile(`^(dm-\d+)$`)
 	macDiskPattern       = regexp.MustCompile(`^(disk\d+)(s\d+)?$`)
-	VirtualIfacePattern  = regexp.MustCompile(`^(lo|docker|veth|br-|virbr|vmnet|tap|tun|wl|wg|zt|tailscale|enp0s|cni)`)
+	VirtualIfacePattern  = regexp.MustCompile(`^(lo|docker|veth|br-|virbr|vmnet|tap|tun|wg|zt|tailscale|enp0s|cni)`)
 )
 
 func CalculateNetworkBps(current net.IOCountersStat, last net.IOCountersStat, interval time.Duration) (inputBps float64, outputBps float64) {


### PR DESCRIPTION
- Fix the regular expression for filtering virtual interfaces in this [PR](https://github.com/alpacanetworks/alpamon/pull/72).
- Additionally, exception handling to filter virtual interfaces has been added to `getNetworkAddress()`.