### PR TITLE
Support string list of group names as input

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -555,7 +555,7 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 	for _, groupname := range data.Groupnames {
 		gid, err := utils.LookUpGID(groupname)
 		if err != nil {
-			return 0, fmt.Sprintf("Failed to lookup GID for group '%s'. %s", groupname, err.Error())
+			return 0, fmt.Sprintf("Failed to lookup GID for group '%s'. %s", groupname, err)
 		}
 		gids = append(gids, uint64(gid))
 	}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -551,21 +551,12 @@ func (cr *CommandRunner) modUser() (exitCode int, result string) {
 		return 1, fmt.Sprintf("moduser: Not enough information. %s", err)
 	}
 
-	var gids []uint64
-	for _, groupname := range data.Groupnames {
-		gid, err := utils.LookUpGID(groupname)
-		if err != nil {
-			return 0, fmt.Sprintf("Failed to lookup GID for group '%s'. %s", groupname, err)
-		}
-		gids = append(gids, uint64(gid))
-	}
-
 	if utils.PlatformLike == "debian" || utils.PlatformLike == "rhel" {
 		exitCode, result = runCmdWithOutput(
 			[]string{
 				"/usr/sbin/usermod",
 				"--comment", data.Comment,
-				"-G", utils.JoinUint64s(gids),
+				"-G", strings.Join(data.Groupnames, ","),
 				data.Username,
 			},
 			"root", "", nil, 60,

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -39,6 +39,7 @@ type CommandData struct {
 	Cols                    uint16   `json:"cols"`
 	Username                string   `json:"username"`
 	Groupname               string   `json:"groupname"`
+	Groupnames              []string `json:"groupnames"`
 	HomeDirectory           string   `json:"home_directory"`
 	HomeDirectoryPermission string   `json:"home_directory_permission"`
 	UID                     uint64   `json:"uid"`
@@ -93,8 +94,9 @@ type deleteGroupData struct {
 }
 
 type modUserData struct {
-	Username string `validate:"required"`
-	Comment  string `validate:"required"`
+	Username   string   `validate:"required"`
+	Groupnames []string `validate:"required"`
+	Comment    string   `validate:"required"`
 }
 
 type openPtyData struct {


### PR DESCRIPTION
### Description

Currently `alpamon` supports either a single group name (string) or a list of group IDs as input. This issue aims to extend the supported input types to include a list of group names (as strings).

Before executing the `moduser` command, `alpamon` will resolve each group name in the list to its corresponding group ID.