### PR TITLE
Resolve "systemd service restarts immediately after quit command"

### DIFF
--- a/configs/alpamon.service
+++ b/configs/alpamon.service
@@ -8,7 +8,7 @@ ExecStart=/usr/local/bin/alpamon
 WorkingDirectory=/var/lib/alpamon
 SELinuxContext=-unconfined_u:unconfined_r:unconfined_t:s0
 AppArmorProfile=-unconfined
-Restart=always
+Restart=on-failure
 StandardOutput=null
 StandardError=null
 


### PR DESCRIPTION
## Description

Changes the systemd service restart policy from `always` to `on-failure` to allow graceful shutdown via the `quit` command while maintaining automatic restart on crashes and system reboots.

## Problem

Currently, when the `quit` internal command is executed, the alpamon service terminates gracefully (exit code 0) but immediately restarts due to `Restart=always` in the systemd configuration. This prevents administrators from intentionally stopping the service through the command interface.

## Solution

Modified `configs/alpamon.service` to use `Restart=on-failure` instead of `Restart=always`.

**Behavior after this change:**
- ✅ `quit` command → Service stops and stays stopped (exit code 0)
- ✅ Service crashes → Automatically restarts (exit code ≠ 0)
- ✅ System reboot → Service auto-starts (via `WantedBy=multi-user.target`)
- ✅ Manual restart → `systemctl restart alpamon` still works

## Changes

### Modified Files
- [`configs/alpamon.service`](configs/alpamon.service#L11)

### Diff
```diff
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/alpamon
 WorkingDirectory=/var/lib/alpamon
 SELinuxContext=-unconfined_u:unconfined_r:unconfined_t:s0
 AppArmorProfile=-unconfined
-Restart=always
+Restart=on-failure
 StandardOutput=null
 StandardError=null
```

## Breaking Changes
None. This is a behavioral change that improves usability without breaking existing functionality.

Closes #129 