### PR TITLE
refactor(logger): remove lumberjack, use systemd journald for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,21 @@ alpamon.service - alpamon agent for Alpacon
      Loaded: loaded (/lib/systemd/system/alpamon.service; enabled; vendor preset: enabled)
      Active: active (running) since Thu 2023-09-28 23:48:55 KST; 4 days ago
 ```
+
+### Logs
+
+Alpamon logs are managed by systemd's journald. Use the following commands to view logs:
+
+```bash
+# View all logs
+journalctl -u alpamon
+
+# Follow logs in real-time
+journalctl -u alpamon -f
+
+# View logs since today
+journalctl -u alpamon --since today
+
+# View recent logs (last 100 lines)
+journalctl -u alpamon -n 100
+```

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -20,7 +20,6 @@ import (
 	"github.com/alpacax/alpamon/pkg/version"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 const (
@@ -54,7 +53,7 @@ func runAgent() {
 	}()
 
 	// Logger
-	logRotate := logger.InitLogger()
+	logger.InitLogger()
 
 	// platform
 	utils.InitPlatform()
@@ -107,17 +106,17 @@ func runAgent() {
 		select {
 		case <-ctx.Done():
 			log.Info().Msg("Received termination signal. Shutting down...")
-			gracefulShutdown(metricCollector, wsClient, logRotate, logServer, pidFilePath)
+			gracefulShutdown(metricCollector, wsClient, logServer, pidFilePath)
 			return
 		case <-wsClient.ShutDownChan:
 			log.Info().Msg("Shutdown command received. Shutting down...")
 			cancel()
-			gracefulShutdown(metricCollector, wsClient, logRotate, logServer, pidFilePath)
+			gracefulShutdown(metricCollector, wsClient, logServer, pidFilePath)
 			return
 		case <-wsClient.RestartChan:
 			log.Info().Msg("Restart command received. Restarting...")
 			cancel()
-			gracefulShutdown(metricCollector, wsClient, logRotate, logServer, pidFilePath)
+			gracefulShutdown(metricCollector, wsClient, logServer, pidFilePath)
 			restartAgent()
 			return
 		case <-wsClient.CollectorRestartChan:
@@ -142,7 +141,7 @@ func restartAgent() {
 	}
 }
 
-func gracefulShutdown(collector *collector.Collector, wsClient *runner.WebsocketClient, logRotate *lumberjack.Logger, logServer *logger.LogServer, pidPath string) {
+func gracefulShutdown(collector *collector.Collector, wsClient *runner.WebsocketClient, logServer *logger.LogServer, pidPath string) {
 	if collector != nil {
 		collector.Stop()
 	}
@@ -155,8 +154,5 @@ func gracefulShutdown(collector *collector.Collector, wsClient *runner.Websocket
 
 	log.Debug().Msg("Bye.")
 
-	if logRotate != nil {
-		_ = logRotate.Close()
-	}
 	_ = os.Remove(pidPath)
 }

--- a/configs/alpamon.service
+++ b/configs/alpamon.service
@@ -9,8 +9,9 @@ WorkingDirectory=/var/lib/alpamon
 SELinuxContext=-unconfined_u:unconfined_r:unconfined_t:s0
 AppArmorProfile=-unconfined
 Restart=on-failure
-StandardOutput=null
-StandardError=null
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=alpamon
 
 [Install]
 WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	golang.org/x/term v0.30.0
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/ini.v1 v1.67.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,6 @@ gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+a
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.21.4 h1:3Be/Rdo1fpr8GrQ7IVw9OHtplU4gWbb+wNgeoBMmGLQ=


### PR DESCRIPTION
## Summary
- Remove lumberjack dependency for log rotation
- Output logs to stderr for systemd/journald to capture
- Update systemd service configuration to use journald
- Add log viewing instructions to README

## Why
Follow Linux-native logging conventions. Let systemd/journald handle log collection and rotation instead of application-level log rotation with lumberjack.

## Test plan
- [ ] Verify logs appear in journald: `journalctl -u alpamon -f`
- [ ] Confirm no file is created at `/var/log/alpamon/alpamon.log`
- [ ] Test log filtering commands from README