### PR TITLE
feat(register): add --tag option for server tags

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -28,12 +28,14 @@ var (
 	platform   string
 	sslVerify  bool
 	caCert     string
+	tags       map[string]string
 )
 
 // RegisterRequest represents the request body for server registration
 type RegisterRequest struct {
-	Name     string `json:"name"`
-	Platform string `json:"platform"`
+	Name     string            `json:"name"`
+	Platform string            `json:"platform"`
+	Tags     map[string]string `json:"tags,omitempty"`
 }
 
 // RegisterResponse represents the response from server registration
@@ -54,6 +56,7 @@ Groups are automatically assigned from the token's allowed_groups configuration.
 Examples:
   sudo alpamon register --url https://alpacon.example.com --token <TOKEN>
   sudo alpamon register --url https://alpacon.example.com --token <TOKEN> --name my-server
+  sudo alpamon register --url https://alpacon.example.com --token <TOKEN> --tag env=prod --tag role=web
 
 Options:
   --url         Alpacon server URL (required)
@@ -61,7 +64,8 @@ Options:
   --name        Server name (optional, defaults to hostname)
   --platform    Platform (debian/rhel, auto-detect if omitted)
   --ssl-verify  SSL certificate verification (default: true)
-  --ca-cert     CA certificate path`,
+  --ca-cert     CA certificate path
+  --tag         Server tags in key=value format (repeatable)`,
 	RunE: runRegister,
 }
 
@@ -72,6 +76,7 @@ func init() {
 	RegisterCmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel, auto-detect)")
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
+	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (can be specified multiple times)")
 
 	_ = RegisterCmd.MarkFlagRequired("url")
 	_ = RegisterCmd.MarkFlagRequired("token")
@@ -103,6 +108,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	reqBody := RegisterRequest{
 		Name:     serverName,
 		Platform: platform,
+		Tags:     tags,
 	}
 
 	fmt.Printf("Registering server: %s\n", serverURL)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -76,7 +76,7 @@ func init() {
 	RegisterCmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel, auto-detect)")
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
-	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (can be specified multiple times)")
+	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
 
 	_ = RegisterCmd.MarkFlagRequired("url")
 	_ = RegisterCmd.MarkFlagRequired("token")

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -65,7 +65,7 @@ Options:
   --platform    Platform (debian/rhel, auto-detect if omitted)
   --ssl-verify  SSL certificate verification (default: true)
   --ca-cert     CA certificate path
-  --tag         Server tags in key=value format (repeatable)`,
+  --tag         Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")`,
 	RunE: runRegister,
 }
 

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -93,14 +93,16 @@ func TestSendRegisterRequest_WithTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var receivedBody RegisterRequest
+			bodyCh := make(chan RegisterRequest, 1)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				assert.Contains(t, r.Header.Get("Authorization"), "token=")
 
-				err := json.NewDecoder(r.Body).Decode(&receivedBody)
+				var body RegisterRequest
+				err := json.NewDecoder(r.Body).Decode(&body)
 				require.NoError(t, err)
