### PR TITLE
fix(pty): remove port validation from WebSocket URL check

### DIFF
--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -200,11 +200,6 @@ func TestValidateWebSocketURL(t *testing.T) {
 			url:  "wss://console.example.com:443/ws/channel/123",
 		},
 		{
-			name:    "mismatched port",
-			url:     "wss://console.example.com:8080/ws/channel/123",
-			wantErr: true,
-		},
-		{
 			name:    "empty scheme",
 			url:     "console.example.com/ws/channel/123",
 			wantErr: true,
@@ -235,67 +230,3 @@ func TestValidateWebSocketURL_InvalidServerURL(t *testing.T) {
 	}
 }
 
-func TestValidateWebSocketURL_ServerWithExplicitPort(t *testing.T) {
-	prevServerURL := config.GlobalSettings.ServerURL
-	t.Cleanup(func() { config.GlobalSettings.ServerURL = prevServerURL })
-	config.GlobalSettings.ServerURL = "https://console.example.com:8443"
-
-	tests := []struct {
-		name    string
-		url     string
-		wantErr bool
-	}{
-		{
-			name: "matching explicit port",
-			url:  "wss://console.example.com:8443/ws/channel/123",
-		},
-		{
-			name:    "default port does not match explicit",
-			url:     "wss://console.example.com:443/ws/channel/123",
-			wantErr: true,
-		},
-		{
-			name:    "no port does not match explicit",
-			url:     "wss://console.example.com/ws/channel/123",
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateWebSocketURL(tc.url)
-			if tc.wantErr && err == nil {
-				t.Fatalf("validateWebSocketURL(%q) expected error", tc.url)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("validateWebSocketURL(%q) unexpected error: %v", tc.url, err)
-			}
-		})
-	}
-}
-
-func TestNormalizePort(t *testing.T) {
-	tests := []struct {
-		name   string
-		scheme string
-		port   string
-		want   string
-	}{
-		{"explicit port returned as-is", "wss", "8080", "8080"},
-		{"wss default", "wss", "", "443"},
-		{"ws default", "ws", "", "80"},
-		{"https default", "https", "", "443"},
-		{"http default", "http", "", "80"},
-		{"unknown scheme empty port", "ftp", "", ""},
-		{"case insensitive scheme", "WSS", "", "443"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := normalizePort(tc.scheme, tc.port)
-			if got != tc.want {
-				t.Fatalf("normalizePort(%q, %q) = %q, want %q", tc.scheme, tc.port, got, tc.want)
-			}
-		})
-	}
-}

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -230,3 +230,45 @@ func TestValidateWebSocketURL_InvalidServerURL(t *testing.T) {
 	}
 }
 
+func TestValidateWebSocketURL_ServerWithExplicitPort(t *testing.T) {
+	prevServerURL := config.GlobalSettings.ServerURL
+	t.Cleanup(func() { config.GlobalSettings.ServerURL = prevServerURL })
+	config.GlobalSettings.ServerURL = "https://console.example.com:8443"
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{
+			name: "same port allowed",
+			url:  "wss://console.example.com:8443/ws/channel/123",
+		},
+		{
+			name: "different port allowed",
+			url:  "wss://console.example.com:9090/ws/channel/123",
+		},
+		{
+			name: "no port allowed",
+			url:  "wss://console.example.com/ws/channel/123",
+		},
+		{
+			name:    "different host rejected",
+			url:     "wss://evil.com:8443/ws/channel/123",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWebSocketURL(tc.url)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateWebSocketURL(%q) expected error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateWebSocketURL(%q) unexpected error: %v", tc.url, err)
+			}
+		})
+	}
+}
+

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -433,28 +433,7 @@ func validateWebSocketURL(rawURL string) error {
 		return fmt.Errorf("WebSocket URL host %q does not match server host %q", parsed.Hostname(), serverURL.Hostname())
 	}
 
-	parsedPort := normalizePort(parsed.Scheme, parsed.Port())
-	serverPort := normalizePort(serverURL.Scheme, serverURL.Port())
-	if parsedPort != "" && serverPort != "" && parsedPort != serverPort {
-		return fmt.Errorf("WebSocket URL port %q does not match server port %q", parsedPort, serverPort)
-	}
-
 	return nil
-}
-
-// normalizePort returns the effective port for a given scheme and port string.
-func normalizePort(scheme, port string) string {
-	if port != "" {
-		return port
-	}
-	switch strings.ToLower(scheme) {
-	case "http", "ws":
-		return "80"
-	case "https", "wss":
-		return "443"
-	default:
-		return ""
-	}
 }
 
 // getPtyUserAndEnv retrieves user information and sets environment variables.


### PR DESCRIPTION
## Summary

Remove port comparison and `normalizePort` helper from `validateWebSocketURL`, keeping only scheme and hostname validation. The proxy server runs on a different port (8080) than the API server (8000) in local dev, causing PTY session initialization to always fail. Port validation was not part of the original CodeQL SSRF fix — it was added later as over-hardening in `e0584fc`.

## Changes

- Remove port comparison logic from `validateWebSocketURL` in `pkg/runner/pty.go`
- Remove `normalizePort` helper function
- Remove port-related test cases (`TestValidateWebSocketURL_ServerWithExplicitPort`, `TestNormalizePort`)

## Context

PR #221 added `validateWebSocketURL` to address a CodeQL SSRF alert. The original fix (scheme + hostname check) was correct, but a subsequent Copilot review added port comparison with a `normalizePort` helper that guesses default ports (443/80).

This breaks PTY connections because:
- **Local dev**: API server on `:8000`, proxy server on `:8080` → port mismatch → rejected
- **Production**: Same host behind LB, but guessing default ports is unreliable when ports are implicit in URLs

Other WebSocket connections in the codebase (FTP, tunnel, main client, control client) do not validate URLs at all — tunnel explicitly comments "Server URL is provided by the authenticated Alpacon console which the agent trusts."

## Security

Scheme + hostname validation is sufficient for SSRF protection:
- **Scheme validation**: Only `ws`/`wss` allowed, blocking SSRF via `http`, `ftp`, etc.
- **Hostname validation**: Ensures the URL matches the configured server host (e.g., `alpacax.dev.alpacon.io`), blocking requests to external hosts like `evil.com`
- Port is not a CodeQL SSRF check criterion — different ports on the same trusted host are not a security threat

Closes #226

## Stack: golang

## Checklist

### Universal
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No hardcoded secrets or credentials

### Golang
- [x] Error handling is complete
- [x] Tests include edge cases
- [x] go mod tidy executed
