### PR TITLE
refactor(pty): extract TerminalManager from package-level globals

### DIFF
--- a/pkg/executor/factory.go
+++ b/pkg/executor/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alpacax/alpamon/pkg/executor/handlers/tunnel"
 	"github.com/alpacax/alpamon/pkg/executor/handlers/user"
 	"github.com/alpacax/alpamon/pkg/executor/services"
+	"github.com/alpacax/alpamon/pkg/runner"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 )
 
@@ -53,6 +54,9 @@ func (f *HandlerFactory) RegisterAll(
 	// Create system info adapter for info handler with function callbacks
 	infoAdapter := NewSystemInfoAdapter(session, callbacks.CommitFunc, callbacks.SyncFunc)
 
+	// Create terminal manager for PTY session lifecycle
+	terminalManager := runner.NewTerminalManager()
+
 	// Define all handlers in a slice for streamlined registration
 	handlers := []common.Handler{
 		system.NewSystemHandler(f.cmdExec, wsClient, ctxManager, pool),
@@ -62,7 +66,7 @@ func (f *HandlerFactory) RegisterAll(
 		user.NewUserHandler(f.cmdExec, groupService, infoAdapter),
 		firewall.NewFirewallHandler(f.cmdExec),
 		file.NewFileHandler(f.cmdExec, session),
-		terminal.NewTerminalHandler(f.cmdExec, session),
+		terminal.NewTerminalHandler(f.cmdExec, session, terminalManager),
 		tunnel.NewTunnelHandler(f.cmdExec),
 	}
 

--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -20,10 +20,11 @@ import (
 type TerminalHandler struct {
 	*common.BaseHandler
 	apiSession *scheduler.Session
+	manager    *runner.TerminalManager
 }
 
 // NewTerminalHandler creates a new terminal handler
-func NewTerminalHandler(cmdExecutor common.CommandExecutor, apiSession *scheduler.Session) *TerminalHandler {
+func NewTerminalHandler(cmdExecutor common.CommandExecutor, apiSession *scheduler.Session, manager *runner.TerminalManager) *TerminalHandler {
 	h := &TerminalHandler{
 		BaseHandler: common.NewBaseHandler(
 			common.Terminal,
@@ -36,6 +37,7 @@ func NewTerminalHandler(cmdExecutor common.CommandExecutor, apiSession *schedule
 			cmdExecutor,
 		),
 		apiSession: apiSession,
+		manager:    manager,
 	}
 	return h
 }
@@ -124,7 +126,7 @@ func (h *TerminalHandler) handleOpenPTY(args *common.CommandArgs) (int, string, 
 		Uint16("cols", data.Cols).
 		Msg("Opening PTY terminal")
 
-	ptyClient := runner.NewPtyClient(data, h.apiSession)
+	ptyClient := runner.NewPtyClient(data, h.apiSession, h.manager)
 	go ptyClient.RunPtyBackground()
 
 	return 0, "Spawned a pty terminal.", nil
@@ -194,12 +196,7 @@ func (h *TerminalHandler) handleResizePTY(args *common.CommandArgs) (int, string
 		Int("cols", int(args.Cols)).
 		Msg("Resizing PTY")
 
-	terminal := runner.GetTerminal(args.SessionID)
-	if terminal == nil {
-		return 1, "Invalid session ID", nil
-	}
-
-	err := terminal.Resize(uint16(args.Rows), uint16(args.Cols))
+	err := h.manager.Resize(args.SessionID, uint16(args.Rows), uint16(args.Cols))
 	if err != nil {
 		return 1, err.Error(), nil
 	}
@@ -215,12 +212,7 @@ func (h *TerminalHandler) handleRefreshPTY(args *common.CommandArgs) (int, strin
 		Str("sessionID", args.SessionID).
 		Msg("Refreshing PTY")
 
-	terminal := runner.GetTerminal(args.SessionID)
-	if terminal == nil {
-		return 1, "Invalid session ID", nil
-	}
-
-	err := terminal.Refresh()
+	err := h.manager.Refresh(args.SessionID)
 	if err != nil {
 		return 1, err.Error(), nil
 	}

--- a/pkg/executor/handlers/terminal/terminal_test.go
+++ b/pkg/executor/handlers/terminal/terminal_test.go
@@ -138,7 +138,7 @@ func TestTerminalHandler_RefreshPTY_InvalidSession(t *testing.T) {
 	if exitCode != 1 {
 		t.Errorf("Execute() exitCode = %v, want 1", exitCode)
 	}
-	if output != "Invalid session ID" {
+	if output != "invalid session ID" {
 		t.Errorf("Execute() output = %v, want 'Invalid session ID'", output)
 	}
 }
@@ -160,7 +160,7 @@ func TestTerminalHandler_ResizePTY_InvalidSession(t *testing.T) {
 	if exitCode != 1 {
 		t.Errorf("Execute() exitCode = %v, want 1", exitCode)
 	}
-	if output != "Invalid session ID" {
+	if output != "invalid session ID" {
 		t.Errorf("Execute() output = %v, want 'Invalid session ID'", output)
 	}
 }

--- a/pkg/executor/handlers/terminal/terminal_test.go
+++ b/pkg/executor/handlers/terminal/terminal_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/pkg/runner"
 )
 
 func TestTerminalHandler_Validate(t *testing.T) {
-	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil)
+	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil, runner.NewTerminalManager())
 
 	tests := []struct {
 		name    string
@@ -110,7 +111,7 @@ func TestTerminalHandler_Validate(t *testing.T) {
 }
 
 func TestTerminalHandler_Execute_UnknownCommand(t *testing.T) {
-	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil)
+	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil, runner.NewTerminalManager())
 
 	exitCode, _, err := handler.Execute(context.TODO(), "unknown", &common.CommandArgs{})
 
@@ -123,7 +124,7 @@ func TestTerminalHandler_Execute_UnknownCommand(t *testing.T) {
 }
 
 func TestTerminalHandler_RefreshPTY_InvalidSession(t *testing.T) {
-	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil)
+	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil, runner.NewTerminalManager())
 
 	args := &common.CommandArgs{
 		SessionID: "nonexistent",
@@ -143,7 +144,7 @@ func TestTerminalHandler_RefreshPTY_InvalidSession(t *testing.T) {
 }
 
 func TestTerminalHandler_ResizePTY_InvalidSession(t *testing.T) {
-	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil)
+	handler := NewTerminalHandler(common.NewMockCommandExecutor(t), nil, runner.NewTerminalManager())
 
 	args := &common.CommandArgs{
 		SessionID: "nonexistent",

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -306,7 +306,11 @@ func (pc *PtyClient) Refresh() error {
 
 // close terminates the PTY session and cleans up resources.
 // It ensures that the PTY, command, and WebSocket connection are properly closed.
+// Remove is called first so that the write lock waits for any in-flight
+// Resize/Refresh (which hold a read lock) to finish before we tear down the PTY.
 func (pc *PtyClient) close() {
+	pc.manager.Remove(pc.sessionID)
+
 	// Remove PID-to-session mapping before cleaning up
 	if pc.cmd != nil && pc.cmd.Process != nil {
 		authManager.RemovePIDSessionMapping(pc.cmd.Process.Pid)
@@ -320,8 +324,6 @@ func (pc *PtyClient) close() {
 		_ = pc.cmd.Process.Kill()
 		_ = pc.cmd.Wait()
 	}
-
-	pc.manager.Remove(pc.sessionID)
 
 	if pc.conn != nil {
 		err := pc.conn.WriteControl(

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -43,6 +42,7 @@ type PtyClient struct {
 	wsToPty       chan []byte
 	ptyToWs       chan []byte
 	isRecovering  atomic.Bool // default : false
+	manager       *TerminalManager
 }
 
 const (
@@ -53,16 +53,7 @@ const (
 	sessionCloseCode = 4000
 )
 
-var (
-	terminals   map[string]*PtyClient
-	terminalsMu sync.RWMutex
-)
-
-func init() {
-	terminals = make(map[string]*PtyClient)
-}
-
-func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session) *PtyClient {
+func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session, manager *TerminalManager) *PtyClient {
 	headers := http.Header{
 		"Authorization": {fmt.Sprintf(`id="%s", key="%s"`, config.GlobalSettings.ID, config.GlobalSettings.Key)},
 		"Origin":        {config.GlobalSettings.ServerURL},
@@ -80,6 +71,7 @@ func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session) *Pty
 		sessionID:     data.SessionID,
 		wsToPty:       make(chan []byte, bufferSize),
 		ptyToWs:       make(chan []byte, bufferSize),
+		manager:       manager,
 	}
 }
 
@@ -113,9 +105,7 @@ func (pc *PtyClient) initializePtySession() error {
 		return fmt.Errorf("failed to start pty: %w", err)
 	}
 
-	terminalsMu.Lock()
-	terminals[pc.sessionID] = pc
-	terminalsMu.Unlock()
+	pc.manager.Register(pc.sessionID, pc)
 
 	// Add PID-to-session mapping for auth manager
 	pid := pc.cmd.Process.Pid
@@ -314,13 +304,6 @@ func (pc *PtyClient) Refresh() error {
 	return nil
 }
 
-// GetTerminal returns the PTY client for the given session ID
-func GetTerminal(sessionID string) *PtyClient {
-	terminalsMu.RLock()
-	defer terminalsMu.RUnlock()
-	return terminals[sessionID]
-}
-
 // close terminates the PTY session and cleans up resources.
 // It ensures that the PTY, command, and WebSocket connection are properly closed.
 func (pc *PtyClient) close() {
@@ -338,11 +321,7 @@ func (pc *PtyClient) close() {
 		_ = pc.cmd.Wait()
 	}
 
-	terminalsMu.Lock()
-	if terminals[pc.sessionID] != nil {
-		delete(terminals, pc.sessionID)
-	}
-	terminalsMu.Unlock()
+	pc.manager.Remove(pc.sessionID)
 
 	if pc.conn != nil {
 		err := pc.conn.WriteControl(

--- a/pkg/runner/terminal_manager.go
+++ b/pkg/runner/terminal_manager.go
@@ -43,7 +43,7 @@ func (m *TerminalManager) Remove(sessionID string) {
 func (m *TerminalManager) Resize(sessionID string, rows, cols uint16) error {
 	client := m.Get(sessionID)
 	if client == nil {
-		return errors.New("Invalid session ID")
+		return errors.New("invalid session ID")
 	}
 	return client.Resize(rows, cols)
 }
@@ -52,7 +52,7 @@ func (m *TerminalManager) Resize(sessionID string, rows, cols uint16) error {
 func (m *TerminalManager) Refresh(sessionID string) error {
 	client := m.Get(sessionID)
 	if client == nil {
-		return errors.New("Invalid session ID")
+		return errors.New("invalid session ID")
 	}
 	return client.Refresh()
 }

--- a/pkg/runner/terminal_manager.go
+++ b/pkg/runner/terminal_manager.go
@@ -40,8 +40,12 @@ func (m *TerminalManager) Remove(sessionID string) {
 }
 
 // Resize resizes the terminal for the given session ID.
+// It holds a read lock for the duration of the resize syscall so that a
+// concurrent close/Remove cannot tear down the PTY mid-operation.
 func (m *TerminalManager) Resize(sessionID string, rows, cols uint16) error {
-	client := m.Get(sessionID)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	client := m.terminals[sessionID]
 	if client == nil {
 		return errors.New("invalid session ID")
 	}
@@ -49,8 +53,12 @@ func (m *TerminalManager) Resize(sessionID string, rows, cols uint16) error {
 }
 
 // Refresh sends SIGWINCH to the terminal for the given session ID.
+// It holds a read lock for the duration of the signal syscall so that a
+// concurrent close/Remove cannot tear down the PTY mid-operation.
 func (m *TerminalManager) Refresh(sessionID string) error {
-	client := m.Get(sessionID)
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	client := m.terminals[sessionID]
 	if client == nil {
 		return errors.New("invalid session ID")
 	}

--- a/pkg/runner/terminal_manager.go
+++ b/pkg/runner/terminal_manager.go
@@ -1,0 +1,58 @@
+package runner
+
+import (
+	"errors"
+	"sync"
+)
+
+// TerminalManager manages PTY session lifecycle in a single place.
+type TerminalManager struct {
+	mu        sync.RWMutex
+	terminals map[string]*PtyClient
+}
+
+// NewTerminalManager creates a new TerminalManager.
+func NewTerminalManager() *TerminalManager {
+	return &TerminalManager{
+		terminals: make(map[string]*PtyClient),
+	}
+}
+
+// Register adds a PtyClient to the manager.
+func (m *TerminalManager) Register(sessionID string, client *PtyClient) {
+	m.mu.Lock()
+	m.terminals[sessionID] = client
+	m.mu.Unlock()
+}
+
+// Get returns the PtyClient for the given session ID, or nil if not found.
+func (m *TerminalManager) Get(sessionID string) *PtyClient {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.terminals[sessionID]
+}
+
+// Remove deletes a PtyClient from the manager.
+func (m *TerminalManager) Remove(sessionID string) {
+	m.mu.Lock()
+	delete(m.terminals, sessionID)
+	m.mu.Unlock()
+}
+
+// Resize resizes the terminal for the given session ID.
+func (m *TerminalManager) Resize(sessionID string, rows, cols uint16) error {
+	client := m.Get(sessionID)
+	if client == nil {
+		return errors.New("Invalid session ID")
+	}
+	return client.Resize(rows, cols)
+}
+
+// Refresh sends SIGWINCH to the terminal for the given session ID.
+func (m *TerminalManager) Refresh(sessionID string) error {
+	client := m.Get(sessionID)
+	if client == nil {
+		return errors.New("Invalid session ID")
+	}
+	return client.Refresh()
+}

--- a/pkg/runner/terminal_manager_test.go
+++ b/pkg/runner/terminal_manager_test.go
@@ -41,8 +41,8 @@ func TestTerminalManager_Resize_InvalidSession(t *testing.T) {
 	if err == nil {
 		t.Error("Resize() expected error for invalid session")
 	}
-	if err.Error() != "Invalid session ID" {
-		t.Errorf("Resize() error = %q, want %q", err.Error(), "Invalid session ID")
+	if err.Error() != "invalid session ID" {
+		t.Errorf("Resize() error = %q, want %q", err.Error(), "invalid session ID")
 	}
 }
 
@@ -53,7 +53,7 @@ func TestTerminalManager_Refresh_InvalidSession(t *testing.T) {
 	if err == nil {
 		t.Error("Refresh() expected error for invalid session")
 	}
-	if err.Error() != "Invalid session ID" {
-		t.Errorf("Refresh() error = %q, want %q", err.Error(), "Invalid session ID")
+	if err.Error() != "invalid session ID" {
+		t.Errorf("Refresh() error = %q, want %q", err.Error(), "invalid session ID")
 	}
 }

--- a/pkg/runner/terminal_manager_test.go
+++ b/pkg/runner/terminal_manager_test.go
@@ -104,7 +104,7 @@ func TestTerminalManager_ConcurrentResizeAndRemove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tty.Close()
+	defer func() { _ = tty.Close() }()
 
 	pc := &PtyClient{sessionID: "test", ptmx: ptmx}
 	m.Register("test", pc)
@@ -124,7 +124,7 @@ func TestTerminalManager_ConcurrentResizeAndRemove(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		m.Remove("test")
-		ptmx.Close()
+		_ = ptmx.Close()
 	}()
 
 	wg.Wait()

--- a/pkg/runner/terminal_manager_test.go
+++ b/pkg/runner/terminal_manager_test.go
@@ -1,7 +1,11 @@
 package runner
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/creack/pty"
 )
 
 func TestTerminalManager_RegisterAndGet(t *testing.T) {
@@ -56,4 +60,72 @@ func TestTerminalManager_Refresh_InvalidSession(t *testing.T) {
 	if err.Error() != "invalid session ID" {
 		t.Errorf("Refresh() error = %q, want %q", err.Error(), "invalid session ID")
 	}
+}
+
+// TestTerminalManager_ConcurrentRegisterGetRemove exercises concurrent map
+// access. Run with -race to verify no data race on the terminals map.
+func TestTerminalManager_ConcurrentRegisterGetRemove(t *testing.T) {
+	m := NewTerminalManager()
+	const n = 50
+
+	var wg sync.WaitGroup
+	wg.Add(n * 3)
+
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("session-%d", i)
+		pc := &PtyClient{sessionID: id}
+
+		go func() {
+			defer wg.Done()
+			m.Register(id, pc)
+		}()
+		go func() {
+			defer wg.Done()
+			m.Get(id)
+		}()
+		go func() {
+			defer wg.Done()
+			m.Remove(id)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestTerminalManager_ConcurrentResizeAndRemove simulates the real race
+// scenario: a handler calling Resize (read lock) while close() calls Remove
+// (write lock) followed by ptmx.Close(). With proper locking, Remove waits
+// for the in-flight Resize to finish before the PTY fd is closed.
+// Run with -race to verify no data race on ptmx access.
+func TestTerminalManager_ConcurrentResizeAndRemove(t *testing.T) {
+	m := NewTerminalManager()
+
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tty.Close()
+
+	pc := &PtyClient{sessionID: "test", ptmx: ptmx}
+	m.Register("test", pc)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: repeatedly resize (holds read lock during syscall)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = m.Resize("test", uint16(20+i%10), 80)
+		}
+	}()
+
+	// Goroutine 2: simulate close() — Remove then close ptmx
+	go func() {
+		defer wg.Done()
+		m.Remove("test")
+		ptmx.Close()
+	}()
+
+	wg.Wait()
 }

--- a/pkg/runner/terminal_manager_test.go
+++ b/pkg/runner/terminal_manager_test.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestTerminalManager_RegisterAndGet(t *testing.T) {
+	m := NewTerminalManager()
+	pc := &PtyClient{sessionID: "test-session"}
+
+	m.Register("test-session", pc)
+
+	got := m.Get("test-session")
+	if got != pc {
+		t.Errorf("Get() = %v, want %v", got, pc)
+	}
+
+	got = m.Get("nonexistent")
+	if got != nil {
+		t.Errorf("Get(nonexistent) = %v, want nil", got)
+	}
+}
+
+func TestTerminalManager_Remove(t *testing.T) {
+	m := NewTerminalManager()
+	pc := &PtyClient{sessionID: "test-session"}
+
+	m.Register("test-session", pc)
+	m.Remove("test-session")
+
+	got := m.Get("test-session")
+	if got != nil {
+		t.Errorf("Get() after Remove = %v, want nil", got)
+	}
+}
+
+func TestTerminalManager_Resize_InvalidSession(t *testing.T) {
+	m := NewTerminalManager()
+
+	err := m.Resize("nonexistent", 40, 120)
+	if err == nil {
+		t.Error("Resize() expected error for invalid session")
+	}
+	if err.Error() != "Invalid session ID" {
+		t.Errorf("Resize() error = %q, want %q", err.Error(), "Invalid session ID")
+	}
+}
+
+func TestTerminalManager_Refresh_InvalidSession(t *testing.T) {
+	m := NewTerminalManager()
+
+	err := m.Refresh("nonexistent")
+	if err == nil {
+		t.Error("Refresh() expected error for invalid session")
+	}
+	if err.Error() != "Invalid session ID" {
+		t.Errorf("Refresh() error = %q, want %q", err.Error(), "Invalid session ID")
+	}
+}


### PR DESCRIPTION
## Summary
- Introduce `TerminalManager` struct to encapsulate PTY session lifecycle (register, get, remove, resize, refresh)
- Remove package-level `terminals` map, `terminalsMu` mutex, `init()`, and `GetTerminal()` from `pty.go`
- Inject `TerminalManager` via constructor into `PtyClient` and `TerminalHandler`, eliminating repeated get-nil-check boilerplate in handlers

## Test plan
- [x] New unit tests for `TerminalManager` (register/get, remove, resize/refresh invalid session)
- [x] Existing `terminal_test.go` tests updated and passing
- [x] `go build ./...` compiles cleanly
- [x] `go test -v ./pkg/runner/... ./pkg/executor/... -p 1` all pass

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)