### PR TITLE
Resolve "Add flag to temporarily disable sudo PAM functionality"

### DIFF
--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -110,8 +110,10 @@ func (pc *PtyClient) initializePtySession() error {
 		Requests:  make(map[string]*SudoRequest),
 	}
 
-	authManager.AddPIDSessionMapping(pid, sessionInfo)
-	log.Debug().Msgf("PID mapping added: %d -> Session: %s", pid, pc.sessionID)
+	if authManager != nil {
+		authManager.AddPIDSessionMapping(pid, sessionInfo)
+		log.Debug().Msgf("PID mapping added: %d -> Session: %s", pid, pc.sessionID)
+	}
 
 	return nil
 }
@@ -271,7 +273,9 @@ func (pc *PtyClient) resize(rows, cols uint16) error {
 func (pc *PtyClient) close() {
 	// Remove PID-to-session mapping before cleaning up
 	if pc.cmd != nil && pc.cmd.Process != nil {
-		authManager.RemovePIDSessionMapping(pc.cmd.Process.Pid)
+		if authManager != nil {
+			authManager.RemovePIDSessionMapping(pc.cmd.Process.Pid)
+		}
 	}
 
 	if pc.ptmx != nil {


### PR DESCRIPTION
Add nil check before calling authManager methods in PTY session to prevent panic when Sudo PAM is
disabled.

Problem:
- When Sudo PAM is disabled (IsSudoPAMDisabled() == true), GetAuthManager() is not called, leaving authManager as nil
- PTY session calls authManager.AddPIDSessionMapping() and authManager.RemovePIDSessionMapping() without nil check
- This causes nil pointer dereference panic on openpty command

Solution:
- Add nil check before authManager.AddPIDSessionMapping() in initializePtySession()
- Add nil check before authManager.RemovePIDSessionMapping() in close()