### PR TITLE
fix: use dependency-resolving package managers in smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,11 @@ jobs:
           - pkg_type: deb
             container: ubuntu:24.04
             arch: amd64
-            install_cmd: dpkg -i
+            install_cmd: apt-get install -y
           - pkg_type: rpm
             container: rockylinux:9
             arch: amd64
-            install_cmd: rpm -i
+            install_cmd: dnf install -y
     container: ${{ matrix.container }}
     steps:
       - name: Set package name
@@ -124,8 +124,12 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}
 
+      - name: Update package index (DEB only)
+        if: matrix.pkg_type == 'deb'
+        run: apt-get update
+
       - name: Install package
-        run: ${{ matrix.install_cmd }} ${{ env.PKG_NAME }}
+        run: ${{ matrix.install_cmd }} ./${{ env.PKG_NAME }}
 
       - name: Smoke test
         run: alpamon --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
       - name: Update package index (DEB only)
         if: matrix.pkg_type == 'deb'
         run: apt-get update
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       - name: Install package
         run: ${{ matrix.install_cmd }} ./${{ env.PKG_NAME }}


### PR DESCRIPTION
## Body

### Summary

- Replace `dpkg -i` / `rpm -i` with `apt-get install -y` / `dnf install -y` to auto-resolve package dependencies in smoke test
- Add `apt-get update` step for DEB containers to refresh package index before installation
- Add `./` prefix to package path so `apt-get install` recognizes local `.deb` files

### Problem

The `package-smoke-test` job fails on v2.0.0-beta.1 release because `dpkg -i` and `rpm -i` are low-level tools that do not resolve dependencies automatically. The bare containers (`ubuntu:24.04`, `rockylinux:9`) lack required packages (`zip`, `sqlite3`/`sqlite`, `nftables`/`iptables`), causing installation to fail.

### Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | `dpkg -i` -> `apt-get install -y` |
| `.github/workflows/release.yml` | `rpm -i` -> `dnf install -y` |
| `.github/workflows/release.yml` | Add `apt-get update` step (DEB only) |
| `.github/workflows/release.yml` | Add `./` prefix to package file path |

### Test plan

- [ ] Trigger release workflow and verify `package-smoke-test` job passes for both DEB and RPM matrix entries
- [ ] Verify `alpamon --help` smoke test succeeds after package installation

Closes #207
