### PR TITLE
feat(ftp): add symbolic link support in list command

### DIFF
--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -79,6 +79,7 @@ type CommandResult struct {
 	PermissionOctal  string          `json:"permission_octal,omitempty"`
 	Owner            string          `json:"owner,omitempty"`
 	Group            string          `json:"group,omitempty"`
+	Target           string          `json:"target,omitempty"` // Symlink target path
 }
 
 type returnCode struct {


### PR DESCRIPTION
## Summary
- Add symbolic link support to FTP list command
- Return symlink target path in the response
- Symlinks are now listed with `type: "symlink"` and include `target` field

## Changes
- `ftp_types.go`: Add `Target` field to `CommandResult` struct
- `ftp.go`: Handle symlinks in `getDiretoryStructure()` instead of skipping them

## Notes
- No recursive traversal into symlink targets (prevents circular reference issues)
- Safe for all depth values including depth=1

## Test plan
- [x] Verify symlinks appear in list response with correct type
- [x] Verify target path is correctly resolved
- [x] Verify no infinite loop with circular symlinks