### PR TITLE
fix(pty): restore PATH and system environment for PTY sessions

### DIFF
--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -1,12 +1,53 @@
 package runner
 
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+const environmentFilePath = "/etc/environment"
+
 func getDefaultEnv() map[string]string {
 	env := make(map[string]string)
 	env["SHELL"] = "/bin/bash"
 	env["TERM"] = "xterm-256color"
 	env["LS_COLORS"] = `rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:`
 	env["LANG"] = "en_US.UTF-8"
-	// env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+	loadEtcEnvironment(env)
 
 	return env
+}
+
+// loadEtcEnvironment parses /etc/environment and merges system-wide
+// environment variables into the provided map. This supplements the
+// PAM pam_env module which is not invoked for PTY sessions.
+func loadEtcEnvironment(env map[string]string) {
+	file, err := os.Open(environmentFilePath)
+	if err != nil {
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(value, `"'`)
+		env[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Debug().Err(err).Msg("Error reading /etc/environment")
+	}
 }

--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -43,7 +43,11 @@ func loadEtcEnvironment(env map[string]string) {
 		if !ok {
 			continue
 		}
-		value = strings.Trim(value, `"'`)
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
 		env[key] = value
 	}
 

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -90,7 +90,7 @@ func (pc *PtyClient) initializePtySession() error {
 		return fmt.Errorf("failed to connect Websh server: %w", err)
 	}
 
-	pc.cmd = exec.Command("/bin/bash", "-i")
+	pc.cmd = exec.Command("/bin/bash", "-il")
 	uid, gid, groupIds, env, err := pc.getPtyUserAndEnv()
 	if err != nil {
 		return fmt.Errorf("failed to get user/env: %w", err)
@@ -463,6 +463,9 @@ func (pc *PtyClient) getPtyUserAndEnv() (uid, gid int, groupIds []string, env ma
 		env["USER"] = pc.username
 		env["HOME"] = pc.homeDirectory
 	}
+
+	env["LOGNAME"] = env["USER"]
+	env["MAIL"] = "/var/mail/" + env["USER"]
 
 	uid, err = strconv.Atoi(usr.Uid)
 	if err != nil {


### PR DESCRIPTION
### Summary

PTY sessions created via `openpty` started with `PATH` unset in the process environment. While bash falls back to a compiled-in default PATH so basic commands still work, all system and user PATH configuration was lost — paths from `/etc/environment`, `/etc/profile`, `/etc/profile.d/*.sh`, and user profiles (e.g., `/snap/bin`, `/usr/local/go/bin`, custom tool directories) were not applied. PAM session variables (`LOGNAME`, `MAIL`) were also missing. This affected all system users.

**Root cause:** `getDefaultEnv()` had `PATH` commented out since commit `f3573de`, and the non-login shell (`bash -i`) did not source `/etc/profile` where system-wide PATH extensions are defined.

### Changes

- **Restore default PATH** in `getDefaultEnv()` as a fallback (`pkg/runner/env.go`)
- **Parse `/etc/environment`** to load system-wide variables that PAM normally provides (`pkg/runner/env.go`)
- **Switch to login shell** (`bash -il`) so `/etc/profile` and user profile files are sourced (`pkg/runner/pty.go`)
- **Add `LOGNAME` and `MAIL`** to supplement PAM session variables (`pkg/runner/pty.go`)

### Environment variable resolution order after fix

```
1. getDefaultEnv()       -> hardcoded defaults (PATH included as fallback)
2. loadEtcEnvironment()  -> /etc/environment overrides
3. getPtyUserAndEnv()    -> USER, HOME, LOGNAME, MAIL
4. bash -il              -> /etc/profile -> ~/.bash_profile -> ~/.bashrc
```

### Test plan

- [x] `go build -v ./cmd/alpamon` succeeds
- [x] `go test -v ./pkg/runner/... -p 1` passes
- [x] `gofmt` and `go vet` clean
- [ ] PTY session: `echo $PATH` outputs a valid PATH
- [ ] PTY session: `echo $LOGNAME` outputs the correct username
- [ ] PTY session: `ls`, `grep`, `cat` work without absolute paths
- [ ] PTY session: custom variables in `/etc/environment` are reflected
