### PR TITLE
[Backport] fix(auth): fix timeout overflow in sudo approval request

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -223,7 +223,7 @@ func (am *AuthManager) createSendOperation(ctx context.Context, req SudoApproval
 			}
 
 			url := fmt.Sprintf("/api/websh/sessions/%s/sudo-approval/", req.SessionID)
-			_, statusCode, err := am.session.Post(url, req, 10*time.Second)
+			_, statusCode, err := am.session.Post(url, req, 10)
 			if err != nil {
 				log.Warn().Err(err).Msg("Failed to send sudo request via REST API, will retry")
 				return err


### PR DESCRIPTION
## Summary

Backport of #201 to `release/v1.3.1`

Fixes the "context deadline exceeded" error that occurred immediately when sending sudo approval requests.

## Changes

- Changed `am.session.Post(url, req, 10*time.Second)` to `am.session.Post(url, req, 10)`

## Root Cause

The `Post()` call was passing `10*time.Second` (time.Duration) but `session.do()` multiplies the timeout by `time.Second` again, causing int64 overflow and immediate context deadline exceeded error.

---
Generated with AlpacaX Claude Plugin