### PR TITLE
docs: fix incorrect PAM installation guidance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sudo yum install alpamon
 
 ### PAM Module
 
-The optional `alpamon-pam` package provides PAM (Pluggable Authentication Modules) integration for Alpacon-managed authentication:
+The optional `alpamon-pam` package provides PAM (Pluggable Authentication Modules) integration for Alpacon-managed sudo authentication:
 - **pam_alpamon.so**: Verifies Alpacon users during sudo authentication
 - **alpacon_approval.so**: Handles sudo command approval requests
 

--- a/README.md
+++ b/README.md
@@ -27,32 +27,40 @@ Download the latest `alpamon` directly from our releases page or install it usin
 #### Debian and Ubuntu
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.deb.sh?any=true | sudo bash
-
-# Install alpamon (includes PAM module by default)
 sudo apt-get install alpamon
-
-# Install without PAM module
-sudo apt-get install alpamon --no-install-recommends
 ```
 
 #### CentOS and RHEL
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.rpm.sh?any=true | sudo bash
-
-# Install alpamon (includes PAM module by default)
 sudo yum install alpamon
-
-# Install without PAM module
-sudo yum install alpamon --setopt=install_weak_deps=False
 ```
+
+> [!TIP]
+> To use Alpacon-managed sudo authentication, install the optional PAM module:
+> `sudo apt-get install alpamon-pam` (Debian/Ubuntu) or `sudo yum install alpamon-pam` (CentOS/RHEL).
+> See [PAM Module](#pam-module) for details.
 
 ### PAM Module
 
-By default, `alpamon` installation includes the `alpamon-pam` package, which provides PAM (Pluggable Authentication Modules) integration for advanced authentication features:
+The optional `alpamon-pam` package provides PAM (Pluggable Authentication Modules) integration for Alpacon-managed authentication:
 - **pam_alpamon.so**: Verifies Alpacon users during sudo authentication
 - **alpacon_approval.so**: Handles sudo command approval requests
 
+#### Installing the PAM module
+
+The PAM module is packaged separately and must be installed explicitly:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install alpamon-pam
+
+# CentOS / RHEL
+sudo yum install alpamon-pam
+```
+
 #### Configuration
+
 After installation, configure PAM and sudo to enable the authentication features:
 
 1. Add to `/etc/pam.d/sudo`:


### PR DESCRIPTION
### Summary

- Remove factually incorrect claim that `alpamon-pam` is included by default
- Remove irrelevant `--no-install-recommends` / `--setopt=install_weak_deps=False` flags
- Clarify that `alpamon-pam` is an optional, separately-installed package
- Add `> [!TIP]` callout and explicit install commands for the PAM module

### Problem

The README states "includes PAM module by default", but `.goreleaser.yaml` declares `alpamon-pam` as a `suggests` dependency — not `recommends`. In both Debian and RPM packaging, `suggests` packages are **not installed by default**.

The README also suggests using `--no-install-recommends` (Debian) and `--setopt=install_weak_deps=False` (RPM) to skip PAM installation. These flags only affect `recommends`-level dependencies, not `suggests`, so they have no effect on `alpamon-pam`.

```yaml
# .goreleaser.yaml (lines 73-82)
suggests:     # NOT recommends
  - alpamon-pam
```

### Changes

| File | Change |
|---|---|
| `README.md` (Installation section) | Remove incorrect "includes PAM module by default" comments and unnecessary `--no-install-recommends` / `--setopt=install_weak_deps=False` examples. Add `> [!TIP]` callout for optional PAM installation. |
| `README.md` (PAM Module section) | Rewrite intro to clarify PAM is optional. Add "Installing the PAM module" subsection with explicit install commands. |

### Test plan

- [ ] Verify `> [!TIP]` callout renders correctly on GitHub
- [ ] Verify `[PAM Module](#pam-module)` anchor link works
- [ ] Confirm no other documentation references the removed "includes PAM module by default" wording