+				bodyCh <- body
 
 				w.WriteHeader(http.StatusCreated)
 				resp := RegisterResponse{
@@ -127,6 +129,7 @@ func TestSendRegisterRequest_WithTags(t *testing.T) {
 			assert.Equal(t, "test-id", resp.ID)
 			assert.Equal(t, "test-key", resp.Key)
 
+			receivedBody := <-bodyCh
 			if tt.expectTags {
 				assert.Equal(t, tt.tags, receivedBody.Tags)
 			} else {

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -1,0 +1,202 @@
+package register
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterRequest_TagsSerialization(t *testing.T) {
+	tests := []struct {
+		name             string
+		tags             map[string]string
+		expectTagsInJSON bool
+		expectedTags     map[string]string
+	}{
+		{
+			name:             "nil tags omitted from JSON",
+			tags:             nil,
+			expectTagsInJSON: false,
+		},
+		{
+			name:             "single tag",
+			tags:             map[string]string{"env": "prod"},
+			expectTagsInJSON: true,
+			expectedTags:     map[string]string{"env": "prod"},
+		},
+		{
+			name:             "multiple tags",
+			tags:             map[string]string{"env": "prod", "role": "web", "team": "platform"},
+			expectTagsInJSON: true,
+			expectedTags:     map[string]string{"env": "prod", "role": "web", "team": "platform"},
+		},
+		{
+			name:             "tag with empty value",
+			tags:             map[string]string{"env": ""},
+			expectTagsInJSON: true,
+			expectedTags:     map[string]string{"env": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := RegisterRequest{
+				Name:     "test-server",
+				Platform: "debian",
+				Tags:     tt.tags,
+			}
+
+			data, err := json.Marshal(req)
+			require.NoError(t, err)
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(data, &raw)
+			require.NoError(t, err)
+
+			if tt.expectTagsInJSON {
+				assert.Contains(t, raw, "tags")
+
+				var parsedTags map[string]string
+				err = json.Unmarshal(raw["tags"], &parsedTags)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTags, parsedTags)
+			} else {
+				_, hasTags := raw["tags"]
+				assert.False(t, hasTags, "JSON should not contain 'tags' field")
+			}
+		})
+	}
+}
+
+func TestSendRegisterRequest_WithTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		tags       map[string]string
+		expectTags bool
+	}{
+		{
+			name:       "request with tags",
+			tags:       map[string]string{"env": "prod", "role": "web"},
+			expectTags: true,
+		},
+		{
+			name:       "request without tags",
+			tags:       nil,
+			expectTags: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedBody RegisterRequest
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Contains(t, r.Header.Get("Authorization"), "token=")
+
+				err := json.NewDecoder(r.Body).Decode(&receivedBody)
+				require.NoError(t, err)
+
+				w.WriteHeader(http.StatusCreated)
+				resp := RegisterResponse{
+					ID:   "test-id",
+					Key:  "test-key",
+					Name: "test-server",
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			serverURL = server.URL
+			apiToken = "test-token"
+			sslVerify = true
+
+			req := RegisterRequest{
+				Name:     "test-server",
+				Platform: "debian",
+				Tags:     tt.tags,
+			}
+
+			resp, err := sendRegisterRequest(req)
+			require.NoError(t, err)
+			assert.Equal(t, "test-id", resp.ID)
+			assert.Equal(t, "test-key", resp.Key)
+
+			if tt.expectTags {
+				assert.Equal(t, tt.tags, receivedBody.Tags)
+			} else {
+				assert.Nil(t, receivedBody.Tags)
+			}
+		})
+	}
+}
+
+func TestSendRegisterRequest_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error": "invalid request"}`))
+	}))
+	defer server.Close()
+
+	serverURL = server.URL
+	apiToken = "test-token"
+	sslVerify = true
+
+	req := RegisterRequest{
+		Name:     "test-server",
+		Platform: "debian",
+		Tags:     map[string]string{"env": "prod"},
+	}
+
+	resp, err := sendRegisterRequest(req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "registration failed (status 400)")
+}
+
+func TestTagFlagParsing(t *testing.T) {
+	tests := []struct {
+		name         string
+		flagArgs     []string
+		expectedTags map[string]string
+	}{
+		{
+			name:         "single tag",
+			flagArgs:     []string{"--tag", "env=prod"},
+			expectedTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:         "multiple tags",
+			flagArgs:     []string{"--tag", "env=prod", "--tag", "role=web"},
+			expectedTags: map[string]string{"env": "prod", "role": "web"},
+		},
+		{
+			name:         "no tags",
+			flagArgs:     []string{},
+			expectedTags: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parsedTags map[string]string
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			fs.StringToStringVar(&parsedTags, "tag", nil, "Server tags")
+
+			err := fs.Parse(tt.flagArgs)
+			require.NoError(t, err)
+
+			if tt.expectedTags == nil {
+				assert.Nil(t, parsedTags)
+			} else {
+				assert.Equal(t, tt.expectedTags, parsedTags)
+			}
+		})
+	}
+}

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -101,7 +101,7 @@ func TestSendRegisterRequest_WithTags(t *testing.T) {
 
 				var body RegisterRequest
 				err := json.NewDecoder(r.Body).Decode(&body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				bodyCh <- body
 
 				w.WriteHeader(http.StatusCreated)
@@ -176,6 +176,11 @@ func TestTagFlagParsing(t *testing.T) {
 		{
 			name:         "multiple tags",
 			flagArgs:     []string{"--tag", "env=prod", "--tag", "role=web"},
+			expectedTags: map[string]string{"env": "prod", "role": "web"},
+		},
+		{
+			name:         "comma-separated tags",
+			flagArgs:     []string{"--tag", "env=prod,role=web"},
 			expectedTags: map[string]string{"env": "prod", "role": "web"},
 		},
 		{

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -114,6 +114,13 @@ func TestSendRegisterRequest_WithTags(t *testing.T) {
 			}))
 			defer server.Close()
 
+			oldServerURL, oldAPIToken, oldSSLVerify := serverURL, apiToken, sslVerify
+			t.Cleanup(func() {
+				serverURL = oldServerURL
+				apiToken = oldAPIToken
+				sslVerify = oldSSLVerify
+			})
+
 			serverURL = server.URL
 			apiToken = "test-token"
 			sslVerify = true
@@ -145,6 +152,13 @@ func TestSendRegisterRequest_ServerError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error": "invalid request"}`))
 	}))
 	defer server.Close()
