### PR TITLE
feat(runner): send sudo approval requests via REST API

### DIFF
--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	name   = "alpamon"
-	wsPath = "/ws/servers/backhaul/"
+	name          = "alpamon"
+	wsPath        = "/ws/servers/backhaul/"
+	controlWsPath = "/ws/servers/control/"
 )
 
 var RootCmd = &cobra.Command{
@@ -74,7 +75,7 @@ func runAgent() {
 	log.Info().Msgf("Starting alpamon... (version: %s)", version.Version)
 
 	// Config & Settings
-	settings := config.LoadConfig(config.Files(name), wsPath)
+	settings := config.LoadConfig(config.Files(name), wsPath, controlWsPath)
 	config.InitSettings(settings)
 
 	// Create global worker pool for the entire application using config settings

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -138,7 +138,7 @@ func runAgent() {
 	go controlClient.RunForever(ctx)
 
 	// Auth Manager for sudo approval workflow
-	authManager := runner.GetAuthManager(controlClient)
+	authManager := runner.GetAuthManager(controlClient, session)
 	go authManager.Start(ctx)
 
 	for {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,7 +8,7 @@ import (
 func TestPoolConfigDefaults(t *testing.T) {
 	// Test that default pool values are set correctly when not configured
 	config := Config{}
-	_, settings := validateConfig(config, "/ws/test/")
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
 
 	if settings.PoolMaxWorkers != DefaultPoolMaxWorkers {
 		t.Errorf("Expected default PoolMaxWorkers to be %d, got %d", DefaultPoolMaxWorkers, settings.PoolMaxWorkers)
@@ -29,7 +29,7 @@ func TestPoolConfigCustomValues(t *testing.T) {
 	config.Pool.MaxWorkers = 50
 	config.Pool.QueueSize = 500
 
-	_, settings := validateConfig(config, "/ws/test/")
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
 
 	if settings.PoolMaxWorkers != 50 {
 		t.Errorf("Expected PoolMaxWorkers to be 50, got %d", settings.PoolMaxWorkers)
@@ -66,7 +66,7 @@ queue_size = 300
 	}
 
 	// Load the config
-	settings := LoadConfig([]string{tmpfile.Name()}, "/ws/test/")
+	settings := LoadConfig([]string{tmpfile.Name()}, "/ws/test/", "/ws/control/")
 
 	if settings.PoolMaxWorkers != 30 {
 		t.Errorf("Expected PoolMaxWorkers to be 30 from INI, got %d", settings.PoolMaxWorkers)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -3,6 +3,7 @@ package config
 type Settings struct {
 	ServerURL          string
 	WSPath             string
+	ControlWSPath      string
 	UseSSL             bool
 	CaCert             string // CA certificate file path
 	SSLVerify          bool

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/cenkalti/backoff"
 	"github.com/rs/zerolog/log"
@@ -223,7 +222,7 @@ func (am *AuthManager) createSendOperation(ctx context.Context, req SudoApproval
 				return fmt.Errorf("HTTP session not available")
 			}
 
-			url := fmt.Sprintf("/api/servers/servers/%s/sudo-approval/", config.GlobalSettings.ID)
+			url := fmt.Sprintf("/api/websh/sessions/%s/sudo-approval/", req.SessionID)
 			_, statusCode, err := am.session.Post(url, req, 10)
 			if err != nil {
 				nextInterval := retryBackoff.NextBackOff()

--- a/pkg/runner/control_client.go
+++ b/pkg/runner/control_client.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	controlWSPath             = "/ws/servers/control/"
 	controlMinConnectInterval = 5 * time.Second
 	controlMaxConnectInterval = 60 * time.Second
 	controlReadTimeout        = 35 * time.Minute
@@ -46,18 +45,7 @@ func NewControlClient() *ControlClient {
 
 // GetWSPath returns the WebSocket URL for control endpoint
 func (cc *ControlClient) GetWSPath() string {
-	// Build control WebSocket path from server URL
-	serverURL := config.GlobalSettings.ServerURL
-	wsURL := serverURL
-	if len(wsURL) > 0 {
-		// Replace http with ws
-		if wsURL[0:5] == "https" {
-			wsURL = "wss" + wsURL[5:]
-		} else if wsURL[0:4] == "http" {
-			wsURL = "ws" + wsURL[4:]
-		}
-	}
-	return wsURL + controlWSPath
+	return config.GlobalSettings.ControlWSPath
 }
 
 // RunForever maintains the control WebSocket connection and handles messages


### PR DESCRIPTION
## Summary
- Change sudo approval requests from WebSocket to REST API
- Update control message parsing logic for wrapped message format

## Changes
- `pkg/runner/auth_manager.go`:
  - Add HTTP session for REST API requests
  - Change `createSendOperation()` to use REST API instead of WebSocket
  - Endpoint: `POST /api/servers/servers/{id}/sudo-approval/`
- `pkg/runner/control_client.go`:
  - Add `ControlMessage` struct for wrapped message format
  - Update `HandleMessage()` to parse `{"query": "control", "data": {...}}` structure

## Message Flow
```
alpamon ──REST API──> alpacon-server
alpamon <──WebSocket── Go backhaul <──Redis control stream── alpacon-server
```

## Test plan
- [ ] Test sudo approval request via REST API
- [ ] Test control WebSocket response reception
- [ ] E2E sudo approval flow test