### PR TITLE
Resolve "[Alpamon Agent Refactoring] Phase 1: Goroutine Pool and Context Management Implementation"

### DIFF
--- a/configs/alpamon.conf
+++ b/configs/alpamon.conf
@@ -9,3 +9,18 @@ ca_cert = {{.CACert}}
 
 [logging]
 debug = {{.Debug}}
+
+[pool]
+# Maximum number of concurrent workers in the global worker pool
+# Default: 20
+# max_workers = 20
+
+# Size of the job queue for the global worker pool
+# Default: 200
+# queue_size = 200
+
+# Default timeout in seconds for pool tasks
+# If not set or commented out, the default value of 30 seconds will be used
+# Set to a positive number to specify timeout in seconds
+# Default: 30
+# default_timeout = 30

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,0 +1,176 @@
+// Package pool provides a true worker pool implementation with job queue and context support.
+package pool
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+// Job represents a unit of work to be executed by the pool
+type Job struct {
+	fn func() error
+}
+
+// Pool represents a pool of workers with a job queue
+type Pool struct {
+	maxWorkers int
+	jobQueue   chan *Job
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+// NewPool creates a new worker pool with job queue
+func NewPool(maxWorkers int, queueSize int) *Pool {
+	if maxWorkers <= 0 {
+		maxWorkers = 10
+	}
+	if queueSize <= 0 {
+		queueSize = maxWorkers * 10 // Default queue size
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p := &Pool{
+		maxWorkers: maxWorkers,
+		jobQueue:   make(chan *Job, queueSize),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+
+	// Start worker goroutines
+	p.startWorkers()
+
+	return p
+}
+
+// startWorkers launches the worker goroutines
+func (p *Pool) startWorkers() {
+	for i := 0; i < p.maxWorkers; i++ {
+		p.wg.Add(1)
+		go p.worker()
+	}
+}
+
+// worker is the main loop for each worker goroutine
+func (p *Pool) worker() {
+	defer p.wg.Done()
+
+	for {
+		select {
+		case job, ok := <-p.jobQueue:
+			if !ok {
+				// Job queue is closed
+				return
+			}
+			p.executeJob(job)
+		case <-p.ctx.Done():
+			// Pool is shutting down - drain remaining jobs first
+			for {
+				select {
+				case job, ok := <-p.jobQueue:
+					if !ok {
+						return
+					}
+					p.executeJob(job)
+				default:
+					// No more jobs in queue
+					return
+				}
+			}
+		}
+	}
+}
+
+// executeJob runs a job with panic recovery
+func (p *Pool) executeJob(job *Job) {
+	// Panic recovery
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("recovered from panic in pool worker: %v\nstack: %s", r, debug.Stack())
+		}
+	}()
+
+	// Execute the function
+	err := job.fn()
+	if err != nil {
+		log.Printf("pool worker error: %v", err)
+	}
+}
+
+// Submit adds a job to the queue (non-blocking)
+// Returns error if the queue is full or pool is shutting down
+func (p *Pool) Submit(ctx context.Context, fn func() error) error {
+	// Check if pool is shutting down first
+	select {
+	case <-p.ctx.Done():
+		return fmt.Errorf("pool is shutting down")
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.ctx.Done():
+		return fmt.Errorf("pool is shutting down")
+	case p.jobQueue <- &Job{fn: fn}:
+		return nil
+	default:
+		// Queue is full
+		return fmt.Errorf("job queue is full")
+	}
+}
+
+// QueueSize returns the current number of jobs in the queue
+func (p *Pool) QueueSize() int {
+	return len(p.jobQueue)
+}
+
+// QueueCapacity returns the maximum queue capacity
+func (p *Pool) QueueCapacity() int {
+	return cap(p.jobQueue)
+}
+
+// MaxWorkers returns the number of workers
+func (p *Pool) MaxWorkers() int {
+	return p.maxWorkers
+}
+
+// Shutdown gracefully shuts down the pool
+func (p *Pool) Shutdown(timeout time.Duration) error {
+	// Signal shutdown to prevent new submissions
+	p.cancel()
+
+	// Don't close the job queue immediately - let workers drain it
+	// Workers will exit when context is cancelled
+
+	// Wait for all workers to complete
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		// Close the job queue after all workers have exited
+		close(p.jobQueue)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("shutdown timeout after %v", timeout)
+	}
+}
+
+// IsShuttingDown returns true if the pool is shutting down
+func (p *Pool) IsShuttingDown() bool {
+	select {
+	case <-p.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,0 +1,193 @@
+package pool
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPoolBasic(t *testing.T) {
+	pool := NewPool(3, 10)
+	defer pool.Shutdown(5 * time.Second)
+
+	var counter int32
+	var wg sync.WaitGroup
+
+	// Submit 10 jobs
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		err := pool.Submit(context.Background(), func() error {
+			atomic.AddInt32(&counter, 1)
+			wg.Done()
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("failed to submit job %d: %v", i, err)
+			wg.Done()
+		}
+	}
+
+	// Wait for all jobs to complete
+	wg.Wait()
+
+	if atomic.LoadInt32(&counter) != 10 {
+		t.Errorf("expected 10 jobs to complete, got %d", counter)
+	}
+}
+
+func TestPoolQueueFull(t *testing.T) {
+	// Small queue size to test overflow
+	// Queue size = 1, Workers = 1
+	pool := NewPool(1, 1)
+	defer pool.Shutdown(5 * time.Second)
+
+	// Use a channel to control task execution
+	blocker := make(chan struct{})
+
+	// Block the worker - this job will be picked up by the worker immediately
+	err := pool.Submit(context.Background(), func() error {
+		<-blocker // Wait until we signal
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to submit blocking task: %v", err)
+	}
+
+	// Give worker time to pick up the first job
+	time.Sleep(10 * time.Millisecond)
+
+	// Fill the queue (capacity is 1)
+	err = pool.Submit(context.Background(), func() error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to submit to queue: %v", err)
+	}
+
+	// This should fail immediately (worker is blocked, queue is full)
+	err = pool.Submit(context.Background(), func() error {
+		return nil
+	})
+
+	if err == nil || err.Error() != "job queue is full" {
+		t.Errorf("expected queue full error, got: %v", err)
+	}
+
+	// Unblock the worker to allow shutdown
+	close(blocker)
+}
+
+func TestPoolConcurrency(t *testing.T) {
+	maxWorkers := 3
+	pool := NewPool(maxWorkers, 100)
+	defer pool.Shutdown(5 * time.Second)
+
+	var concurrent int32
+	var maxConcurrent int32
+
+	// Submit many jobs
+	for i := 0; i < 50; i++ {
+		pool.Submit(context.Background(), func() error {
+			current := atomic.AddInt32(&concurrent, 1)
+			defer atomic.AddInt32(&concurrent, -1)
+
+			// Track max concurrent
+			for {
+				max := atomic.LoadInt32(&maxConcurrent)
+				if current <= max || atomic.CompareAndSwapInt32(&maxConcurrent, max, current) {
+					break
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+	}
+
+	// Wait a bit for jobs to run
+	time.Sleep(200 * time.Millisecond)
+
+	// Max concurrent should not exceed worker count
+	if int(maxConcurrent) > maxWorkers {
+		t.Errorf("exceeded max concurrency: got %d, want <= %d", maxConcurrent, maxWorkers)
+	}
+}
+
+func TestPoolPanicRecovery(t *testing.T) {
+	pool := NewPool(2, 10)
+	defer pool.Shutdown(5 * time.Second)
+
+	var completed int32
+
+	// Submit job that panics
+	pool.Submit(context.Background(), func() error {
+		panic("test panic")
+	})
+
+	// Submit normal job after panic
+	err := pool.Submit(context.Background(), func() error {
+		atomic.AddInt32(&completed, 1)
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("failed to submit job after panic: %v", err)
+	}
+
+	// Wait for job completion
+	time.Sleep(100 * time.Millisecond)
+
+	if atomic.LoadInt32(&completed) != 1 {
+		t.Error("normal job did not complete after panic")
+	}
+}
+
+func TestPoolShutdown(t *testing.T) {
+	pool := NewPool(2, 10)
+
+	var completed int32
+
+	// Submit several jobs
+	for i := 0; i < 5; i++ {
+		pool.Submit(context.Background(), func() error {
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&completed, 1)
+			return nil
+		})
+	}
+
+	// Shutdown with timeout
+	err := pool.Shutdown(1 * time.Second)
+	if err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+
+	// All jobs should have completed
+	if atomic.LoadInt32(&completed) != 5 {
+		t.Errorf("not all jobs completed: got %d, want 5", completed)
+	}
+
+	// New submissions should fail
+	err = pool.Submit(context.Background(), func() error { return nil })
+	if err == nil {
+		t.Error("expected error when submitting to shut down pool")
+	}
+}
+
+// Benchmark comparison
+func BenchmarkPoolSubmit(b *testing.B) {
+	pool := NewPool(10, 1000)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool.Submit(ctx, func() error {
+			return nil
+		})
+	}
+
+	pool.Shutdown(10 * time.Second)
+}

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -24,16 +24,6 @@ func NewContextManager() *ContextManager {
 	}
 }
 
-// NewContextManagerWithRoot creates a new context manager with a provided root context.
-// This is useful when you want to integrate with an existing context hierarchy.
-func NewContextManagerWithRoot(root context.Context) *ContextManager {
-	ctx, cancel := context.WithCancel(root)
-	return &ContextManager{
-		root:   ctx,
-		cancel: cancel,
-	}
-}
-
 // NewContext creates a new child context with an optional timeout.
 // If timeout is 0 or negative, no timeout is applied.
 func (m *ContextManager) NewContext(timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -1,0 +1,85 @@
+// Package agent provides context management for the Alpamon agent.
+package agent
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ContextManager manages contexts for the agent, providing
+// centralized context creation and cancellation.
+type ContextManager struct {
+	root   context.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+}
+
+// NewContextManager creates a new context manager with a root context.
+func NewContextManager() *ContextManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ContextManager{
+		root:   ctx,
+		cancel: cancel,
+	}
+}
+
+// NewContextManagerWithRoot creates a new context manager with a provided root context.
+// This is useful when you want to integrate with an existing context hierarchy.
+func NewContextManagerWithRoot(root context.Context) *ContextManager {
+	ctx, cancel := context.WithCancel(root)
+	return &ContextManager{
+		root:   ctx,
+		cancel: cancel,
+	}
+}
+
+// NewContext creates a new child context with an optional timeout.
+// If timeout is 0 or negative, no timeout is applied.
+func (m *ContextManager) NewContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if timeout > 0 {
+		return context.WithTimeout(m.root, timeout)
+	}
+	return context.WithCancel(m.root)
+}
+
+// NewContextWithDeadline creates a new child context with a specific deadline.
+func (m *ContextManager) NewContextWithDeadline(deadline time.Time) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return context.WithDeadline(m.root, deadline)
+}
+
+// Root returns the root context.
+// This should be used sparingly, primarily for operations that need
+// to outlive the normal shutdown process.
+func (m *ContextManager) Root() context.Context {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.root
+}
+
+// Shutdown cancels the root context, triggering cancellation of all child contexts.
+// This should be called during graceful shutdown.
+func (m *ContextManager) Shutdown() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cancel()
+}
+
+// IsShutdown returns true if the context manager has been shut down.
+func (m *ContextManager) IsShutdown() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	select {
+	case <-m.root.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestContextManagerCreation verifies context manager initialization
+func TestContextManagerCreation(t *testing.T) {
+	cm := NewContextManager()
+	if cm == nil {
+		t.Fatal("NewContextManager returned nil")
+	}
+
+	if cm.IsShutdown() {
+		t.Error("new context manager should not be shutdown")
+	}
+
+	// Root context should be active
+	select {
+	case <-cm.Root().Done():
+		t.Error("root context should not be cancelled")
+	default:
+		// Expected
+	}
+}
+
+// TestContextManagerWithRoot verifies creation with custom root context
+func TestContextManagerWithRoot(t *testing.T) {
+	root, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	cm := NewContextManagerWithRoot(root)
+	if cm == nil {
+		t.Fatal("NewContextManagerWithRoot returned nil")
+	}
+
+	// Create a child context
+	ctx, cancel := cm.NewContext(0)
+	defer cancel()
+
+	// Cancel the original root
+	rootCancel()
+
+	// Child context should also be cancelled
+	select {
+	case <-ctx.Done():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Error("child context not cancelled when root was cancelled")
+	}
+
+	// Context manager should report shutdown
+	if !cm.IsShutdown() {
+		t.Error("context manager should report shutdown after root cancellation")
+	}
+}
+
+// TestContextCancellation verifies that shutdown cancels all child contexts
+func TestContextCancellation(t *testing.T) {
+	cm := NewContextManager()
+
+	// Create multiple child contexts
+	ctx1, cancel1 := cm.NewContext(0)
+	defer cancel1()
+
+	ctx2, cancel2 := cm.NewContext(5 * time.Second)
+	defer cancel2()
+
+	ctx3, cancel3 := cm.NewContext(0)
+	defer cancel3()
+
+	// Shutdown the manager
+	cm.Shutdown()
+
+	// All contexts should be cancelled
+	for i, ctx := range []context.Context{ctx1, ctx2, ctx3} {
+		select {
+		case <-ctx.Done():
+			// Expected
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("context %d not cancelled after shutdown", i+1)
+		}
+	}
+
+	// Manager should report as shutdown
+	if !cm.IsShutdown() {
+		t.Error("IsShutdown() should return true after Shutdown()")
+	}
+}
+
+// TestContextTimeout verifies timeout context creation
+func TestContextTimeout(t *testing.T) {
+	cm := NewContextManager()
+	defer cm.Shutdown()
+
+	// Create context with timeout
+	ctx, cancel := cm.NewContext(50 * time.Millisecond)
+	defer cancel()
+
+	// Should timeout
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != context.DeadlineExceeded {
+			t.Errorf("expected DeadlineExceeded, got %v", ctx.Err())
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("context did not timeout")
+	}
+}
+
+// TestContextDeadline verifies deadline context creation
+func TestContextDeadline(t *testing.T) {
+	cm := NewContextManager()
+	defer cm.Shutdown()
+
+	deadline := time.Now().Add(50 * time.Millisecond)
+	ctx, cancel := cm.NewContextWithDeadline(deadline)
+	defer cancel()
+
+	// Should respect deadline
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != context.DeadlineExceeded {
+			t.Errorf("expected DeadlineExceeded, got %v", ctx.Err())
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("context did not respect deadline")
+	}
+}
+
+// TestContextNoTimeout verifies context without timeout
+func TestContextNoTimeout(t *testing.T) {
+	cm := NewContextManager()
+	defer cm.Shutdown()
+
+	// Create context without timeout (0 duration)
+	ctx, cancel := cm.NewContext(0)
+	defer cancel()
+
+	// Should not timeout on its own
+	select {
+	case <-ctx.Done():
+		t.Error("context should not be cancelled without explicit cancellation")
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+
+	// Manual cancellation should work
+	cancel()
+	select {
+	case <-ctx.Done():
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Error("context not cancelled after explicit cancel")
+	}
+}
+
+// TestConcurrentContextCreation verifies thread-safe context creation
+func TestConcurrentContextCreation(t *testing.T) {
+	cm := NewContextManager()
+	defer cm.Shutdown()
+
+	done := make(chan bool)
+
+	// Create contexts concurrently
+	for i := 0; i < 100; i++ {
+		go func(id int) {
+			ctx, cancel := cm.NewContext(time.Duration(id) * time.Millisecond)
+			defer cancel()
+
+			// Do some work
+			select {
+			case <-ctx.Done():
+				// Timeout expected for non-zero durations
+			case <-time.After(200 * time.Millisecond):
+				// Maximum wait
+			}
+
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 100; i++ {
+		select {
+		case <-done:
+			// Continue
+		case <-time.After(5 * time.Second):
+			t.Fatal("concurrent operations timed out")
+		}
+	}
+
+	// Context manager should still be functional
+	ctx, cancel := cm.NewContext(0)
+	cancel()
+	select {
+	case <-ctx.Done():
+		// Expected
+	default:
+		t.Error("context manager not functional after concurrent operations")
+	}
+}
+
+// TestShutdownIdempotency verifies that Shutdown can be called multiple times
+func TestShutdownIdempotency(t *testing.T) {
+	cm := NewContextManager()
+
+	// Create a context
+	ctx, cancel := cm.NewContext(0)
+	defer cancel()
+
+	// Shutdown multiple times
+	cm.Shutdown()
+	cm.Shutdown() // Should not panic
+	cm.Shutdown() // Should not panic
+
+	// Context should still be cancelled
+	select {
+	case <-ctx.Done():
+		// Expected
+	default:
+		t.Error("context not cancelled after shutdown")
+	}
+
+	// IsShutdown should still return true
+	if !cm.IsShutdown() {
+		t.Error("IsShutdown() should return true after multiple shutdowns")
+	}
+}

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -26,37 +26,6 @@ func TestContextManagerCreation(t *testing.T) {
 	}
 }
 
-// TestContextManagerWithRoot verifies creation with custom root context
-func TestContextManagerWithRoot(t *testing.T) {
-	root, rootCancel := context.WithCancel(context.Background())
-	defer rootCancel()
-
-	cm := NewContextManagerWithRoot(root)
-	if cm == nil {
-		t.Fatal("NewContextManagerWithRoot returned nil")
-	}
-
-	// Create a child context
-	ctx, cancel := cm.NewContext(0)
-	defer cancel()
-
-	// Cancel the original root
-	rootCancel()
-
-	// Child context should also be cancelled
-	select {
-	case <-ctx.Done():
-		// Expected
-	case <-time.After(100 * time.Millisecond):
-		t.Error("child context not cancelled when root was cancelled")
-	}
-
-	// Context manager should report shutdown
-	if !cm.IsShutdown() {
-		t.Error("context manager should report shutdown after root cancellation")
-	}
-}
-
 // TestContextCancellation verifies that shutdown cancels all child contexts
 func TestContextCancellation(t *testing.T) {
 	cm := NewContextManager()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,16 @@ var (
 const (
 	MinConnectInterval = 5 * time.Second
 	MaxConnectInterval = 300 * time.Second
+
+	// Pool configuration defaults
+	DefaultPoolMaxWorkers     = 20
+	DefaultPoolQueueSize      = 200
+	DefaultPoolDefaultTimeout = 30
+
+	// Pool configuration limits for warnings
+	MaxReasonableWorkers       = 1000
+	MaxReasonableQueueSize     = 10000
+	MaxReasonableTimeoutSeconds = 3600
 )
 
 func InitSettings(settings Settings) {
@@ -86,11 +96,14 @@ func validateConfig(config Config, wsPath string) (bool, Settings) {
 	log.Debug().Msg("Validating configuration fields...")
 
 	settings := Settings{
-		WSPath:      wsPath,
-		UseSSL:      false,
-		SSLVerify:   true,
-		SSLOpt:      make(map[string]interface{}),
-		HTTPThreads: 4,
+		WSPath:             wsPath,
+		UseSSL:             false,
+		SSLVerify:          true,
+		SSLOpt:             make(map[string]interface{}),
+		HTTPThreads:        4,
+		PoolMaxWorkers:     DefaultPoolMaxWorkers,
+		PoolQueueSize:      DefaultPoolQueueSize,
+		PoolDefaultTimeout: DefaultPoolDefaultTimeout,
 	}
 
 	valid := true
@@ -132,6 +145,47 @@ func validateConfig(config Config, wsPath string) (bool, Settings) {
 			}
 		}
 	}
+
+	// Validate and set worker pool configuration
+	if config.Pool.MaxWorkers > 0 {
+		settings.PoolMaxWorkers = config.Pool.MaxWorkers
+		log.Debug().Msgf("Using configured pool max workers: %d", settings.PoolMaxWorkers)
+	} else {
+		log.Debug().Msgf("Using default pool max workers: %d", settings.PoolMaxWorkers)
+	}
+
+	if config.Pool.QueueSize > 0 {
+		settings.PoolQueueSize = config.Pool.QueueSize
+		log.Debug().Msgf("Using configured pool queue size: %d", settings.PoolQueueSize)
+	} else {
+		log.Debug().Msgf("Using default pool queue size: %d", settings.PoolQueueSize)
+	}
+
+	// Validate and set default timeout for pool tasks
+	// Note: When not configured in INI file, config.Pool.DefaultTimeout will be 0 (zero value)
+	// To distinguish "not configured" from "explicitly set to 0", we treat:
+	// - Positive value: use configured value
+	// - Zero: use default (DefaultPoolDefaultTimeout) unless explicitly set
+	// Since we can't distinguish, we only override if a positive value is provided
+	if config.Pool.DefaultTimeout > 0 {
+		settings.PoolDefaultTimeout = config.Pool.DefaultTimeout
+		log.Debug().Msgf("Using configured pool default timeout: %d seconds", settings.PoolDefaultTimeout)
+	} else {
+		// Keep the default value that was set during Settings initialization
+		log.Debug().Msgf("Using default pool timeout: %d seconds", settings.PoolDefaultTimeout)
+	}
+
+	// Validate pool settings are reasonable
+	if settings.PoolMaxWorkers > MaxReasonableWorkers {
+		log.Warn().Msgf("Pool max workers (%d) seems very high, consider reducing it", settings.PoolMaxWorkers)
+	}
+	if settings.PoolQueueSize > MaxReasonableQueueSize {
+		log.Warn().Msgf("Pool queue size (%d) seems very high, consider reducing it", settings.PoolQueueSize)
+	}
+	if settings.PoolDefaultTimeout > MaxReasonableTimeoutSeconds {
+		log.Warn().Msgf("Pool default timeout (%d seconds) seems very high, consider reducing it", settings.PoolDefaultTimeout)
+	}
+
 	return valid, settings
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -162,14 +162,14 @@ func validateConfig(config Config, wsPath string) (bool, Settings) {
 	}
 
 	// Validate and set default timeout for pool tasks
-	// Note: When not configured in INI file, config.Pool.DefaultTimeout will be 0 (zero value)
-	// To distinguish "not configured" from "explicitly set to 0", we treat:
-	// - Positive value: use configured value
-	// - Zero: use default (DefaultPoolDefaultTimeout) unless explicitly set
-	// Since we can't distinguish, we only override if a positive value is provided
-	if config.Pool.DefaultTimeout > 0 {
-		settings.PoolDefaultTimeout = config.Pool.DefaultTimeout
-		log.Debug().Msgf("Using configured pool default timeout: %d seconds", settings.PoolDefaultTimeout)
+	// Use pointer type to distinguish "not configured" (nil) from "explicitly set to 0"
+	if config.Pool.DefaultTimeout != nil {
+		settings.PoolDefaultTimeout = *config.Pool.DefaultTimeout
+		if settings.PoolDefaultTimeout == 0 {
+			log.Debug().Msg("Using configured pool default timeout: 0 (no timeout)")
+		} else {
+			log.Debug().Msgf("Using configured pool default timeout: %d seconds", settings.PoolDefaultTimeout)
+		}
 	} else {
 		// Keep the default value that was set during Settings initialization
 		log.Debug().Msgf("Using default pool timeout: %d seconds", settings.PoolDefaultTimeout)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPoolConfigDefaults(t *testing.T) {
+	// Test that default pool values are set correctly when not configured
+	config := Config{}
+	_, settings := validateConfig(config, "/ws/test/")
+
+	if settings.PoolMaxWorkers != DefaultPoolMaxWorkers {
+		t.Errorf("Expected default PoolMaxWorkers to be %d, got %d", DefaultPoolMaxWorkers, settings.PoolMaxWorkers)
+	}
+
+	if settings.PoolQueueSize != DefaultPoolQueueSize {
+		t.Errorf("Expected default PoolQueueSize to be %d, got %d", DefaultPoolQueueSize, settings.PoolQueueSize)
+	}
+
+	if settings.PoolDefaultTimeout != DefaultPoolDefaultTimeout {
+		t.Errorf("Expected default PoolDefaultTimeout to be %d, got %d", DefaultPoolDefaultTimeout, settings.PoolDefaultTimeout)
+	}
+}
+
+func TestPoolConfigCustomValues(t *testing.T) {
+	// Test that custom pool values are applied correctly
+	config := Config{}
+	config.Pool.MaxWorkers = 50
+	config.Pool.QueueSize = 500
+
+	_, settings := validateConfig(config, "/ws/test/")
+
+	if settings.PoolMaxWorkers != 50 {
+		t.Errorf("Expected PoolMaxWorkers to be 50, got %d", settings.PoolMaxWorkers)
+	}
+
+	if settings.PoolQueueSize != 500 {
+		t.Errorf("Expected PoolQueueSize to be 500, got %d", settings.PoolQueueSize)
+	}
+}
+
+func TestPoolConfigFromINI(t *testing.T) {
+	// Create a temporary config file
+	content := `[server]
+url = http://test.com
+id = testid
+key = testkey
+
+[pool]
+max_workers = 30
+queue_size = 300
+`
+
+	tmpfile, err := os.CreateTemp("", "alpamon-test-*.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load the config
+	settings := LoadConfig([]string{tmpfile.Name()}, "/ws/test/")
+
+	if settings.PoolMaxWorkers != 30 {
+		t.Errorf("Expected PoolMaxWorkers to be 30 from INI, got %d", settings.PoolMaxWorkers)
+	}
+
+	if settings.PoolQueueSize != 300 {
+		t.Errorf("Expected PoolQueueSize to be 300 from INI, got %d", settings.PoolQueueSize)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,8 +29,8 @@ type Config struct {
 		Debug bool `ini:"debug"`
 	} `ini:"logging"`
 	Pool struct {
-		MaxWorkers     int `ini:"max_workers"`
-		QueueSize      int `ini:"queue_size"`
-		DefaultTimeout int `ini:"default_timeout"`
+		MaxWorkers     int  `ini:"max_workers"`
+		QueueSize      int  `ini:"queue_size"`
+		DefaultTimeout *int `ini:"default_timeout"`
 	} `ini:"pool"`
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,15 +1,18 @@
 package config
 
 type Settings struct {
-	ServerURL   string
-	WSPath      string
-	UseSSL      bool
-	CaCert      string // CA certificate file path
-	SSLVerify   bool
-	SSLOpt      map[string]interface{}
-	HTTPThreads int
-	ID          string
-	Key         string
+	ServerURL          string
+	WSPath             string
+	UseSSL             bool
+	CaCert             string // CA certificate file path
+	SSLVerify          bool
+	SSLOpt             map[string]interface{}
+	HTTPThreads        int
+	ID                 string
+	Key                string
+	PoolMaxWorkers     int // Maximum number of workers in the global worker pool
+	PoolQueueSize      int // Size of the job queue for the global worker pool
+	PoolDefaultTimeout int // Default timeout in seconds for pool tasks (0 = no timeout)
 }
 
 type Config struct {
@@ -25,4 +28,9 @@ type Config struct {
 	Logging struct {
 		Debug bool `ini:"debug"`
 	} `ini:"logging"`
+	Pool struct {
+		MaxWorkers     int `ini:"max_workers"`
+		QueueSize      int `ini:"queue_size"`
+		DefaultTimeout int `ini:"default_timeout"`
+	} `ini:"pool"`
 }

--- a/pkg/logger/server.go
+++ b/pkg/logger/server.go
@@ -57,12 +57,14 @@ func (ls *LogServer) StartLogServer() {
 				continue
 			}
 			// Submit connection handler to worker pool
-			ctx, _ := ls.ctxManager.NewContext(0) // No timeout for connection handlers
+			ctx, cancel := ls.ctxManager.NewContext(0) // No timeout for connection handlers
 			err = ls.workerPool.Submit(ctx, func() error {
+				defer cancel()
 				ls.handleConnection(conn)
 				return nil
 			})
 			if err != nil {
+				cancel()
 				log.Error().Err(err).Msg("Failed to submit connection handler to pool")
 				conn.Close()
 			}

--- a/pkg/logger/server.go
+++ b/pkg/logger/server.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"time"
 
+	"github.com/alpacax/alpamon/internal/pool"
+	"github.com/alpacax/alpamon/pkg/agent"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/rs/zerolog/log"
 )
@@ -19,9 +21,11 @@ const (
 type LogServer struct {
 	listener     net.Listener
 	shutDownChan chan struct{}
+	workerPool   *pool.Pool
+	ctxManager   *agent.ContextManager
 }
 
-func NewLogServer() *LogServer {
+func NewLogServer(workerPool *pool.Pool, ctxManager *agent.ContextManager) *LogServer {
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Error().Err(err).Msgf("Log server startup failed: cannot bind to %s.", address)
@@ -31,6 +35,8 @@ func NewLogServer() *LogServer {
 	return &LogServer{
 		listener:     listener,
 		shutDownChan: make(chan struct{}),
+		workerPool:   workerPool,
+		ctxManager:   ctxManager,
 	}
 }
 
@@ -50,7 +56,16 @@ func (ls *LogServer) StartLogServer() {
 				log.Error().Err(err).Msg("Failed to accept socket.")
 				continue
 			}
-			go ls.handleConnection(conn)
+			// Submit connection handler to worker pool
+			ctx, _ := ls.ctxManager.NewContext(0) // No timeout for connection handlers
+			err = ls.workerPool.Submit(ctx, func() error {
+				ls.handleConnection(conn)
+				return nil
+			})
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to submit connection handler to pool")
+				conn.Close()
+			}
 		}
 	}
 }

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -249,6 +249,7 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 			return commandRunner.Run(ctx)
 		})
 		if err != nil {
+			cancel()
 			log.Error().Err(err).Msgf("Failed to submit command %s to pool", content.Command.ID)
 			// Send failure notification
 			payload := &commandFin{

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -223,13 +223,15 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 			message = "Collector will be restarted."
 		default:
 			// Submit to worker pool for managed execution
-			ctx, _ := cr.wsClient.ctxManager.NewContext(2 * time.Second)
+			ctx, cancel := cr.wsClient.ctxManager.NewContext(2 * time.Second)
 			err := cr.wsClient.pool.Submit(ctx, func() error {
+				defer cancel()
 				time.Sleep(1 * time.Second)
 				cr.wsClient.Restart()
 				return nil
 			})
 			if err != nil {
+				cancel()
 				log.Error().Err(err).Msg("Failed to submit restart task to pool")
 			}
 		}
@@ -237,26 +239,30 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 		return 0, message
 	case "quit":
 		// Submit to worker pool for managed execution
-		ctx, _ := cr.wsClient.ctxManager.NewContext(2 * time.Second)
+		ctx, cancel := cr.wsClient.ctxManager.NewContext(2 * time.Second)
 		err := cr.wsClient.pool.Submit(ctx, func() error {
+			defer cancel()
 			time.Sleep(1 * time.Second)
 			cr.wsClient.ShutDown()
 			return nil
 		})
 		if err != nil {
+			cancel()
 			log.Error().Err(err).Msg("Failed to submit quit task to pool")
 		}
 		return 0, "Alpamon will shutdown in 1 second."
 	case "reboot":
 		log.Info().Msg("Reboot request received.")
 		// Submit to worker pool for managed execution
-		ctx, _ := cr.wsClient.ctxManager.NewContext(2 * time.Second)
+		ctx, cancel := cr.wsClient.ctxManager.NewContext(2 * time.Second)
 		err := cr.wsClient.pool.Submit(ctx, func() error {
+			defer cancel()
 			time.Sleep(1 * time.Second)
 			cr.handleShellCmd("reboot", "root", "root", nil)
 			return nil
 		})
 		if err != nil {
+			cancel()
 			log.Error().Err(err).Msg("Failed to submit reboot task to pool")
 		}
 
@@ -264,13 +270,15 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 	case "shutdown":
 		log.Info().Msg("Shutdown request received.")
 		// Submit to worker pool for managed execution
-		ctx, _ := cr.wsClient.ctxManager.NewContext(2 * time.Second)
+		ctx, cancel := cr.wsClient.ctxManager.NewContext(2 * time.Second)
 		err := cr.wsClient.pool.Submit(ctx, func() error {
+			defer cancel()
 			time.Sleep(1 * time.Second)
 			cr.handleShellCmd("shutdown", "root", "root", nil)
 			return nil
 		})
 		if err != nil {
+			cancel()
 			log.Error().Err(err).Msg("Failed to submit shutdown task to pool")
 		}
 

--- a/pkg/scheduler/types.go
+++ b/pkg/scheduler/types.go
@@ -43,3 +43,9 @@ type counters struct {
 	delay   float64
 	latency float64
 }
+
+// ReporterManager manages the lifecycle of multiple reporter goroutines
+type ReporterManager struct {
+	wg      *sync.WaitGroup
+	cancels []func()
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the Alpamon agent refactoring: integrates ContextManager and WorkerPool throughout the project for centralized context and goroutine management.

## Changes

### 🎯 Core Infrastructure
- **ContextManager Integration**: Extended ContextManager usage from `cmd/alpamon/root.go` to all major components
- **WorkerPool Integration**: Applied bounded concurrency pattern to appropriate short-lived tasks
- **Graceful Shutdown**: Coordinated shutdown across all components using context cancellation

### 📝 Modified Components

#### 1. **Collector** ([pkg/collector/collector.go](pkg/collector/collector.go))
- Updated `InitCollector()` and `NewCollector()` to accept `ContextManager` parameter
- Changed `Start()` to use `ctxManager.NewContext(0)` instead of `context.Background()`
- Ensures collector workers shut down gracefully on application termination

#### 2. **Reporter** ([pkg/scheduler/reporter.go](pkg/scheduler/reporter.go))
- Updated `StartReporters()` to accept `ContextManager` parameter
- Modified `Run()` to use context for graceful shutdown
- **Refactored for readability**: Split `Run()` into three focused functions:
  - `Run()`: Main loop management
  - `waitForEntry()`: Queue entry waiting logic
  - `processEntry()`: Entry processing logic
- Reduced nesting from 4 levels to 2 levels

#### 3. **Command System Operations** ([pkg/runner/command.go](pkg/runner/command.go))
- Changed system operations (restart/quit/reboot/shutdown) to use WorkerPool
- Replaced direct `go func()` with `pool.Submit()` for managed execution
- Uses 2-second timeout contexts for operations

#### 4. **Log Server** ([pkg/logger/server.go](pkg/logger/server.go))
- Added `workerPool` and `ctxManager` to `LogServer` struct
- Updated `NewLogServer()` to accept both parameters
- Changed connection handlers from `go ls.handleConnection(conn)` to pool submission
- Prevents goroutine explosion from unlimited connection handlers

#### 5. **Commit Operations** ([pkg/runner/commit.go](pkg/runner/commit.go))
- Updated `CommitAsync()` to use ContextManager instead of `context.Background()`
- Removed unused `CommitAsyncWithContext()` function
- Ensures commit goroutine respects application shutdown

#### 6. **Root Initialization** ([cmd/alpamon/command/root.go](cmd/alpamon/command/root.go))
- Updated all component initialization calls to pass `ctxManager` and/or `workerPool`
- Lines modified: 88, 91, 99, 105, 134

### 🧹 Code Quality Improvements
- Removed unused `context` import from `pkg/logger/server.go`
- Removed unused `agent` import from `pkg/runner/commit.go`
- Fixed all syntax errors and import issues
- Improved code readability through function extraction (Reporter)

### ✅ Design Decisions

#### When to Use WorkerPool
- ✅ **Short-lived tasks**: restart, quit, reboot, shutdown, log connections
- ❌ **Long-running daemons**: Collector workers, Reporter workers, PTY sessions, FTP sessions

#### When to Use Timeout
- ✅ **One-time operations**: CommitAsync (5 seconds)
- ❌ **Long-running daemons**: Collector (no timeout), Reporter (no timeout)

#### Exceptions (as requested)
- PTY and FTP sessions in `handleInternalCmd()` remain as direct goroutines (long-running sessions)

## Testing

### Build
```bash
cd cmd/alpamon && CGO_ENABLED=0 go build -v .
```
✅ Build successful

### Tests
```
go test -v ./... -p 1
```
✅ All tests passing

## Breaking Changes
None. This is a backward-compatible internal refactoring.

## Configuration
No configuration changes required. The existing alpamon.conf files (with or without [pool] section) continue to work:
- Without [pool] section: Uses default values (MaxWorkers=20, QueueSize=200, DefaultTimeout=30)
- With [pool] section: Uses configured values

## Related Issues
Closes #132

### Checklist
- [x] Code follows project conventions
- [x] All tests passing
- [x] Build successful
- [x] No breaking changes
- [x] Backward compatibility maintained
