### PR TITLE
refactor(ws): modify websocket url

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,7 @@ func validateConfig(config Config, wsPath string) (bool, Settings) {
 		val = strings.TrimSuffix(val, "/")
 		settings.ServerURL = val
 		settings.WSPath = strings.Replace(val, "http", "ws", 1) + settings.WSPath
+		settings.WSPath = strings.Replace(settings.WSPath, "8000", "8081", 1) // just for local environment (not effected in prod)
 		settings.UseSSL = strings.HasPrefix(val, "https://")
 	} else {
 		log.Error().Msg("Server url is invalid.")


### PR DESCRIPTION
Modify alpamon websocket url for `alpacon-backhaul-server`.
   
This change will not affect to production, but in local develop environment. If you want to connect `alpamon` to `alpacon`, you need to run `alpacon-backhaul-server`.