### PR TITLE
feat: add refreshpty command to send SIGWINCH without resizing

### DIFF
--- a/pkg/executor/handlers/common/types.go
+++ b/pkg/executor/handlers/common/types.go
@@ -67,9 +67,10 @@ const (
 	Download CommandType = "download"
 
 	// Terminal commands
-	OpenPty   CommandType = "openpty"
-	OpenFtp   CommandType = "openftp"
-	ResizePty CommandType = "resizepty"
+	OpenPty    CommandType = "openpty"
+	OpenFtp    CommandType = "openftp"
+	ResizePty  CommandType = "resizepty"
+	RefreshPty CommandType = "refreshpty"
 
 	// Tunnel commands
 	OpenTunnel  CommandType = "opentunnel"

--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -31,6 +31,7 @@ func NewTerminalHandler(cmdExecutor common.CommandExecutor, apiSession *schedule
 				common.OpenPty,
 				common.OpenFtp,
 				common.ResizePty,
+				common.RefreshPty,
 			},
 			cmdExecutor,
 		),
@@ -48,6 +49,8 @@ func (h *TerminalHandler) Execute(_ context.Context, cmd string, args *common.Co
 		return h.handleOpenFTP(args)
 	case common.ResizePty.String():
 		return h.handleResizePTY(args)
+	case common.RefreshPty.String():
+		return h.handleRefreshPTY(args)
 	default:
 		return 1, "", fmt.Errorf("unknown terminal command: %s", cmd)
 	}
@@ -83,6 +86,12 @@ func (h *TerminalHandler) Validate(cmd string, args *common.CommandArgs) error {
 			SessionID: args.SessionID,
 			Rows:      int(args.Rows),
 			Cols:      int(args.Cols),
+		}
+		return h.ValidateStruct(data)
+
+	case common.RefreshPty.String():
+		data := RefreshPTYData{
+			SessionID: args.SessionID,
 		}
 		return h.ValidateStruct(data)
 
@@ -196,4 +205,25 @@ func (h *TerminalHandler) handleResizePTY(args *common.CommandArgs) (int, string
 	}
 
 	return 0, fmt.Sprintf("Resized terminal for %s to %dx%d.", args.SessionID, args.Cols, args.Rows), nil
+}
+
+// handleRefreshPTY sends SIGWINCH to the PTY process to force a terminal redraw
+// without changing the terminal size. This is used after WebSocket reconnection
+// to make the shell refresh its display.
+func (h *TerminalHandler) handleRefreshPTY(args *common.CommandArgs) (int, string, error) {
+	log.Info().
+		Str("sessionID", args.SessionID).
+		Msg("Refreshing PTY")
+
+	terminal := runner.GetTerminal(args.SessionID)
+	if terminal == nil {
+		return 1, "Invalid session ID", nil
+	}
+
+	err := terminal.Refresh()
+	if err != nil {
+		return 1, err.Error(), nil
+	}
+
+	return 0, fmt.Sprintf("Refreshed terminal for %s.", args.SessionID), nil
 }

--- a/pkg/executor/handlers/terminal/terminal_test.go
+++ b/pkg/executor/handlers/terminal/terminal_test.go
@@ -78,6 +78,20 @@ func TestTerminalHandler_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "refreshpty valid",
+			cmd:  "refreshpty",
+			args: &common.CommandArgs{
+				SessionID: "session123",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "refreshpty missing session ID",
+			cmd:     "refreshpty",
+			args:    &common.CommandArgs{},
+			wantErr: true,
+		},
+		{
 			name:    "unknown command",
 			cmd:     "unknown",
 			args:    &common.CommandArgs{},
@@ -105,6 +119,26 @@ func TestTerminalHandler_Execute_UnknownCommand(t *testing.T) {
 	}
 	if exitCode != 1 {
 		t.Errorf("Execute() exitCode = %v, want 1", exitCode)
+	}
+}
+
+func TestTerminalHandler_RefreshPTY_InvalidSession(t *testing.T) {
+	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil)
+
+	args := &common.CommandArgs{
+		SessionID: "nonexistent",
+	}
+
+	exitCode, output, err := handler.Execute(context.TODO(), "refreshpty", args)
+
+	if err != nil {
+		t.Errorf("Execute() unexpected error: %v", err)
+	}
+	if exitCode != 1 {
+		t.Errorf("Execute() exitCode = %v, want 1", exitCode)
+	}
+	if output != "Invalid session ID" {
+		t.Errorf("Execute() output = %v, want 'Invalid session ID'", output)
 	}
 }
 

--- a/pkg/executor/handlers/terminal/types.go
+++ b/pkg/executor/handlers/terminal/types.go
@@ -26,3 +26,8 @@ type ResizePTYData struct {
 	Rows      int    `json:"rows" validate:"required"`
 	Cols      int    `json:"cols" validate:"required"`
 }
+
+// RefreshPTYData contains data for refreshing PTY (sending SIGWINCH)
+type RefreshPTYData struct {
+	SessionID string `json:"session_id" validate:"required"`
+}

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/alpacax/alpamon/internal/protocol"
+	"golang.org/x/sys/unix"
 	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -286,18 +287,30 @@ func (pc *PtyClient) Resize(rows, cols uint16) error {
 	return pc.resize(rows, cols)
 }
 
