### PR TITLE
Resolve "[Backport] Sync Comparison Fix to release/v1.3.1"

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -213,7 +213,8 @@ func compareData(entry commitDef, currentData, remoteData ComparableData) {
 	if remoteData == nil {
 		createData = currentData
 	} else {
-		if currentData != remoteData.GetData() {
+		// Compare using GetComparableData() to exclude fields not stored by server
+		if !cmp.Equal(currentData.GetComparableData(), remoteData.GetComparableData()) {
 			updateData = currentData
 		}
 	}
@@ -232,7 +233,9 @@ func compareListData[T ComparableData](entry commitDef, currentData, remoteData 
 
 	for _, remoteItem := range remoteData {
 		if currentItem, exists := currentMap[remoteItem.GetKey()]; exists {
-			if !cmp.Equal(currentItem, remoteItem.GetData()) {
+			// Compare using GetComparableData() to exclude fields not stored by server
+			if !cmp.Equal(currentItem.GetComparableData(), remoteItem.GetComparableData()) {
+				// Transmit using GetData() to include all raw data
 				scheduler.Rqueue.Patch(entry.URL+remoteItem.GetID()+"/", currentItem.GetData(), 80, time.Time{})
 			}
 			delete(currentMap, currentItem.GetKey())

--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -181,7 +181,8 @@ type commitData struct {
 type ComparableData interface {
 	GetID() string
 	GetKey() interface{}
-	GetData() ComparableData
+	GetData() ComparableData           // For transmission (includes all raw data)
+	GetComparableData() ComparableData // For comparison (excludes fields not stored by server)
 }
 
 func (s SystemData) GetID() string {
@@ -209,6 +210,10 @@ func (s SystemData) GetData() ComparableData {
 	}
 }
 
+func (s SystemData) GetComparableData() ComparableData {
+	return s.GetData()
+}
+
 func (o OSData) GetID() string {
 	return o.ID
 }
@@ -229,6 +234,10 @@ func (o OSData) GetData() ComparableData {
 	}
 }
 
+func (o OSData) GetComparableData() ComparableData {
+	return o.GetData()
+}
+
 func (t TimeData) GetID() string {
 	return t.ID
 }
@@ -243,6 +252,10 @@ func (t TimeData) GetData() ComparableData {
 		Timezone: t.Timezone,
 		Uptime:   t.Uptime,
 	}
+}
+
+func (t TimeData) GetComparableData() ComparableData {
+	return t.GetData()
 }
 
 func (u UserData) GetID() string {
@@ -265,6 +278,21 @@ func (u UserData) GetData() ComparableData {
 	}
 }
 
+// GetComparableData returns data for comparison, excluding fields not stored by server.
+// ValidShells is excluded because the server doesn't store it (system-wide, rarely changes).
+// ShadowExpireDate is included because the server stores it for real-time expiration checks.
+func (u UserData) GetComparableData() ComparableData {
+	return UserData{
+		Username:         u.Username,
+		UID:              u.UID,
+		GID:              u.GID,
+		Directory:        u.Directory,
+		Shell:            u.Shell,
+		ShadowExpireDate: u.ShadowExpireDate,
+		// ValidShells excluded - server doesn't store this field
+	}
+}
+
 func (g GroupData) GetID() string {
 	return g.ID
 }
@@ -278,6 +306,10 @@ func (g GroupData) GetData() ComparableData {
 		GID:       g.GID,
 		GroupName: g.GroupName,
 	}
+}
+
+func (g GroupData) GetComparableData() ComparableData {
+	return g.GetData()
 }
 
 func (i Interface) GetID() string {
@@ -299,6 +331,10 @@ func (i Interface) GetData() ComparableData {
 	}
 }
 
+func (i Interface) GetComparableData() ComparableData {
+	return i.GetData()
+}
+
 func (a Address) GetID() string {
 	return a.ID
 }
@@ -314,6 +350,10 @@ func (a Address) GetData() ComparableData {
 		InterfaceName: a.InterfaceName,
 		Mask:          a.Mask,
 	}
+}
+
+func (a Address) GetComparableData() ComparableData {
+	return a.GetData()
 }
 
 func (d Disk) GetID() string {
@@ -332,6 +372,10 @@ func (d Disk) GetData() ComparableData {
 	}
 }
 
+func (d Disk) GetComparableData() ComparableData {
+	return d.GetData()
+}
+
 func (p Partition) GetID() string {
 	return p.ID
 }
@@ -348,4 +392,8 @@ func (p Partition) GetData() ComparableData {
 		Fstype:      p.Fstype,
 		IsVirtual:   p.IsVirtual,
 	}
+}
+
+func (p Partition) GetComparableData() ComparableData {
+	return p.GetData()
 }


### PR DESCRIPTION
## Summary

- Backport sync comparison fix from `main` (commit `9bc6628`) to `release/v1.3.1`
- Add `GetComparableData()` method to `ComparableData` interface
- Exclude `ValidShells` from comparison (server doesn't store it)
- Keep `ShadowExpireDate` in comparison (server stores it)
- Prevent unnecessary PATCH requests caused by field mismatch during sync

## Problem

After implementing the `login_enabled` improvement (#171), all SystemUsers triggered PATCH requests on every sync, even when no actual data changed.

### Root Cause

| Field | Server Stores | Agent Sends | Previous Comparison |
|-------|---------------|-------------|---------------------|
| `shadow_expire_date` | Yes | Yes | Compared |
| `valid_shells` | No | Yes | **Compared (bug)** |

Since `valid_shells` was included in comparison but not stored by server, every sync detected a false difference.

## Solution

Separate comparison logic from transmission logic:

- `GetData()`: For transmission - includes all raw data (unchanged)
- `GetComparableData()`: For comparison - excludes fields not stored by server

```go
// UserData.GetComparableData() - excludes ValidShells
func (u UserData) GetComparableData() ComparableData {
    return UserData{
        Username:         u.Username,
        UID:              u.UID,
        GID:              u.GID,
        Directory:        u.Directory,
        Shell:            u.Shell,
        ShadowExpireDate: u.ShadowExpireDate,  // Included (server stores it)
        // ValidShells excluded (server doesn't store it)
    }
}
```

## Changes

### `pkg/runner/commit_types.go`
- Add `GetComparableData()` to `ComparableData` interface
- Implement `GetComparableData()` for `UserData` (excludes `ValidShells`)
- Implement `GetComparableData()` for other types (returns `GetData()`)

### `pkg/runner/commit.go`
- Update `compareListData()` to use `GetComparableData()` for comparison
- Update `compareData()` to use `GetComparableData()` for comparison
- Keep using `GetData()` for transmission (POST/PATCH)

### `pkg/runner/commit_test.go`
- Add `TestUserDataGetComparableData()`
- Add `TestCompareUserDataNoUnnecessaryPatch()`
- Add `TestCompareUserDataDetectRealChanges()`
- Add `TestOtherTypesGetComparableData()`

## Test Plan

- [x] `go vet ./...` passes
- [x] `gofmt -l .` shows no formatting issues
- [x] `go test -v ./pkg/runner/...` passes
- [x] `go build ./...` succeeds
- [ ] Manual test: verify no unnecessary PATCH requests during sync
- [ ] Manual test: verify real changes still trigger PATCH requests

## Comparison Example

### Before (Bug)
```
Current:  {Username: "test", Shell: "/bin/bash", ValidShells: ["/bin/bash"]}
Remote:   {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Result:   NOT EQUAL -> Unnecessary PATCH
```

### After (Fixed)
```
Current.GetComparableData():  {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Remote.GetComparableData():   {Username: "test", Shell: "/bin/bash", ValidShells: nil}
Result:   EQUAL -> No PATCH
```

## Related Issues

- Closes #177 - Backport: Sync Comparison Fix to release/v1.3.1
- #176 - fix(sync): prevent unnecessary PATCH requests during sync comparison (main)
- #171 - Backport: login_enabled raw data collection to v1.3.1
