### PR TITLE
Fix folder upload not replacing existing folder contents

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -1578,8 +1578,14 @@ func fileDownload(data CommandData, sysProcAttr *syscall.SysProcAttr) (exitCode 
 	if isZip && data.AllowUnzip {
 		escapePath := utils.Quote(data.Path)
 		escapeDirPath := utils.Quote(filepath.Dir(data.Path))
-		command := fmt.Sprintf("tee %s > /dev/null && unzip -n %s -d %s; rm %s",
+		// Use -o (overwrite) if AllowOverwrite is true, otherwise -n (never overwrite)
+		unzipOpt := "-n"
+		if data.AllowOverwrite {
+			unzipOpt = "-o"
+		}
+		command := fmt.Sprintf("tee %s > /dev/null && unzip %s %s -d %s; rm %s",
 			escapePath,
+			unzipOpt,
 			escapePath,
 			escapeDirPath,
 			escapePath)

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -52,6 +52,52 @@ func CopyDir(src, dst string, allowOverwrite bool) error {
 		return fmt.Errorf("%s is inside %s, causing infinite recursion", dst, src)
 	}
 
+	// Check if dst already exists
+	var backupPath string
+	dstExists := false
+	if _, err := os.Stat(dst); err == nil {
+		dstExists = true
+		if allowOverwrite {
+			// Create backup by renaming existing dst
+			backupPath = generateBackupPath(dst)
+			if err := os.Rename(dst, backupPath); err != nil {
+				return fmt.Errorf("failed to backup existing directory: %w", err)
+			}
+		}
+	}
+
+	// Perform the actual copy
+	err = copyDirRecursive(src, dst)
+	if err != nil {
+		// Rollback: restore backup if exists
+		if backupPath != "" {
+			_ = os.RemoveAll(dst)
+			_ = os.Rename(backupPath, dst)
+		}
+		return err
+	}
+
+	// Success: remove backup if exists
+	if backupPath != "" {
+		_ = os.RemoveAll(backupPath)
+	} else if dstExists && !allowOverwrite {
+		// dst existed but allowOverwrite was false - this shouldn't happen
+		// as the caller should have handled this case
+	}
+
+	return nil
+}
+
+func generateBackupPath(path string) string {
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s_backup_%d", path, i)
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}
+
+func copyDirRecursive(src, dst string) error {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return err
@@ -72,12 +118,12 @@ func CopyDir(src, dst string, allowOverwrite bool) error {
 		dstPath := filepath.Join(dst, entry.Name())
 
 		if entry.IsDir() {
-			err = CopyDir(srcPath, dstPath, allowOverwrite)
+			err = copyDirRecursive(srcPath, dstPath)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = CopyFile(srcPath, dstPath, allowOverwrite)
+			err = CopyFile(srcPath, dstPath, true)
 			if err != nil {
 				return err
 			}

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -52,17 +52,13 @@ func CopyDir(src, dst string, allowOverwrite bool) error {
 		return fmt.Errorf("%s is inside %s, causing infinite recursion", dst, src)
 	}
 
-	// Check if dst already exists
+	// Check if dst already exists and allowOverwrite is true
 	var backupPath string
-	dstExists := false
-	if _, err := os.Stat(dst); err == nil {
-		dstExists = true
-		if allowOverwrite {
-			// Create backup by renaming existing dst
-			backupPath = generateBackupPath(dst)
-			if err := os.Rename(dst, backupPath); err != nil {
-				return fmt.Errorf("failed to backup existing directory: %w", err)
-			}
+	if _, err := os.Stat(dst); err == nil && allowOverwrite {
+		// Create backup by renaming existing dst
+		backupPath = generateBackupPath(dst)
+		if err := os.Rename(dst, backupPath); err != nil {
+			return fmt.Errorf("failed to backup existing directory: %w", err)
 		}
 	}
 
@@ -80,9 +76,6 @@ func CopyDir(src, dst string, allowOverwrite bool) error {
 	// Success: remove backup if exists
 	if backupPath != "" {
 		_ = os.RemoveAll(backupPath)
-	} else if dstExists && !allowOverwrite {
-		// dst existed but allowOverwrite was false - this shouldn't happen
-		// as the caller should have handled this case
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Fix folder upload to properly replace existing folder contents when `AllowOverwrite=true`
- Fix `CopyDir` to use backup-and-replace strategy instead of merging folders

## Problem

When uploading a folder with the same name as an existing folder, the contents of the existing folder were not properly replaced due to two issues:

1. **`unzip -n` option**: The `fileDownload` function used `unzip -n` which never overwrites existing files, regardless of the `AllowOverwrite` setting
2. **`CopyDir` merge behavior**: The function merged folders instead of replacing them

## Changes

### `pkg/runner/command.go`
- Use `-o` (overwrite) when `AllowOverwrite=true`, otherwise `-n` (never overwrite) for unzip command

### `pkg/utils/fs.go`
- Implement backup-and-replace strategy for `CopyDir`:
  1. Rename existing `dst` to `dst_backup_N`
  2. Copy `src` to `dst`
  3. On success: Delete backup
  4. On failure: Remove partial `dst`, restore backup
- Add `generateBackupPath` helper function
- Add `copyDirRecursive` for pure copy operation

## Test Plan

- [x] Upload a folder to an empty directory → folder created
- [x] Upload a folder with `AllowOverwrite=false` to existing folder → new folder name (e.g., `test (1)`)
- [x] Upload a folder with `AllowOverwrite=true` to existing folder → existing folder completely replaced
- [x] Test copy failure scenario → original folder restored

Closes #148