### PR TITLE
fix: use transaction for DiskIO cleanup query

### DIFF
--- a/pkg/collector/check/batch/daily/cleanup/cleanup.go
+++ b/pkg/collector/check/batch/daily/cleanup/cleanup.go
@@ -198,7 +198,7 @@ func deleteAllDiskIO(ctx context.Context, client *ent.Client, now time.Time) err
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = client.DiskIO.Delete().
+	_, err = tx.DiskIO.Delete().
 		Where(diskio.TimestampLTE(now.Add(-1 * time.Hour))).Exec(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Overview
`deleteAllDiskIO` creates a transaction but executes the DELETE query on `client` instead of `tx`, bypassing the transaction.

## Changes
- `client.DiskIO.Delete()` → `tx.DiskIO.Delete()`

Closes #197