### PR TITLE
feat(firewall): Temporarily disable firewall functionality

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -245,21 +245,37 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 
 		return 0, "Collector will be restarted."
 	case "firewall":
+		if utils.IsFirewallDisabled() {
+			log.Warn().Msg("Firewall command ignored - firewall functionality is temporarily disabled")
+			return 0, "Firewall functionality is temporarily disabled"
+		}
 		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
 			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
 		}
 		return cr.firewall()
 	case "firewall-rollback":
+		if utils.IsFirewallDisabled() {
+			log.Warn().Msg("Firewall rollback command ignored - firewall functionality is temporarily disabled")
+			return 0, "Firewall functionality is temporarily disabled"
+		}
 		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
 			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
 		}
 		return cr.firewallRollback()
 	case "firewall-reorder-chains":
+		if utils.IsFirewallDisabled() {
+			log.Warn().Msg("Firewall reorder-chains command ignored - firewall functionality is temporarily disabled")
+			return 0, "Firewall functionality is temporarily disabled"
+		}
 		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
 			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
 		}
 		return cr.firewallReorderChains()
 	case "firewall-reorder-rules":
+		if utils.IsFirewallDisabled() {
+			log.Warn().Msg("Firewall reorder-rules command ignored - firewall functionality is temporarily disabled")
+			return 0, "Firewall functionality is temporarily disabled"
+		}
 		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
 			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
 		}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -245,12 +245,24 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 
 		return 0, "Collector will be restarted."
 	case "firewall":
+		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
+		}
 		return cr.firewall()
 	case "firewall-rollback":
+		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
+		}
 		return cr.firewallRollback()
 	case "firewall-reorder-chains":
+		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
+		}
 		return cr.firewallReorderChains()
 	case "firewall-reorder-rules":
+		if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+			return 1, fmt.Sprintf("Alpacon firewall management is disabled because %s is active. Please use %s to manage firewall rules.", toolName, toolName)
+		}
 		return cr.firewallReorderRules()
 	case "help":
 		helpMessage := `

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -64,12 +64,16 @@ func commitSystemInfo() {
 		"description": "Committed system information. version: %s"}`, version.Version)), 80, time.Time{})
 
 	// Sync firewall rules after committing system info
-	// Always sync with alpacon regardless of current ruleset state
-	firewallData, err := utils.CollectFirewallRules()
-	if err != nil {
-		log.Debug().Err(err).Msg("Failed to collect firewall rules during commit.")
+	// Skip if high-level firewall tools (ufw/firewalld) are detected
+	if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+		log.Info().Msgf("Skipping firewall sync - %s is active", toolName)
 	} else {
-		scheduler.Rqueue.Post(firewallSyncURL, firewallData, 80, time.Time{})
+		firewallData, err := utils.CollectFirewallRules()
+		if err != nil {
+			log.Debug().Err(err).Msg("Failed to collect firewall rules during commit.")
+		} else {
+			scheduler.Rqueue.Post(firewallSyncURL, firewallData, 80, time.Time{})
+		}
 	}
 
 	log.Info().Msg("Completed committing system information.")
