### PR TITLE
refactor(ftp): modify websocket url

### DIFF
--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -34,7 +34,7 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 
 	return &FtpClient{
 		requestHeader:    headers,
-		url:              strings.Replace(data.ServerURL, "http", "ws", 1) + data.URL,
+		url:              data.URL,
 		homeDirectory:    data.HomeDirectory,
 		workingDirectory: data.HomeDirectory,
 		log:              data.Logger,


### PR DESCRIPTION
This is PR that re-modify for FTP client websocket URL.   

This modify is not affected for production users, only local develop user will be affected. You need to use proxy-server for WebFTP in develop.