### PR TITLE
fix(auth): fix timeout overflow in sudo approval request

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -223,7 +223,7 @@ func (am *AuthManager) createSendOperation(ctx context.Context, req SudoApproval
 			}
 
 			url := fmt.Sprintf("/api/websh/sessions/%s/sudo-approval/", req.SessionID)
-			_, statusCode, err := am.session.Post(url, req, 10*time.Second)
+			_, statusCode, err := am.session.Post(url, req, 10)
 			if err != nil {
 				log.Warn().Err(err).Msg("Failed to send sudo request via REST API, will retry")
 				return err


### PR DESCRIPTION
## Summary

Fixes the "context deadline exceeded" error that occurred immediately when sending sudo approval requests. The bug was caused by passing `10*time.Second` to `Post()` while `session.do()` multiplies the timeout by `time.Second` again, causing int64 overflow.

## Changes

- Changed `am.session.Post(url, req, 10*time.Second)` to `am.session.Post(url, req, 10)` to match other API calls in the codebase

## Root Cause

```go
// auth_manager.go:226 - was passing time.Duration
am.session.Post(url, req, 10*time.Second)  // 10,000,000,000 ns

// session.go:112 - multiplies by time.Second again
ctx, cancel := context.WithTimeout(req.Context(), timeout*time.Second)
// Result: 10,000,000,000 * 1,000,000,000 = OVERFLOW!
// → Negative value → Immediate deadline exceeded
```

## Testing

- [x] Verified sudo approval request now works correctly in deployed environment
- [x] Other API calls using the same pattern (integer timeout) work correctly

## Backport

After merge, needs backport to `release/v1.3.1`

---
Generated with AlpacaX Claude Plugin