-// Refresh sends SIGWINCH to the PTY process to force a terminal redraw
-// without changing the terminal size.
+// Refresh sends SIGWINCH to the PTY foreground process group to force a
+// terminal redraw without changing the terminal size. It uses TIOCGPGRP to
+// look up the foreground process group from the PTY fd, ensuring that
+// full-screen programs (vim, less, top, etc.) also receive the signal.
 func (pc *PtyClient) Refresh() error {
-	if pc.cmd == nil || pc.cmd.Process == nil {
-		return fmt.Errorf("no running process for session %s", pc.sessionID)
+	if pc.ptmx == nil {
+		return fmt.Errorf("no PTY for session %s", pc.sessionID)
 	}
-	err := syscall.Kill(-pc.cmd.Process.Pid, syscall.SIGWINCH)
+
+	pgid, err := unix.IoctlGetInt(int(pc.ptmx.Fd()), unix.TIOCGPGRP)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to get foreground process group, falling back to shell PID.")
+		if pc.cmd == nil || pc.cmd.Process == nil {
+			return fmt.Errorf("no running process for session %s", pc.sessionID)
+		}
+		pgid = pc.cmd.Process.Pid
+	}
+
+	err = syscall.Kill(-pgid, syscall.SIGWINCH)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to send SIGWINCH to terminal.")
 		return err
 	}
-	log.Debug().Msgf("Sent SIGWINCH to terminal for %s.", pc.sessionID)
+	log.Debug().Msgf("Sent SIGWINCH to process group %d for %s.", pgid, pc.sessionID)
 	return nil
 }
 

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/alpacax/alpamon/internal/protocol"
-	"golang.org/x/sys/unix"
 	"github.com/alpacax/alpamon/pkg/config"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -25,6 +24,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/unix"
 )
 
 type PtyClient struct {

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -292,7 +292,7 @@ func (pc *PtyClient) Refresh() error {
 	if pc.cmd == nil || pc.cmd.Process == nil {
 		return fmt.Errorf("no running process for session %s", pc.sessionID)
 	}
-	err := pc.cmd.Process.Signal(syscall.SIGWINCH)
+	err := syscall.Kill(-pc.cmd.Process.Pid, syscall.SIGWINCH)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to send SIGWINCH to terminal.")
 		return err

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/alpacax/alpamon/internal/protocol"
@@ -283,6 +284,21 @@ func (pc *PtyClient) resize(rows, cols uint16) error {
 // Resize is the exported version of resize for external packages
 func (pc *PtyClient) Resize(rows, cols uint16) error {
 	return pc.resize(rows, cols)
+}
+
+// Refresh sends SIGWINCH to the PTY process to force a terminal redraw
+// without changing the terminal size.
+func (pc *PtyClient) Refresh() error {
+	if pc.cmd == nil || pc.cmd.Process == nil {
+		return fmt.Errorf("no running process for session %s", pc.sessionID)
+	}
+	err := pc.cmd.Process.Signal(syscall.SIGWINCH)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to send SIGWINCH to terminal.")
+		return err
+	}
+	log.Debug().Msgf("Sent SIGWINCH to terminal for %s.", pc.sessionID)
+	return nil
 }
 
 // GetTerminal returns the PTY client for the given session ID


### PR DESCRIPTION
## Summary

- Add new `refreshpty` internal command that sends SIGWINCH to the PTY foreground process group without changing terminal size
- Used by the web frontend after WebSocket reconnection to force the shell to redraw its display
- `PtyClient.Refresh()` uses `TIOCGPGRP` to look up the foreground process group from the PTY fd, then sends `SIGWINCH` via `syscall.Kill(-pgid, SIGWINCH)`, ensuring full-screen programs (vim, less, top) also redraw

## Background

When a WebSH client reconnects, the terminal size is typically unchanged. The existing `resizepty` command calls `pty.Setsize()`, which uses `ioctl(TIOCSWINSZ)` — but the kernel only delivers SIGWINCH when the size **actually changes**. This means the shell never redraws after reconnection.

The current frontend workaround sends `cols-1` followed by the real `cols` to force a size change and trigger SIGWINCH. This causes a visible 1-column gap and introduces race conditions.

The new `refreshpty` command cleanly solves this by sending SIGWINCH directly to the foreground process group, independent of any size change.

## Changes

| File | Change |
|------|--------|
| `pkg/executor/handlers/common/types.go` | Add `RefreshPty` command type constant |
| `pkg/executor/handlers/terminal/types.go` | Add `RefreshPTYData` validation struct |
| `pkg/executor/handlers/terminal/terminal.go` | Register `refreshpty` command, add handler and validation |
| `pkg/runner/pty.go` | Add `Refresh()` method using `TIOCGPGRP` + `syscall.Kill` to signal the foreground process group |

## Protocol

Server sends via Redis Stream:
```json
{
  "query": "command",
  "command": {
    "shell": "internal",
    "line": "refreshpty",
    "data": "{\"session_id\": \"<uuid>\"}"
  }
}
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/executor/handlers/terminal/... ./pkg/runner/...` passes
- [ ] Verify reconnection triggers shell redraw without column gap (requires alpacon-server + alpacon-web changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)