### PR TITLE
fix(ci): install systemd in DEB smoke test container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,9 +124,9 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}
 
-      - name: Update package index (DEB only)
+      - name: Install prerequisites (DEB only)
         if: matrix.pkg_type == 'deb'
-        run: apt-get update
+        run: apt-get update && apt-get install -y systemd
         env:
           DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
### Summary

- Install `systemd` as a prerequisite in the DEB smoke test container to prevent `postinstall.sh` failure
- Rename step from `Update package index` to `Install prerequisites` to reflect the expanded scope

### Problem

After applying the dependency resolution fix (`apt-get install -y` / `dnf install -y`), the DEB `package-smoke-test` job still fails because `ubuntu:24.04` minimal container does not include systemd.

The `postinstall.sh` script calls `check_systemd_status()` which hard-fails (`exit 1`) when `systemctl` is not found:

```
Setting up alpamon (2.0.0~beta.2) ...
Error: systemctl is required but could not be found.
dpkg: error processing package alpamon (--configure):
 installed alpamon package post-installation script subprocess returned error exit status 1
```

The RPM job (`rockylinux:9`) is not affected because RHEL-based minimal images include systemd by default.

### Why not modify postinstall.sh?

alpamon is a systemd-based daemon. The hard fail on missing systemd is intentional — if a production server lacks systemd, the installation should fail loudly. The smoke test should match production conditions, so the fix belongs in the test environment, not in the production script.

### Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Install `systemd` alongside `apt-get update` in DEB prerequisite step |

### Test plan

- [ ] Trigger release workflow and verify `package-smoke-test` job passes for both DEB and RPM matrix entries
- [ ] Verify `alpamon --help` smoke test succeeds after package installation

Closes #207
