### PR TITLE
feat(pam): add flag to temporarily disable sudo PAM functionality

### DIFF
--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -1,0 +1,12 @@
+package utils
+
+// sudoPAMDisabled controls whether sudo PAM approval functionality is enabled.
+// When true, the control client and auth manager will not be started.
+// This is useful for testing environments or releases where the server-side
+// control endpoint is not yet available.
+var sudoPAMDisabled = true
+
+// IsSudoPAMDisabled returns whether sudo PAM functionality is disabled.
+func IsSudoPAMDisabled() bool {
+	return sudoPAMDisabled
+}


### PR DESCRIPTION
Add sudoPAMDisabled flag to skip control client and auth manager startup when server-side control endpoint is not available. 
This allows v1.3.1 release to proceed without server dependency.

Changes:
- Add pkg/utils/pam.go with IsSudoPAMDisabled() function
- Update cmd/alpamon/command/root.go with conditional startup logic
- Graceful shutdown already handles nil controlClient/authManager