### PR TITLE
feat: upgrade alpamon-pam alongside alpamon

### DIFF
--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -84,9 +84,9 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	var cmd string
 	switch utils.PlatformLike {
 	case "debian":
-		cmd = "apt-get update -y && apt-get install --only-upgrade alpamon -y"
+		cmd = "apt-get update -y && apt-get install --only-upgrade alpamon alpamon-pam -y"
 	case "rhel":
-		cmd = "yum update -y alpamon"
+		cmd = "yum update -y alpamon alpamon-pam"
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
 	}


### PR DESCRIPTION
## Summary
When alpamon receives an upgrade command, it now also upgrades `alpamon-pam` if installed. This ensures both packages stay in sync without requiring separate manual upgrades.

## Changes
- Modified `handleUpgrade()` in `system.go` to include `alpamon-pam` in both Debian (`apt-get install --only-upgrade`) and RHEL (`yum update`) upgrade commands
- `--only-upgrade` (apt) safely skips `alpamon-pam` if not installed
- `yum update` also ignores non-installed packages

## Testing
- [x] Build passes (`go build ./...`)
- [x] Existing upgrade tests pass
- [ ] Manual testing on Debian/Ubuntu with alpamon-pam installed
- [ ] Manual testing on Debian/Ubuntu without alpamon-pam installed
- [ ] Manual testing on RHEL-based system