@@ -155,7 +159,11 @@ func syncSystemInfo(session *scheduler.Session, keys []string) {
 			remoteData = &[]Partition{}
 		case "firewall":
 			// Firewall sync only posts current rules without comparison
-			// Early return to avoid unnecessary processing
+			// Skip if high-level firewall tools (ufw/firewalld) are detected
+			if detected, toolName := utils.DetectHighLevelFirewall(); detected {
+				log.Info().Msgf("Skipping firewall sync - %s is active", toolName)
+				continue
+			}
 			firewallData, err := utils.CollectFirewallRules()
 			if err != nil {
 				log.Debug().Err(err).Msg("Failed to collect firewall rules.")

--- a/pkg/utils/firewall.go
+++ b/pkg/utils/firewall.go
@@ -21,6 +21,16 @@ var (
 	firewallNftablesInstalled bool
 	firewallIptablesInstalled bool
 	firewallCheckError        error
+
+	// Feature flag to disable automatic rule recreation
+	// Set to true to prevent conflicts with ufw/firewalld
+	disableRuleRecreation = true
+
+	// High-level firewall detection cache
+	highLevelFirewallCheckMutex     sync.Mutex
+	highLevelFirewallCheckAttempted bool
+	highLevelFirewallDetected       bool
+	highLevelFirewallToolName       string
 )
 
 // Default values matching alpacon-server FirewallRuleSyncSerializer
@@ -85,6 +95,66 @@ func runFirewallCommand(args []string, timeout int) (exitCode int, output string
 		return 1, "firewall command executor not initialized"
 	}
 	return commandExecutor(args, "root", "", nil, timeout)
+}
+
+// DetectHighLevelFirewall detects if high-level firewall management tools are active
+// Returns (detected, toolName) where toolName is "ufw" or "firewalld"
+func DetectHighLevelFirewall() (detected bool, toolName string) {
+	// Use mutex to prevent concurrent checks
+	highLevelFirewallCheckMutex.Lock()
+	defer highLevelFirewallCheckMutex.Unlock()
+
+	// Return cached result if we've already checked
+	if highLevelFirewallCheckAttempted {
+		return highLevelFirewallDetected, highLevelFirewallToolName
+	}
+
+	// 1. Check ufw via systemctl (most reliable)
+	exitCode, output := runFirewallCommand([]string{"systemctl", "is-active", "ufw"}, 5)
+	if exitCode == 0 && strings.TrimSpace(output) == "active" {
+		highLevelFirewallCheckAttempted = true
+		highLevelFirewallDetected = true
+		highLevelFirewallToolName = "ufw"
+		log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
+		return true, "ufw"
+	}
+
+	// 2. Fallback: Check ufw via direct command
+	exitCode, output = runFirewallCommand([]string{"ufw", "status"}, 5)
+	if exitCode == 0 && strings.Contains(strings.ToLower(output), "status: active") {
+		highLevelFirewallCheckAttempted = true
+		highLevelFirewallDetected = true
+		highLevelFirewallToolName = "ufw"
+		log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
+		return true, "ufw"
+	}
+
+	// 3. Check firewalld via systemctl
+	exitCode, output = runFirewallCommand([]string{"systemctl", "is-active", "firewalld"}, 5)
+	if exitCode == 0 && strings.TrimSpace(output) == "active" {
+		highLevelFirewallCheckAttempted = true
+		highLevelFirewallDetected = true
+		highLevelFirewallToolName = "firewalld"
+		log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
+		return true, "firewalld"
+	}
+
+	// 4. Fallback: Check firewalld via firewall-cmd
+	exitCode, output = runFirewallCommand([]string{"firewall-cmd", "--state"}, 5)
+	if exitCode == 0 && strings.Contains(strings.ToLower(output), "running") {
+		highLevelFirewallCheckAttempted = true
+		highLevelFirewallDetected = true
+		highLevelFirewallToolName = "firewalld"
+		log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
+		return true, "firewalld"
+	}
+
+	// No high-level firewall detected
+	highLevelFirewallCheckAttempted = true
+	highLevelFirewallDetected = false
+	highLevelFirewallToolName = ""
+	log.Debug().Msg("No high-level firewall detected - alpacon firewall management enabled")
+	return false, ""
 }
 
 // CheckFirewallTool checks if firewall tools (nftables or iptables) are installed
@@ -586,7 +656,8 @@ func parseNftablesRuleToSync(ruleMap map[string]interface{}) (*FirewallRuleSync,
 	rule.RuleID, rule.RuleType = ParseCommentOrGenerate(fullComment)
 
 	// If rule_id or type was missing, re-create the rule with proper metadata
-	if originalRuleID == "" || originalRuleType == "" {
+	// DISABLED: This can conflict with ufw/firewalld
+	if !disableRuleRecreation && (originalRuleID == "" || originalRuleType == "") {
 		newComment := BuildFirewallComment(existingComment, rule.RuleID, rule.RuleType)
 
 		// Get rule handle from the ruleMap
@@ -757,7 +828,8 @@ func parseIptablesSaveRuleLine(line string) *FirewallRuleSync {
 	rule.RuleID, rule.RuleType = ParseCommentOrGenerate(fullComment)
 
 	// If rule_id or type was missing, re-create the rule with proper metadata
-	if originalRuleID == "" || originalRuleType == "" {
+	// DISABLED: This can conflict with ufw/firewalld
+	if !disableRuleRecreation && (originalRuleID == "" || originalRuleType == "") {
 		newComment := BuildFirewallComment(existingComment, rule.RuleID, rule.RuleType)
 
 		// Create the rule with updated comment first

--- a/pkg/utils/firewall.go
+++ b/pkg/utils/firewall.go
@@ -26,6 +26,10 @@ var (
 	// Set to true to prevent conflicts with ufw/firewalld
 	disableRuleRecreation = true
 
+	// Temporary flag to disable all firewall functionality
+	// Set to true to completely disable alpacon firewall management
+	firewallFunctionalityDisabled = true
+
 	// High-level firewall detection cache
 	highLevelFirewallCheckMutex     sync.Mutex
 	highLevelFirewallCheckAttempted bool
@@ -95,6 +99,11 @@ func runFirewallCommand(args []string, timeout int) (exitCode int, output string
 		return 1, "firewall command executor not initialized"
 	}
 	return commandExecutor(args, "root", "", nil, timeout)
+}
+
+// IsFirewallDisabled checks if firewall functionality is disabled
+func IsFirewallDisabled() bool {
+	return firewallFunctionalityDisabled
 }
 
 // DetectHighLevelFirewall detects if high-level firewall management tools are active


### PR DESCRIPTION
## Summary

Temporarily disable all alpacon firewall management functionality to prevent conflicts with existing firewall tools and avoid unintended rule modifications.

## Changes

### 1. Disable Rule Recreation (Commit 5a5c948)
- Add `disableRuleRecreation = true` flag to prevent automatic rule recreation
- Add `DetectHighLevelFirewall()` to detect active ufw/firewalld
- Skip firewall sync when high-level firewall tools are detected
- Block firewall commands when ufw/firewalld is active
- Use 4-level detection: systemctl + direct command fallbacks
- Cache detection results for performance optimization

### 2. Global Firewall Disable (Commit 40fc41b)
- Add `firewallFunctionalityDisabled = true` flag
- Add `IsFirewallDisabled()` check function
- Block all firewall commands with warning logs
- Skip firewall sync in commit and syncSystemInfo
- Return success (exit 0) instead of error when disabled

## Behavior

### When firewall commands are received:
```
Log: "Firewall command ignored - firewall functionality is temporarily disabled"
Return: (0, "Firewall functionality is temporarily disabled")
```

### When firewall sync is triggered:
```
Log: "Skipping firewall sync - firewall functionality is temporarily disabled"
Action: Skip sync (no error)
```

## Modified Files

- `pkg/utils/firewall.go` - Add disable flags and detection logic
- `pkg/runner/command.go` - Block firewall commands
- `pkg/runner/commit.go` - Skip firewall sync

## Reason

- Prevent conflicts with ufw/firewalld
- Avoid unintended modification of existing firewall rules
- Temporary measure until proper firewall integration is implemented

## Future Work

- Re-enable firewall functionality with proper ufw/firewalld detection
- Implement read-only mode for firewall monitoring
- Add configuration option for firewall management mode