### PR TITLE
Resolve "Fix edge cases that occur when creating/deleting system users"

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -461,7 +461,8 @@ func (cr *CommandRunner) addGroup() (exitCode int, result string) {
 
 func (cr *CommandRunner) delUser() (exitCode int, result string) {
 	data := deleteUserData{
-		Username: cr.data.Username,
+		Username:           cr.data.Username,
+		PurgeHomeDirectory: cr.data.PurgeHomeDirectory,
 	}
 
 	err := cr.validateData(data)
@@ -469,30 +470,58 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 		return 1, fmt.Sprintf("deluser: Not enough information. %s", err)
 	}
 
-	if utils.PlatformLike == "debian" {
-		exitCode, result = runCmdWithOutput(
-			[]string{
-				"/usr/sbin/deluser",
-				data.Username,
-			},
-			"root", "", nil, 60,
-		)
-		if exitCode != 0 {
-			return exitCode, result
+	cmd := "/usr/sbin/userdel"
+	args := []string{}
+
+	switch utils.PlatformLike {
+	case "debian":
+		cmd = "/usr/sbin/deluser"
+		if data.PurgeHomeDirectory {
+			args = append(args, "--remove-home")
 		}
-	} else if utils.PlatformLike == "rhel" {
-		exitCode, result = runCmdWithOutput(
-			[]string{
-				"/usr/sbin/userdel",
-				data.Username,
-			},
-			"root", "", nil, 60,
-		)
-		if exitCode != 0 {
-			return exitCode, result
+	case "rhel":
+		if data.PurgeHomeDirectory {
+			args = append(args, "--remove")
 		}
-	} else {
+	default:
 		return 1, "Not implemented 'deluser' command for this platform."
+	}
+
+	if !data.PurgeHomeDirectory {
+		homeDir := fmt.Sprintf("/home/%s", data.Username)
+		timestamp := time.Now().UTC().Format(time.RFC3339)
+		backupDir := fmt.Sprintf("/home/deleted_users/%s_%s", data.Username, timestamp)
+
+		err = os.Mkdir("/home/deleted_users", 0755)
+		if err != nil {
+			return 1, fmt.Sprintf("Failed to create backup directory: %v", err)
+		}
+
+		_, err = os.Stat(homeDir)
+		if err != nil {
+			return 1, fmt.Sprintf("%s not exist: %v", homeDir, err)
+		}
+
+		err = os.Rename(homeDir, backupDir)
+		if err != nil {
+			return 1, fmt.Sprintf("Failed to move home directory: %v", err)
+		}
+
+		err = utils.ChownRecursive(backupDir, 0, 0)
+		if err != nil {
+			return 1, fmt.Sprintf("Failed to chown backup directory: %v", err)
+		}
+	}
+
+	args = append(args, data.Username)
+	cmdString := append([]string{cmd}, args...)
+
+	exitCode, result = runCmdWithOutput(
+		cmdString,
+		"root", "", nil, 60,
+	)
+	if exitCode != 0 {
+		return exitCode, result
 	}
 
 	cr.sync([]string{"groups", "users"})

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -492,7 +492,7 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 		timestamp := time.Now().UTC().Format(time.RFC3339)
 		backupDir := fmt.Sprintf("/home/deleted_users/%s_%s", data.Username, timestamp)
 
-		err = os.MkdirAll("/home/deleted_users", 0755)
+		err = os.MkdirAll("/home/deleted_users", 0700)
 		if err != nil {
 			return 1, fmt.Sprintf("Failed to create backup directory: %v", err)
 		}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -492,7 +492,7 @@ func (cr *CommandRunner) delUser() (exitCode int, result string) {
 		timestamp := time.Now().UTC().Format(time.RFC3339)
 		backupDir := fmt.Sprintf("/home/deleted_users/%s_%s", data.Username, timestamp)
 
-		err = os.Mkdir("/home/deleted_users", 0755)
+		err = os.MkdirAll("/home/deleted_users", 0755)
 		if err != nil {
 			return 1, fmt.Sprintf("Failed to create backup directory: %v", err)
 		}

--- a/pkg/runner/command_types.go
+++ b/pkg/runner/command_types.go
@@ -41,6 +41,7 @@ type CommandData struct {
 	Groupname               string   `json:"groupname"`
 	HomeDirectory           string   `json:"home_directory"`
 	HomeDirectoryPermission string   `json:"home_directory_permission"`
+	PurgeHomeDirectory      bool     `json:"purge_home"`
 	UID                     uint64   `json:"uid"`
 	GID                     uint64   `json:"gid"`
 	Comment                 string   `json:"comment"`
@@ -85,7 +86,8 @@ type addGroupData struct {
 }
 
 type deleteUserData struct {
-	Username string `validate:"required"`
+	Username           string `validate:"required"`
+	PurgeHomeDirectory bool   `validate:"omitempty"`
 }
 
 type deleteGroupData struct {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -520,7 +520,7 @@ func (fc *FtpClient) chown(path, username, groupname string, recursive bool) (Co
 	msg := ""
 	if recursive {
 		msg = " recursively"
-		err = fc.chownRecursive(path, uid, gid)
+		err = utils.ChownRecursive(path, uid, gid)
 	} else {
 		err = os.Chown(path, uid, gid)
 	}
@@ -534,23 +534,4 @@ func (fc *FtpClient) chown(path, username, groupname string, recursive bool) (Co
 	return CommandResult{
 		Message: fmt.Sprintf("Changed owner of %s to UID: %d, GID: %d%s", path, uid, gid, msg),
 	}, nil
-}
-
-func (fc *FtpClient) chownRecursive(path string, uid, gid int) error {
-	return filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil
-		}
-
-		return os.Chown(p, uid, gid)
-	})
 }

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -145,3 +145,22 @@ func GetFileInfo(info os.FileInfo, path string) (permString, permOctal, owner, g
 
 	return permString, permOctal, ownerInfo.Username, groupInfo.Name, nil
 }
+
+func ChownRecursive(path string, uid, gid int) error {
+	return filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		return os.Chown(p, uid, gid)
+	})
+}


### PR DESCRIPTION
As mentioned in https://github.com/alpacanetworks/alpamon/issues/86, fix an edge case where a system user is deleted, 
and then a new system user is created with the exact same username as follows:

- Update `delUser` command
  - Add `PurgeHomeDirectory` to support system user purge.
  - If `PurgeHomeDirectory` is false, the home directory of the system user to be deleted will be moved to a backup directory.