### PR TITLE
feat(runner): add ping/pong handler for WebSocket heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 alpamon.log
 alpamon.db
 /alpamon
+/cmd/alpamon/alpamon
 .DS_Store
 .idea

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -228,7 +228,9 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 
 	switch content.Query {
 	case "ping":
-		_ = wc.SendPongResponse()
+		if err := wc.SendPongResponse(); err != nil {
+			log.Debug().Err(err).Msg("Failed to send pong response.")
+		}
 	case "command":
 		scheduler.Rqueue.Post(fmt.Sprintf(eventCommandAckURL, content.Command.ID),
 			nil,

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -70,8 +70,6 @@ func (wc *WebsocketClient) RunForever(ctx context.Context) {
 				wc.CloseAndReconnect(ctx)
 				continue
 			}
-			// Sends "ping" query for Alpacon to verify WebSocket session status without error handling.
-			_ = wc.SendPingQuery()
 			wc.CommandRequestHandler(message)
 		}
 	}
@@ -85,6 +83,14 @@ func (wc *WebsocketClient) SendPingQuery() error {
 	}
 
 	return nil
+}
+
+func (wc *WebsocketClient) SendPongResponse() error {
+	pongResponse := map[string]string{
+		"query":     "pong",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+	return wc.WriteJSON(pongResponse)
 }
 
 func (wc *WebsocketClient) ReadMessage() (messageType int, message []byte, err error) {
@@ -221,6 +227,8 @@ func (wc *WebsocketClient) CommandRequestHandler(message []byte) {
 	}
 
 	switch content.Query {
+	case "ping":
+		_ = wc.SendPongResponse()
 	case "command":
 		scheduler.Rqueue.Post(fmt.Sprintf(eventCommandAckURL, content.Command.ID),
 			nil,

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -134,6 +134,7 @@ func (cr *CommandRunner) handleInternalCmd() (int, string) {
 	case "moduser":
 		return cr.modUser()
 	case "ping":
+		_ = cr.wsClient.SendPongResponse()
 		return 0, time.Now().Format(time.RFC3339)
 	case "download":
 		return cr.runFileDownload(args[1])


### PR DESCRIPTION
## Summary
- Add `SendPongResponse()` method to handle explicit ping queries from server
- Handle "ping" query in `CommandRequestHandler` with pong response including timestamp
- Remove automatic ping on every message read (rely on explicit ping/pong instead)

## Test plan
- [ ] Verify server can send `{"query": "ping"}` and receive `{"query": "pong", "timestamp": "..."}`
- [ ] Confirm WebSocket connection remains stable without automatic ping
- [ ] Test plugin access to `SendPongResponse()` method