### PR TITLE
Fix wildcard (*) glob expansion in shell command execution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
       - "docs/**"
 
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
 
   workflow_call:
 

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -173,9 +173,9 @@ func runCmdWithOutput(args []string, username, groupname string, env map[string]
 	defer cancel()
 
 	// Expand glob patterns (*) in arguments using filepath.Glob
-	expandedArgs := expandGlobArgs(args)
+	args = expandGlobArgs(args)
 
-	cmd := exec.CommandContext(ctx, expandedArgs[0], expandedArgs[1:]...)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	if username != "root" {
 		sysProcAttr, err := demote(username, groupname)
 		if err != nil {

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -172,10 +172,15 @@ func runCmdWithOutput(args []string, username, groupname string, env map[string]
 	}
 	defer cancel()
 
-	// Expand glob patterns (*) in arguments using filepath.Glob
-	args = expandGlobArgs(args)
+	// Check if args is empty
+	if len(args) == 0 {
+		return 1, "no command provided"
+	}
 
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	// Expand glob patterns (*) in arguments using filepath.Glob
+	expandedArgs := expandGlobArgs(args[1:])
+	cmd := exec.CommandContext(ctx, args[0], expandedArgs...)
+
 	if username != "root" {
 		sysProcAttr, err := demote(username, groupname)
 		if err != nil {

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -214,13 +214,12 @@ func runCmdWithOutput(args []string, username, groupname string, env map[string]
 	return 0, string(output)
 }
 
-// expandGlobArgs expands glob patterns (*) in arguments using filepath.Glob.
-// This is safer than using shell execution as it doesn't allow command injection.
+// expandGlobArgs expands glob patterns in arguments using filepath.Glob.
 func expandGlobArgs(args []string) []string {
 	var expandedArgs []string
 
 	for _, arg := range args {
-		if strings.Contains(arg, "*") {
+		if containsGlobPattern(arg) {
 			// Try to expand glob pattern
 			matches, err := filepath.Glob(arg)
 			if err == nil && len(matches) > 0 {
@@ -235,4 +234,10 @@ func expandGlobArgs(args []string) []string {
 	}
 
 	return expandedArgs
+}
+
+// containsGlobPattern checks if a string contains glob pattern characters.
+// Supported: * (any), ? (single char), [ (character class)
+func containsGlobPattern(s string) bool {
+	return strings.ContainsAny(s, "*?[")
 }

--- a/pkg/runner/shell.go
+++ b/pkg/runner/shell.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -171,19 +172,10 @@ func runCmdWithOutput(args []string, username, groupname string, env map[string]
 	}
 	defer cancel()
 
-	// Check if command contains glob wildcard (*) that requires shell expansion
-	var cmd *exec.Cmd
-	if needsGlobExpansion(args) {
-		// Quote each argument to prevent command injection, preserving * for glob expansion
-		quotedArgs := make([]string, len(args))
-		for i, arg := range args {
-			quotedArgs[i] = quoteArgPreservingGlob(arg)
-		}
-		shellCmd := strings.Join(quotedArgs, " ")
-		cmd = exec.CommandContext(ctx, "sh", "-c", shellCmd)
-	} else {
-		cmd = exec.CommandContext(ctx, args[0], args[1:]...)
-	}
+	// Expand glob patterns (*) in arguments using filepath.Glob
+	expandedArgs := expandGlobArgs(args)
+
+	cmd := exec.CommandContext(ctx, expandedArgs[0], expandedArgs[1:]...)
 	if username != "root" {
 		sysProcAttr, err := demote(username, groupname)
 		if err != nil {
@@ -217,32 +209,25 @@ func runCmdWithOutput(args []string, username, groupname string, env map[string]
 	return 0, string(output)
 }
 
-// needsGlobExpansion checks if any argument contains * wildcard for glob expansion
-func needsGlobExpansion(args []string) bool {
+// expandGlobArgs expands glob patterns (*) in arguments using filepath.Glob.
+// This is safer than using shell execution as it doesn't allow command injection.
+func expandGlobArgs(args []string) []string {
+	var expandedArgs []string
+
 	for _, arg := range args {
 		if strings.Contains(arg, "*") {
-			return true
+			// Try to expand glob pattern
+			matches, err := filepath.Glob(arg)
+			if err == nil && len(matches) > 0 {
+				expandedArgs = append(expandedArgs, matches...)
+			} else {
+				// No matches or error, keep original argument
+				expandedArgs = append(expandedArgs, arg)
+			}
+		} else {
+			expandedArgs = append(expandedArgs, arg)
 		}
 	}
-	return false
-}
 
-// quoteArgPreservingGlob quotes an argument for safe shell execution,
-// but preserves * wildcards for glob expansion.
-// This prevents command injection while allowing glob patterns to work.
-func quoteArgPreservingGlob(arg string) string {
-	if !strings.Contains(arg, "*") {
-		// No glob, use full quoting for safety
-		return "'" + strings.ReplaceAll(arg, "'", "'\"'\"'") + "'"
-	}
-
-	// Has glob - we need to be careful
-	// Split by *, quote each part, rejoin with *
-	parts := strings.Split(arg, "*")
-	for i, part := range parts {
-		if part != "" {
-			parts[i] = "'" + strings.ReplaceAll(part, "'", "'\"'\"'") + "'"
-		}
-	}
-	return strings.Join(parts, "*")
+	return expandedArgs
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/user"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -184,4 +185,59 @@ func LookUpGID(groupname string) (int, error) {
 	}
 
 	return strconv.Atoi(group.Gid)
+}
+
+// expandGlobArgs expands glob patterns in arguments using filepath.Glob.
+// baseDir is used as the working directory for relative path glob expansion.
+func ExpandGlobArgs(args []string, baseDir string) []string {
+	var result []string
+	for _, arg := range args {
+		result = append(result, expandSingleGlobArg(arg, baseDir)...)
+	}
+	return result
+}
+
+// expandSingleGlobArg expands a single argument if it contains glob patterns.
+func expandSingleGlobArg(arg, baseDir string) []string {
+	if !containsGlobPattern(arg) {
+		return []string{arg}
+	}
+
+	pattern, isRelative := toAbsolutePattern(arg, baseDir)
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return []string{arg}
+	}
+
+	if !isRelative {
+		return matches
+	}
+
+	return toRelativePaths(matches, baseDir)
+}
+
+// toAbsolutePattern converts a glob pattern to absolute path if it's relative.
+func toAbsolutePattern(arg, baseDir string) (pattern string, isRelative bool) {
+	if filepath.IsAbs(arg) {
+		return arg, false
+	}
+	return filepath.Join(baseDir, arg), true
+}
+
+// toRelativePaths converts absolute paths back to relative paths based on baseDir.
+func toRelativePaths(paths []string, baseDir string) []string {
+	result := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if rel, err := filepath.Rel(baseDir, p); err == nil {
+			result = append(result, rel)
+		} else {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// containsGlobPattern checks if a string contains glob pattern characters.
+func containsGlobPattern(s string) bool {
+	return strings.ContainsAny(s, "*?[")
 }


### PR DESCRIPTION
## Summary

Fix shell command execution to properly handle wildcard (`*`) glob patterns like `rm -rf ./hello/*`.

## Problem

`exec.Command` executes commands directly without shell interpretation, so `*` is passed as a literal string instead of being expanded.

```go
// Before: * not expanded
cmd := exec.CommandContext(ctx, "rm", "-rf", "./hello/*")
// Result: tries to find file literally named "./hello/*"
```

## Solution

When arguments contain `*`, execute via shell with proper quoting to enable glob expansion while preventing command injection:

```go
if needsGlobExpansion(args) {
    // Quote args, preserving * for glob
    cmd = exec.CommandContext(ctx, "sh", "-c", shellCmd)
}
```

### Security

- Only `*` triggers shell execution (not `;`, `|`, `&`, etc.)
- All arguments are quoted with single quotes
- `*` is preserved unquoted for glob expansion

| Input | Quoted Output |
|-------|---------------|
| `rm -rf ./hello/*` | `'rm' '-rf' './hello/'*` |
| `ls ; rm -rf /` | `'ls ; rm -rf /'` (injection prevented) |

## Changes

- `pkg/runner/shell.go`:
  - Modify `runCmdWithOutput` to detect `*` and execute via shell
  - Add `needsGlobExpansion` function
  - Add `quoteArgPreservingGlob` function

## Test Plan

- [x] `rm -rf ./test/*` removes all files in test directory
- [x] `ls *.txt` lists all txt files
- [x] `echo hello` works without shell (no `*`)

Closes #151