### PR TITLE
Resolve "[Alpamon Agent Refactoring] Phase4: Transport Layer Separation"

### DIFF
--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -1,0 +1,69 @@
+package protocol
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// MessageType defines the type of protocol message
+type MessageType string
+
+const (
+	MessageTypeCommand   MessageType = "command"
+	MessageTypeQuit      MessageType = "quit"
+	MessageTypeReconnect MessageType = "reconnect"
+	MessageTypePing      MessageType = "ping"
+)
+
+// Message is the base protocol message envelope received from the server
+type Message struct {
+	Query   MessageType     `json:"query"`
+	Command *Command        `json:"command,omitempty"`
+	Reason  string          `json:"reason,omitempty"`
+	Raw     json.RawMessage `json:"-"` // Original raw message for debugging
+}
+
+// Response represents a response message to send back to the server
+type Response struct {
+	Query string `json:"query"`
+}
+
+// CommandResponse represents a command execution result
+type CommandResponse struct {
+	Success     bool    `json:"success"`
+	Result      string  `json:"result"`
+	ElapsedTime float64 `json:"elapsed_time"`
+}
+
+// PingResponse represents a ping response
+type PingResponse struct {
+	Query     string    `json:"query"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+}
+
+// NewPingResponse creates a new ping response
+func NewPingResponse() *PingResponse {
+	return &PingResponse{
+		Query:     "ping",
+		Timestamp: time.Now(),
+	}
+}
+
+// NewCommandResponse creates a new command response
+func NewCommandResponse(success bool, result string, elapsed float64) *CommandResponse {
+	return &CommandResponse{
+		Success:     success,
+		Result:      result,
+		ElapsedTime: elapsed,
+	}
+}
+
+// ParseMessage parses a raw JSON message into a Message struct
+func ParseMessage(data []byte) (*Message, error) {
+	var msg Message
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	msg.Raw = data
+	return &msg, nil
+}

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -1,0 +1,128 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMessage_Command(t *testing.T) {
+	raw := `{
+		"query": "command",
+		"command": {
+			"id": "test-123",
+			"shell": "internal",
+			"line": "ping",
+			"user": "root",
+			"group": "root",
+			"env": {"FOO": "bar"},
+			"data": "{\"session_id\": \"sess-456\"}"
+		}
+	}`
+
+	msg, err := ParseMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, MessageTypeCommand, msg.Query)
+	require.NotNil(t, msg.Command)
+	assert.Equal(t, "test-123", msg.Command.ID)
+	assert.Equal(t, "internal", msg.Command.Shell)
+	assert.Equal(t, "ping", msg.Command.Line)
+	assert.Equal(t, "root", msg.Command.User)
+	assert.Equal(t, "bar", msg.Command.Env["FOO"])
+}
+
+func TestParseMessage_Quit(t *testing.T) {
+	raw := `{"query": "quit", "reason": "server shutdown"}`
+
+	msg, err := ParseMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, MessageTypeQuit, msg.Query)
+	assert.Equal(t, "server shutdown", msg.Reason)
+}
+
+func TestParseMessage_Reconnect(t *testing.T) {
+	raw := `{"query": "reconnect", "reason": "server restart"}`
+
+	msg, err := ParseMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, MessageTypeReconnect, msg.Query)
+	assert.Equal(t, "server restart", msg.Reason)
+}
+
+func TestParseMessage_Invalid(t *testing.T) {
+	raw := `invalid json`
+
+	msg, err := ParseMessage([]byte(raw))
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
+func TestCommand_ParseCommandData(t *testing.T) {
+	cmd := &Command{
+		ID:    "test-123",
+		Shell: "internal",
+		Line:  "adduser",
+		Data:  `{"username": "testuser", "uid": 1000, "gid": 1000}`,
+	}
+
+	data, err := cmd.ParseCommandData()
+	require.NoError(t, err)
+	assert.Equal(t, "testuser", data.Username)
+	assert.Equal(t, uint64(1000), data.UID)
+	assert.Equal(t, uint64(1000), data.GID)
+}
+
+func TestCommand_ParseCommandData_Empty(t *testing.T) {
+	cmd := &Command{
+		ID:   "test-123",
+		Data: "",
+	}
+
+	data, err := cmd.ParseCommandData()
+	require.NoError(t, err)
+	assert.NotNil(t, data)
+	assert.Equal(t, "", data.Username)
+}
+
+func TestCommand_ParseCommandData_Invalid(t *testing.T) {
+	cmd := &Command{
+		ID:   "test-123",
+		Data: "invalid json",
+	}
+
+	data, err := cmd.ParseCommandData()
+	assert.Error(t, err)
+	assert.Nil(t, data)
+}
+
+func TestNewCommandResponse(t *testing.T) {
+	resp := NewCommandResponse(true, "success output", 1.5)
+
+	assert.True(t, resp.Success)
+	assert.Equal(t, "success output", resp.Result)
+	assert.Equal(t, 1.5, resp.ElapsedTime)
+}
+
+func TestNewPingResponse(t *testing.T) {
+	resp := NewPingResponse()
+
+	assert.Equal(t, "ping", resp.Query)
+	assert.False(t, resp.Timestamp.IsZero())
+}
+
+func TestCommandResponse_JSON(t *testing.T) {
+	resp := NewCommandResponse(true, "done", 2.5)
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded CommandResponse
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.Success, decoded.Success)
+	assert.Equal(t, resp.Result, decoded.Result)
+	assert.Equal(t, resp.ElapsedTime, decoded.ElapsedTime)
+}

--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/alpacax/alpamon/internal/protocol"
 	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/pkg/runner"
@@ -97,7 +98,7 @@ func (h *TerminalHandler) handleOpenPTY(args *common.CommandArgs) (int, string, 
 		return 1, fmt.Sprintf("openpty: Not enough information. %s", err.Error()), nil
 	}
 
-	data := runner.CommandData{
+	data := protocol.CommandData{
 		SessionID:     args.SessionID,
 		URL:           args.URL,
 		Username:      args.Username,

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/alpacax/alpamon/internal/protocol"
 	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -58,7 +59,7 @@ func init() {
 	terminals = make(map[string]*PtyClient)
 }
 
-func NewPtyClient(data CommandData, apiSession *scheduler.Session) *PtyClient {
+func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session) *PtyClient {
 	headers := http.Header{
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
 		"Origin":        {config.GlobalSettings.ServerURL},


### PR DESCRIPTION
## Summary

Separate protocol message types into a dedicated `internal/protocol` package for better code organization and type safety.

## Motivation

- Decouple protocol message definitions from WebSocket transport layer
- Improve type safety with `MessageType` constants instead of string literals
- Hide internal protocol details from go.dev by using `internal/` directory

## Changes

### New Package: `internal/protocol`

| File | Purpose |
|------|---------|
| `message.go` | `Message`, `MessageType`, `CommandResponse`, `PingResponse` types |
| `command.go` | `Command`, `CommandData`, `File` types and `ToArgs()` method |
| `message_test.go` | Unit tests (10 test cases) |

### Modified Files

| File | Change |
|------|--------|
| `pkg/runner/client.go` | Use `protocol.ParseMessage()` and `MessageType` constants |
| `pkg/runner/command.go` | Use `protocol.Command`, `protocol.CommandData` types |
| `pkg/runner/pty.go` | Use `protocol.CommandData` directly |
| `pkg/executor/handlers/terminal/terminal.go` | Use `protocol.CommandData` directly |

### Deleted Files

| File | Reason |
|------|--------|
| `pkg/runner/command_types.go` | Types moved to `internal/protocol` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -p 1` all tests pass
- [x] Local alpamon execution test
- [x] WebSocket connection and command execution test

## Notification
The separation of transport logic described in the [issue](https://github.com/alpacax/alpamon/issues/135) was deemed overkill at the current stage and was not implemented, as we do not yet support multi-protocol. 
Instead, only the refactoring described above was carried out to facilitate future maintenance and scalability.

## Related issues

Closes #135