+
+	oldServerURL, oldAPIToken, oldSSLVerify := serverURL, apiToken, sslVerify
+	t.Cleanup(func() {
+		serverURL = oldServerURL
+		apiToken = oldAPIToken
+		sslVerify = oldSSLVerify
+	})
 
 	serverURL = server.URL
 	apiToken = "test-token"


### PR DESCRIPTION
## Summary

- Add `--tag key=value` flag to `alpamon register` command for assigning tags at registration time
- Tags are included in the POST `/api/servers/servers/register/` request body
- Backward compatible: omitting `--tag` produces the same request as before

## Changes

### `cmd/alpamon/command/register/register.go`
- Add `tags map[string]string` package-level variable
- Add `Tags` field to `RegisterRequest` with `json:"tags,omitempty"`
- Register `--tag` flag via cobra's `StringToStringVar`
- Include `Tags` in registration request body
- Update command help text with `--tag` usage and examples

### `cmd/alpamon/command/register/register_test.go` (new)
- `TestRegisterRequest_TagsSerialization` — JSON marshaling with nil/single/multiple tags
- `TestSendRegisterRequest_WithTags` — HTTP request body verification via httptest
- `TestSendRegisterRequest_ServerError` — Error handling for non-201 responses
- `TestTagFlagParsing` — Flag parsing for single, multiple, and no tags

## Usage

```bash
# Single tag
sudo alpamon register \
  --url https://alpacon.example.com \
  --token "alpat-xxxxxxxxxxxx" \
  --tag env=production

# Multiple tags (repeatable)
sudo alpamon register \
  --url https://alpacon.example.com \
  --token "alpat-xxxxxxxxxxxx" \
  --tag env=production \
  --tag role=web \
  --tag team=platform

# Multiple tags (comma-separated)
sudo alpamon register \
  --url https://alpacon.example.com \
  --token "alpat-xxxxxxxxxxxx" \
  --tag "env=production,role=web,team=platform"
```

## Test plan

- [x] `--tag` option parsing works correctly
- [x] Multiple tags can be specified
- [x] Registration without tags still works as before (backward compatible)
- [x] Invalid tag format produces a clear error message (handled by pflag)
- [x] All tests pass: `go test -v ./cmd/alpamon/command/register/ -p 1`
- [x] Build succeeds: `go build -v ./cmd/alpamon/...`

## Related

- Closes #214
