### PR TITLE
fix(test): replace flaky port uniqueness assertion with range validation

### DIFF
--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -17,12 +17,10 @@ func TestFindAvailablePort(t *testing.T) {
 }
 
 func TestFindAvailablePortUnique(t *testing.T) {
-	ports := make(map[int]bool)
 	for i := 0; i < 10; i++ {
 		port, err := findAvailablePort()
 		assert.NoError(t, err, "Failed to find available port")
-		assert.False(t, ports[port], "Port should be unique across calls")
-		ports[port] = true
+		assert.True(t, port > 0 && port <= 65535, "Port should be in valid range")
 	}
 }
 

--- a/pkg/runner/editor_test.go
+++ b/pkg/runner/editor_test.go
@@ -16,7 +16,7 @@ func TestFindAvailablePort(t *testing.T) {
 	assert.True(t, port <= 65535, "Port should be less than or equal to 65535")
 }
 
-func TestFindAvailablePortUnique(t *testing.T) {
+func TestFindAvailablePortRepeated(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		port, err := findAvailablePort()
 		assert.NoError(t, err, "Failed to find available port")


### PR DESCRIPTION
## Summary

- Fix `TestFindAvailablePortUnique` flaky test that fails on RHEL-9 and Fedora-41 CI jobs
- Replace port uniqueness assertion with valid-range check (`0 < port <= 65535`)
- Root cause: `findAvailablePort()` closes the listener immediately, so the OS may reassign the same ephemeral port on consecutive calls — newer kernels (RHEL-9 5.14+, Fedora-41 6.x) recycle ports more aggressively

## Changes

| File | Change |
|------|--------|
| `pkg/runner/editor_test.go` | Replace `assert.False(ports[port])` with `assert.True(port > 0 && port <= 65535)` |

## Why

`findAvailablePort()` is only called once in production (`CodeServerManager.doStart`). The uniqueness assumption across 10 sequential calls was never a real requirement — it's an OS-level behavior that varies by kernel version and container environment.

## Test plan

- [x] `go test -v -run TestFindAvailablePort ./pkg/runner/` passes locally
- [ ] CI passes on all distros including rhel-9 and fedora-41

Closes #222