### PR TITLE
feat: add pam version reporting and dedicated access policy endpoint

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -218,7 +218,7 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 func syncAccessPolicy(session *scheduler.Session) {
 	resp, statusCode, err := session.Get(accessPolicyURL, 10)
 	if err != nil {
-		log.Debug().Err(err).Msg("Failed to fetch access policy")
+		log.Warn().Err(err).Msg("Failed to fetch access policy")
 		return
 	}
 	if statusCode == http.StatusNotFound {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -218,7 +218,11 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 func syncAccessPolicy(session *scheduler.Session) {
 	resp, statusCode, err := session.Get(accessPolicyURL, 10)
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to fetch access policy")
+		log.Debug().Err(err).Msg("Failed to fetch access policy")
+		return
+	}
+	if statusCode == http.StatusNotFound {
+		log.Debug().Msg("Access policy endpoint not available on this server")
 		return
 	}
 	if statusCode < 200 || statusCode >= 300 {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -30,7 +30,7 @@ const (
 	commitURL         = "/api/servers/servers/-/commit/"
 	eventURL          = "/api/events/events/"
 	firewallSyncURL   = "/api/firewall/agent/sync/"
-	accessPolicyURL = "/api/servers/servers/-/access-policy/"
+	accessPolicyURL   = "/api/servers/servers/-/access-policy/"
 
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -30,7 +30,7 @@ const (
 	commitURL         = "/api/servers/servers/-/commit/"
 	eventURL          = "/api/events/events/"
 	firewallSyncURL   = "/api/firewall/agent/sync/"
-	serverSettingsURL = "/api/servers/servers/-/"
+	accessPolicyURL = "/api/servers/servers/-/access-policy/"
 
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"
@@ -121,8 +121,9 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 				log.Debug().Err(err).Msg("Failed to retrieve load average.")
 			}
 			currentData = &ServerData{
-				Version: version.Version,
-				Load:    loadAvg,
+				Version:    version.Version,
+				PamVersion: utils.GetPamVersion(),
+				Load:       loadAvg,
 			}
 			scheduler.Rqueue.Patch(utils.JoinPath(entry.URL, entry.URLSuffix), currentData, 80, time.Time{})
 			continue
@@ -206,33 +207,33 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 			compareData(entry, currentData.(ComparableData), remoteData.(ComparableData))
 		}
 	}
-	// Sync server settings (e.g., block_local_sudo) only during full sync
+	// Sync access policy (e.g., block_local_sudo) only during full sync
 	if fullSync {
-		syncServerSettings(session)
+		syncAccessPolicy(session)
 	}
 
 	log.Info().Msg("Completed system information synchronization.")
 }
 
-func syncServerSettings(session *scheduler.Session) {
-	resp, statusCode, err := session.Get(serverSettingsURL, 10)
+func syncAccessPolicy(session *scheduler.Session) {
+	resp, statusCode, err := session.Get(accessPolicyURL, 10)
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to fetch server settings")
+		log.Warn().Err(err).Msg("Failed to fetch access policy")
 		return
 	}
 	if statusCode < 200 || statusCode >= 300 {
-		log.Warn().Int("status_code", statusCode).Msg("Failed to fetch server settings")
+		log.Warn().Int("status_code", statusCode).Msg("Failed to fetch access policy")
 		return
 	}
 
-	var serverSettings ServerSettings
-	if err := json.Unmarshal(resp, &serverSettings); err != nil {
-		log.Warn().Err(err).Msg("Failed to parse server settings")
+	var accessPolicy AccessPolicy
+	if err := json.Unmarshal(resp, &accessPolicy); err != nil {
+		log.Warn().Err(err).Msg("Failed to parse access policy")
 		return
 	}
 
 	if authManager != nil {
-		authManager.UpdateBlockLocalSudo(serverSettings.BlockLocalSudo)
+		authManager.UpdateBlockLocalSudo(accessPolicy.BlockLocalSudo)
 	}
 }
 
@@ -288,6 +289,7 @@ func collectData() *commitData {
 
 	var err error
 	data.Version = version.Version
+	data.PamVersion = utils.GetPamVersion()
 
 	if data.Load, err = getLoadAverage(); err != nil {
 		log.Debug().Err(err).Msg("Failed to retrieve load average.")

--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -65,8 +65,9 @@ var commitDefs = map[string]commitDef{
 }
 
 type ServerData struct {
-	Version string  `json:"version"`
-	Load    float64 `json:"load"`
+	Version    string  `json:"version"`
+	PamVersion string  `json:"pam_version,omitempty"`
+	Load       float64 `json:"load"`
 }
 
 type SystemData struct {
@@ -162,12 +163,13 @@ type shadowEntry struct {
 	expireDate *int64 // days since epoch, nil if not set
 }
 
-type ServerSettings struct {
+type AccessPolicy struct {
 	BlockLocalSudo bool `json:"block_local_sudo"`
 }
 
 type commitData struct {
 	Version    string      `json:"version"`
+	PamVersion string      `json:"pam_version,omitempty"`
 	Load       float64     `json:"load"`
 	Info       SystemData  `json:"info"`
 	OS         OSData      `json:"os"`

--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -1,20 +1,27 @@
 package utils
 
 import (
+	"context"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+const pamQueryTimeout = 3 * time.Second
 
 // GetPamVersion returns the installed alpamon-pam package version.
 // Returns empty string if the package is not installed.
 func GetPamVersion() string {
+	ctx, cancel := context.WithTimeout(context.Background(), pamQueryTimeout)
+	defer cancel()
+
 	// Try dpkg first (Debian/Ubuntu)
-	out, err := exec.Command("dpkg-query", "-W", "-f=${Version}", "alpamon-pam").Output()
+	out, err := exec.CommandContext(ctx, "dpkg-query", "-W", "-f=${Version}", "alpamon-pam").Output()
 	if err == nil {
 		return strings.TrimSpace(string(out))
 	}
 	// Try rpm (RHEL/CentOS)
-	out, err = exec.Command("rpm", "-q", "--queryformat", "%{VERSION}", "alpamon-pam").Output()
+	out, err = exec.CommandContext(ctx, "rpm", "-q", "--queryformat", "%{VERSION}", "alpamon-pam").Output()
 	if err == nil {
 		return strings.TrimSpace(string(out))
 	}

--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// GetPamVersion returns the installed alpamon-pam package version.
+// Returns empty string if the package is not installed.
+func GetPamVersion() string {
+	// Try dpkg first (Debian/Ubuntu)
+	out, err := exec.Command("dpkg-query", "-W", "-f=${Version}", "alpamon-pam").Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	// Try rpm (RHEL/CentOS)
+	out, err = exec.Command("rpm", "-q", "--queryformat", "%{VERSION}", "alpamon-pam").Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	return ""
+}

--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -4,14 +4,38 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
-const pamQueryTimeout = 3 * time.Second
+const (
+	pamQueryTimeout = 3 * time.Second
+	pamCacheTTL     = 3 * time.Hour
+)
+
+var (
+	pamCache      string
+	pamCacheTime  time.Time
+	pamCacheMutex sync.Mutex
+)
 
 // GetPamVersion returns the installed alpamon-pam package version.
 // Returns empty string if the package is not installed.
+// Results are cached with a TTL to avoid spawning external processes on every sync.
 func GetPamVersion() string {
+	pamCacheMutex.Lock()
+	defer pamCacheMutex.Unlock()
+
+	if !pamCacheTime.IsZero() && time.Since(pamCacheTime) < pamCacheTTL {
+		return pamCache
+	}
+
+	pamCache = queryPamVersion()
+	pamCacheTime = time.Now()
+	return pamCache
+}
+
+func queryPamVersion() string {
 	ctx, cancel := context.WithTimeout(context.Background(), pamQueryTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## Summary
Add alpamon-pam version reporting to server sync/commit data, and introduce a dedicated access policy endpoint to fix the broken `block_local_sudo` setting delivery.

## Changes
- **pam version**: New `GetPamVersion()` utility that detects installed alpamon-pam version via dpkg/rpm. Included in both sync and commit data as `pam_version`.
- **access policy**: Rename `serverSettingsURL` → `accessPolicyURL`, `syncServerSettings()` → `syncAccessPolicy()`, `ServerSettings` → `AccessPolicy`. URL changed from `/api/servers/servers/-/` to `/api/servers/servers/-/access-policy/`.

## Context
The previous `serverSettingsURL` pointed to the default server detail endpoint (`ServerSerializer`), which does NOT include `block_local_sudo` in its response. This meant the setting always deserialized to `false` — it never worked. A dedicated `/access-policy/` endpoint on alpacon-server is needed to properly deliver workspace-level access control policies.

## Dependencies
- **alpacon-server**: Requires new `GET /api/servers/servers/-/access-policy/` endpoint with `AccessPolicySerializer` (separate PR)

## Testing
- [x] `go build` passes
- [x] `go test ./... -p 1` all tests pass
- [ ] Integration test with alpacon-server access-policy endpoint

## Checklist
- [x] No breaking changes to existing sync flow
- [x] `pam_version` uses `omitempty` for backward compatibility