### PR TITLE
Resolve "[sync] Excessive unnecessary PATCH requests during sync comparison"

### DIFF
--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -181,7 +181,8 @@ type commitData struct {
 type ComparableData interface {
 	GetID() string
 	GetKey() interface{}
-	GetData() ComparableData
+	GetData() ComparableData           // For transmission (includes all raw data)
+	GetComparableData() ComparableData // For comparison (excludes fields not stored by server)
 }
 
 func (s SystemData) GetID() string {
@@ -209,6 +210,10 @@ func (s SystemData) GetData() ComparableData {
 	}
 }
 
+func (s SystemData) GetComparableData() ComparableData {
+	return s.GetData()
+}
+
 func (o OSData) GetID() string {
 	return o.ID
 }
@@ -229,6 +234,10 @@ func (o OSData) GetData() ComparableData {
 	}
 }
 
+func (o OSData) GetComparableData() ComparableData {
+	return o.GetData()
+}
+
 func (t TimeData) GetID() string {
 	return t.ID
 }
@@ -243,6 +252,10 @@ func (t TimeData) GetData() ComparableData {
 		Timezone: t.Timezone,
 		Uptime:   t.Uptime,
 	}
+}
+
+func (t TimeData) GetComparableData() ComparableData {
+	return t.GetData()
 }
 
 func (u UserData) GetID() string {
@@ -265,6 +278,21 @@ func (u UserData) GetData() ComparableData {
 	}
 }
 
+// GetComparableData returns data for comparison, excluding fields not stored by server.
+// ValidShells is excluded because the server doesn't store it (system-wide, rarely changes).
+// ShadowExpireDate is included because the server stores it for real-time expiration checks.
+func (u UserData) GetComparableData() ComparableData {
+	return UserData{
+		Username:         u.Username,
+		UID:              u.UID,
+		GID:              u.GID,
+		Directory:        u.Directory,
+		Shell:            u.Shell,
+		ShadowExpireDate: u.ShadowExpireDate,
+		// ValidShells excluded - server doesn't store this field
+	}
+}
+
 func (g GroupData) GetID() string {
 	return g.ID
 }
@@ -278,6 +306,10 @@ func (g GroupData) GetData() ComparableData {
 		GID:       g.GID,
 		GroupName: g.GroupName,
 	}
+}
+
+func (g GroupData) GetComparableData() ComparableData {
+	return g.GetData()
 }
 
 func (i Interface) GetID() string {
@@ -299,6 +331,10 @@ func (i Interface) GetData() ComparableData {
 	}
 }
 
+func (i Interface) GetComparableData() ComparableData {
+	return i.GetData()
+}
+
 func (a Address) GetID() string {
 	return a.ID
 }
@@ -314,6 +350,10 @@ func (a Address) GetData() ComparableData {
 		InterfaceName: a.InterfaceName,
 		Mask:          a.Mask,
 	}
+}
+
+func (a Address) GetComparableData() ComparableData {
+	return a.GetData()
 }
 
 func (d Disk) GetID() string {
@@ -332,6 +372,10 @@ func (d Disk) GetData() ComparableData {
 	}
 }
 
+func (d Disk) GetComparableData() ComparableData {
+	return d.GetData()
+}
+
 func (p Partition) GetID() string {
 	return p.ID
 }
@@ -348,4 +392,8 @@ func (p Partition) GetData() ComparableData {
 		Fstype:      p.Fstype,
 		IsVirtual:   p.IsVirtual,
 	}
+}
+
+func (p Partition) GetComparableData() ComparableData {
+	return p.GetData()
 }


### PR DESCRIPTION
## Summary

- Add `GetComparableData()` method to `ComparableData` interface for sync comparison
    - Exclude `ValidShells` from comparison (server doesn't store it)
    - Keep `ShadowExpireDate` in comparison (server stores it for real-time expiration checks)
- Prevent unnecessary PATCH requests caused by field mismatch during sync

## Problem

After implementing the `login_enabled` improvement (#169), all SystemUsers triggered PATCH requests on every sync, even when no actual data changed.

### Root Cause

| Field | Server Stores | Included in Sync Response | Previous Comparison |
|-------|---------------|---------------------------|---------------------|
| `shadow_expire_date` | ✅ Yes | ✅ Yes | ✅ Compared |
| `valid_shells` | ❌ No | ❌ No | ❌ **Compared (bug)** |

Since `valid_shells` was included in comparison but not stored by server, every sync detected a false difference.

## Solution

Separate comparison logic from transmission logic:

- `GetData()`: For transmission - includes all raw data (unchanged)
- `GetComparableData()`: For comparison - excludes fields not stored by server

```go
// UserData.GetComparableData() - excludes ValidShells
func (u UserData) GetComparableData() ComparableData {
    return UserData{
        Username:         u.Username,
        UID:              u.UID,
        GID:              u.GID,
        Directory:        u.Directory,
        Shell:            u.Shell,
        ShadowExpireDate: u.ShadowExpireDate,  // Included (server stores it)
        // ValidShells excluded (server doesn't store it)
    }
}
```

## Changes

### `pkg/runner/commit_types.go`
- Add `GetComparableData()` to `ComparableData` interface
- Implement `GetComparableData()` for `UserData` (excludes `ValidShells`)
- Implement `GetComparableData()` for other types (returns `GetData()`)

### `pkg/runner/commit.go`
- Update `compareListData()` to use `GetComparableData()` for comparison
- Update `compareData()` to use `GetComparableData()` for comparison
- Keep using `GetData()` for transmission (POST/PATCH)

### `pkg/runner/commit_test.go`
- Add `TestUserDataGetComparableData()`
- Add `TestCompareUserDataNoUnnecessaryPatch()`
- Add `TestCompareUserDataDetectRealChanges()`
- Add `TestOtherTypesGetComparableData()`

## Test Plan

- [x] `go test -v ./pkg/runner/...` passes
- [x] `go build ./...` succeeds
- [x] Manual test: verify no unnecessary PATCH requests during sync
- [x] Manual test: verify real changes still trigger PATCH requests

## Comparison Example

### Before (Bug)
```
Current:  {Username: "test", Shell: "/bin/bash", ValidShells: ["/bin/bash"]}
Remote:   {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Result:   NOT EQUAL → Unnecessary PATCH
```

### After (Fixed)
```
Current.GetComparableData():  {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Remote.GetComparableData():   {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Result:   EQUAL → No PATCH
```

## Related Issues

- #169 - Improve `login_enabled` field accuracy
- Resolves: Closes #175 
