### PR TITLE
Resolve "Support Alpacon's automatic deletion feature"

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	fileUploadTimeout = 60 * 10
+	fileUploadTimeout   = 60 * 10
+	serverUnregisterURL = "/api/servers/servers/-/unregister/"
 )
 
 func init() {
@@ -2110,25 +2111,35 @@ func (cr *CommandRunner) applyRulesBatchWithFlush() (int, []map[string]interface
 
 // executeUninstall performs complete uninstallation of Alpamon
 func (cr *CommandRunner) executeUninstall() {
-	var cmd string
-
+	// Only debian and rhel support systemd-run based uninstall
 	if utils.PlatformLike == "debian" {
-		// Use purge to remove package and config files
-		cmd = "apt-get purge alpamon -y && apt-get autoremove -y"
+		cmd := "apt-get purge alpamon -y && apt-get autoremove -y"
+		cr.scheduleSystemdUninstall(cmd)
 	} else if utils.PlatformLike == "rhel" {
-		// Remove package using yum
-		cmd = "yum remove alpamon -y"
+		cmd := "yum remove alpamon -y"
+		cr.scheduleSystemdUninstall(cmd)
 	} else if utils.PlatformLike == "darwin" {
-		// For macOS development environment, just shutdown
 		log.Warn().Msgf("Platform '%s' does not support full uninstall. Shutting down instead.", utils.PlatformLike)
-		cr.wsClient.ShutDown()
-		return
 	} else {
 		log.Error().Msgf("Platform '%s' not supported for uninstall.", utils.PlatformLike)
-		cr.wsClient.ShutDown()
-		return
 	}
 
+	// Send deletion event to server synchronously before shutdown (ALL platforms)
+	_, statusCode, err := cr.apiSession.Delete(serverUnregisterURL, nil, 10)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to send unregister request to server")
+	} else if statusCode >= 200 && statusCode < 300 {
+		log.Info().Msgf("Successfully sent unregister request to server (status: %d)", statusCode)
+	} else {
+		log.Warn().Msgf("Unregister request returned status: %d", statusCode)
+	}
+
+	// ShutDown asynchronously to ensure cleanup completes (ALL platforms)
+	go cr.wsClient.ShutDown()
+}
+
+// scheduleSystemdUninstall schedules the uninstall command via systemd-run
+func (cr *CommandRunner) scheduleSystemdUninstall(cmd string) {
 	// Build the complete uninstall command that includes:
 	// 1. Package removal
 	// 2. Cleanup of transient systemd units created by this operation
@@ -2156,9 +2167,6 @@ func (cr *CommandRunner) executeUninstall() {
 	} else {
 		log.Info().Msg("Alpamon uninstall scheduled via systemd, will execute in 5 seconds")
 	}
-
-	// The scheduled systemd service will continue independently
-	cr.wsClient.ShutDown()
 }
 
 // convertRuleDataToCommandData converts rule data map to CommandData fields

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -186,6 +186,15 @@ func (session *Session) Patch(url string, rawBody interface{}, timeout time.Dura
 	return session.do(req, timeout)
 }
 
+func (session *Session) Delete(url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
+	req, err := session.newRequest(http.MethodDelete, url, rawBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return session.do(req, timeout)
+}
+
 func (session *Session) MultipartRequest(url string, body bytes.Buffer, contentType string, timeout time.Duration) ([]byte, int, error) {
 	req, err := http.NewRequest(http.MethodPost, url, &body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add synchronous DELETE request to alpacon when `byebye` command is executed
- Refactor `executeUninstall()` to ensure unregister request is sent on all platforms (including darwin)
- Add `Delete` method to `scheduler.Session` for synchronous HTTP DELETE requests

## Changes

### pkg/scheduler/session.go
- Added `Delete()` method for synchronous HTTP DELETE requests

### pkg/runner/command.go
- Added `serverUnregisterURL` constant for unregister endpoint
- Refactored `executeUninstall()` to remove early returns on darwin/unsupported platforms
- Extracted systemd-run scheduling logic into `scheduleSystemdUninstall()` helper function
- Added synchronous DELETE request to server before shutdown (ALL platforms)
- Changed `ShutDown()` to run asynchronously to ensure cleanup completes

## Related Issue
Closes #146
