### PR TITLE
Resolve "Adjusting the RPM file format"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,8 +28,7 @@ archives:
     name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-{{ .Os }}-{{ .Arch }}'
 
 nfpms:
-  - file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
-    package_name: alpamon
+  - package_name: alpamon
     maintainer: AlpacaX <support@alpacax.com>
     description: Alpamon
     homepage: https://github.com/alpacax/alpamon
@@ -67,11 +66,13 @@ nfpms:
           - zip
           - sqlite3
           - nftables | iptables
+        file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}'
       rpm:
         dependencies:
           - zip
           - sqlite
           - nftables | iptables
+        file_name_template: '{{ .PackageName }}-{{ trimprefix .Version "v" }}-1.{{ .Os }}.{{ .Arch }}'
       
 changelog:
   sort: asc


### PR DESCRIPTION
## Description

Fix RPM package filenames to follow RPM naming conventions by configuring format-specific filename templates in GoReleaser.

Fixes #[issue-number]

## Changes

### Modified Files

- `.goreleaser.yaml`: Added separate `file_name_template` configurations for DEB and RPM formats

### Before

**DEB**: `alpamon_1.2.2_linux_amd64.deb` ✅  
**RPM**: `alpamon_1.2.2_linux_amd64.rpm` ❌

### After

**DEB**: `alpamon_1.2.2_linux_amd64.deb` ✅ (unchanged)  
**RPM**: `alpamon-1.2.2-1.linux.x86_64.rpm` ✅

## Implementation Details

Added format-specific `file_name_template` to the `nfpms.overrides` section in `.goreleaser.yaml`:

```yaml
overrides:
  deb:
    dependencies:
      - zip
      - sqlite3
      - nftables | iptables
    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
  rpm:
    dependencies:
      - zip
      - sqlite
      - nftables | iptables
    file_name_template: "{{ .PackageName }}-{{ .Version }}-1.{{ .Os }}.{{ .Arch }}"
```

### RPM Naming Convention
Follows the standard RPM naming convention:
- Format: <name>-<version>-<release>.<os>.<arch>.rpm
- Separator: hyphens (-)
- Release number: includes -1 (initial release)

### DEB Naming Convention
Maintains the Debian standard naming convention:
- Format: <name>_<version>_<os>_<arch>.deb
- Separator: underscores (_)

## Checklist
- [x] Verified RPM naming convention and applied
- [x] Verified DEB naming convention is maintained
- [x] Validated .goreleaser.yaml syntax
- [x] Tested GoReleaser build
- [x] Verified generated package filenames

Closes #124 