### PR TITLE
Resolve "[sync] Improve login_enabled field accuracy with native Linux checks"

### DIFF
--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -96,13 +96,11 @@ func TestLoadShadowData(t *testing.T) {
 	// shadowData may be nil if /etc/shadow is not readable (permission denied)
 	// This is expected behavior on non-root execution
 	// The function should not panic or error
-	if shadowData != nil {
-		// If we could read the shadow file, verify the structure
-		for username, entry := range shadowData {
-			assert.NotEmpty(t, username, "Username should not be empty")
-			assert.Equal(t, username, entry.username, "Entry username should match key")
-			// expireDate is *int64 (may be nil)
-		}
+	// Note: range over nil map is safe and does nothing
+	for username, entry := range shadowData {
+		assert.NotEmpty(t, username, "Username should not be empty")
+		assert.Equal(t, username, entry.username, "Entry username should match key")
+		// expireDate is *int64 (may be nil)
 	}
 }
 

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -101,7 +101,7 @@ func TestLoadShadowData(t *testing.T) {
 		for username, entry := range shadowData {
 			assert.NotEmpty(t, username, "Username should not be empty")
 			assert.Equal(t, username, entry.username, "Entry username should match key")
-			// passwordLocked is boolean, expireDate is *int64 (may be nil)
+			// expireDate is *int64 (may be nil)
 		}
 	}
 }
@@ -114,7 +114,7 @@ func TestGetUserDataWithRawFields(t *testing.T) {
 	for _, user := range userData {
 		assert.NotEmpty(t, user.Username, "Username should not be empty.")
 		// ValidShells will be set if /etc/shells was readable (same for all users)
-		// PasswordLocked and ShadowExpireDate will be set if /etc/shadow was readable
+		// ShadowExpireDate will be set if /etc/shadow was readable
 		// These raw data fields enable server-side login_enabled determination
 	}
 }

--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -105,13 +105,16 @@ type TimeData struct {
 }
 
 type UserData struct {
-	ID          string `json:"id,omitempty"`
-	UID         int    `json:"uid"`
-	GID         int    `json:"gid"`
-	Username    string `json:"username"`
-	Description string `json:"description"`
-	Directory   string `json:"directory"`
-	Shell       string `json:"shell"`
+	ID               string   `json:"id,omitempty"`
+	UID              int      `json:"uid"`
+	GID              int      `json:"gid"`
+	Username         string   `json:"username"`
+	Description      string   `json:"description"`
+	Directory        string   `json:"directory"`
+	Shell            string   `json:"shell"`
+	PasswordLocked   *bool    `json:"password_locked,omitempty"`    // /etc/shadow: password locked (boolean for security - no hash exposure)
+	ShadowExpireDate *int64   `json:"shadow_expire_date,omitempty"` // /etc/shadow: raw expiration date (days since epoch)
+	ValidShells      []string `json:"valid_shells,omitempty"`       // /etc/shells: full list of valid login shells
 }
 
 type GroupData struct {
@@ -152,6 +155,13 @@ type Partition struct {
 	DiskName    string   `json:"disk_name"`
 	Fstype      string   `json:"fs_type"`
 	IsVirtual   bool     `json:"is_virtual"`
+}
+
+// shadowEntry represents a parsed /etc/shadow entry (internal use only)
+type shadowEntry struct {
+	username       string
+	passwordLocked bool
+	expireDate     *int64 // days since epoch, nil if not set
 }
 
 type commitData struct {
@@ -247,11 +257,14 @@ func (u UserData) GetKey() interface{} {
 
 func (u UserData) GetData() ComparableData {
 	return UserData{
-		Username:  u.Username,
-		UID:       u.UID,
-		GID:       u.GID,
-		Directory: u.Directory,
-		Shell:     u.Shell,
+		Username:         u.Username,
+		UID:              u.UID,
+		GID:              u.GID,
+		Directory:        u.Directory,
+		Shell:            u.Shell,
+		PasswordLocked:   u.PasswordLocked,
+		ShadowExpireDate: u.ShadowExpireDate,
+		ValidShells:      u.ValidShells,
 	}
 }
 

--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -112,7 +112,6 @@ type UserData struct {
 	Description      string   `json:"description"`
 	Directory        string   `json:"directory"`
 	Shell            string   `json:"shell"`
-	PasswordLocked   *bool    `json:"password_locked,omitempty"`    // /etc/shadow: password locked (boolean for security - no hash exposure)
 	ShadowExpireDate *int64   `json:"shadow_expire_date,omitempty"` // /etc/shadow: raw expiration date (days since epoch)
 	ValidShells      []string `json:"valid_shells,omitempty"`       // /etc/shells: full list of valid login shells
 }
@@ -159,9 +158,8 @@ type Partition struct {
 
 // shadowEntry represents a parsed /etc/shadow entry (internal use only)
 type shadowEntry struct {
-	username       string
-	passwordLocked bool
-	expireDate     *int64 // days since epoch, nil if not set
+	username   string
+	expireDate *int64 // days since epoch, nil if not set
 }
 
 type commitData struct {
@@ -262,7 +260,6 @@ func (u UserData) GetData() ComparableData {
 		GID:              u.GID,
 		Directory:        u.Directory,
 		Shell:            u.Shell,
-		PasswordLocked:   u.PasswordLocked,
 		ShadowExpireDate: u.ShadowExpireDate,
 		ValidShells:      u.ValidShells,
 	}


### PR DESCRIPTION
## Summary

Collect raw login data in alpamon and send to server for improved `login_enabled` accuracy.

- `shadow_expire_date`: `*int64` - raw value transmitted (days since epoch)
- `valid_shells`: `[]string` - full /etc/shells list transmitted

Server determines `login_enabled` using this raw data, enabling policy changes without agent updates.

## Changes

### pkg/runner/commit_types.go
- Add raw data fields to `UserData` struct
- Add `shadowEntry` struct (internal use)
- Update `GetData()` method

### pkg/runner/commit.go
- `loadValidShells()`: Parse /etc/shells and return `[]string`
- `loadShadowData()`: Parse /etc/shadow for password lock and expire date
- `getUserData()`: Collect raw data and include in UserData

### pkg/runner/commit_test.go
- `TestLoadValidShells`: Test /etc/shells parsing
- `TestLoadShadowData`: Test /etc/shadow parsing
- `TestGetUserDataWithRawFields`: Test raw data fields

## API Changes

**Before:**
```json
{
  "uid": 4,
  "username": "sync",
  "shell": "/bin/sync"
}
```

**After:**
```json
{
  "uid": 4,
  "username": "sync",
  "shell": "/bin/sync",
  "shadow_expire_date": null,
  "valid_shells": ["/bin/sh", "/bin/bash", "/bin/zsh"]
}
```

## Backward Compatibility

| alpamon | alpacon-server | Behavior |
|---------|----------------|----------|
| Old | Old | Server calculates from shell |
| Old | New | Server calculates from shell (fallback) |
| New | Old | Server ignores extra fields |
| New | New | Server uses raw data for accurate determination |

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go test ./pkg/runner/...` passes
- [x] Test /etc/shadow reading on Linux (requires root)
- [x] Integration test with alpacon-server

## Related Issues

- Closes #169 
