### PR TITLE
Add apt-get retry option for transient network failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,8 +102,8 @@ jobs:
       - name: Install dependencies (Debian/Ubuntu)
         if: matrix.pkg_manager == 'apt-get'
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git curl gcc libc6-dev ca-certificates
+          apt-get update -o Acquire::Retries=3
+          apt-get install -y -o Acquire::Retries=3 --no-install-recommends git curl gcc libc6-dev ca-certificates
 
       - name: Install dependencies (yum)
         if: matrix.pkg_manager == 'yum'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           - pkg_type: deb
             container: ubuntu:24.04
             arch: amd64
-            install_cmd: apt-get install -y
+            install_cmd: apt-get install -y -o Acquire::Retries=3
           - pkg_type: rpm
             container: rockylinux:9
             arch: amd64
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install prerequisites (DEB only)
         if: matrix.pkg_type == 'deb'
-        run: apt-get update && apt-get install -y systemd
+        run: apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 systemd
         env:
           DEBIAN_FRONTEND: noninteractive
 

--- a/Dockerfiles/debian/10/Dockerfile
+++ b/Dockerfiles/debian/10/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM debian:10
 
-RUN apt-get update && apt-get install -y --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/debian/11/Dockerfile
+++ b/Dockerfiles/debian/11/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM debian:11
 
-RUN apt-get update && apt-get install -y --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/18.04/Dockerfile
+++ b/Dockerfiles/ubuntu/18.04/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/20.04/Dockerfile
+++ b/Dockerfiles/ubuntu/20.04/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/22.04/Dockerfile
+++ b/Dockerfiles/ubuntu/22.04/Dockerfile
@@ -19,7 +19,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends \
     curl \
     systemd \
     ca-certificates \

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -84,7 +84,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	var cmd string
 	switch utils.PlatformLike {
 	case "debian":
-		cmd = "apt-get update -y && apt-get install --only-upgrade alpamon alpamon-pam -y"
+		cmd = "apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade alpamon alpamon-pam -y -o Acquire::Retries=3"
 	case "rhel":
 		cmd = "yum update -y alpamon alpamon-pam"
 	default:
@@ -291,7 +291,7 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 	var cmd string
 	switch utils.PlatformLike {
 	case "debian":
-		cmd = "apt-get update && apt-get upgrade -y && apt-get autoremove -y"
+		cmd = "apt-get update -o Acquire::Retries=3 && apt-get upgrade -y -o Acquire::Retries=3 && apt-get autoremove -y"
 	case "rhel":
 		cmd = "yum update -y"
 	case "darwin":

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	commitURL         = "/api/servers/servers/-/commit/"
-	eventURL          = "/api/events/events/"
-	firewallSyncURL   = "/api/firewall/agent/sync/"
-	accessPolicyURL   = "/api/servers/servers/-/access-policy/"
+	commitURL       = "/api/servers/servers/-/commit/"
+	eventURL        = "/api/events/events/"
+	firewallSyncURL = "/api/firewall/agent/sync/"
+	accessPolicyURL = "/api/servers/servers/-/access-policy/"
 
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -44,13 +44,13 @@ func TestParsePath(t *testing.T) {
 			want: "/home/other/file.txt",
 		},
 		{
-			name: "null byte rejected",
-			path: "/tmp/file\x00.txt",
+			name:    "null byte rejected",
+			path:    "/tmp/file\x00.txt",
 			wantErr: true,
 		},
 		{
-			name: "only null byte",
-			path: "\x00",
+			name:    "only null byte",
+			path:    "\x00",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
## Summary
  - Add `-o Acquire::Retries=3` to all apt-get commands across Dockerfiles, CI workflows, and runtime code to prevent package download failures caused by transient network errors.
  - Apply gofmt formatting

## Scope
  - **Dockerfiles** (5 files): ubuntu 18.04/20.04/22.04, debian 10/11
  - **CI workflows** (2 files): build-and-test.yml, release.yml
  - **Runtime code** (1 file): system upgrade/update handlers in system.go

Closes #224
