### PR TITLE
feat: support /bin/sh -c execution via allow_sh flag

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -8,13 +8,14 @@ import (
 
 // Command represents a command request from the server
 type Command struct {
-	ID    string            `json:"id"`
-	Shell string            `json:"shell"`
-	Line  string            `json:"line"`
-	User  string            `json:"user"`
-	Group string            `json:"group"`
-	Env   map[string]string `json:"env"`
-	Data  string            `json:"data,omitempty"`
+	ID      string            `json:"id"`
+	Shell   string            `json:"shell"`
+	Line    string            `json:"line"`
+	User    string            `json:"user"`
+	Group   string            `json:"group"`
+	Env     map[string]string `json:"env"`
+	AllowSh bool              `json:"allow_sh,omitempty"`
+	Data    string            `json:"data,omitempty"`
 }
 
 // File represents a file in command data

--- a/internal/protocol/message_test.go
+++ b/internal/protocol/message_test.go
@@ -97,6 +97,32 @@ func TestCommand_ParseCommandData_Invalid(t *testing.T) {
 	assert.Nil(t, data)
 }
 
+func TestCommand_AllowSh(t *testing.T) {
+	t.Run("allow_sh present and true", func(t *testing.T) {
+		raw := `{"id":"cmd-1","shell":"system","line":"grep err /log | head","allow_sh":true}`
+		var cmd Command
+		err := json.Unmarshal([]byte(raw), &cmd)
+		require.NoError(t, err)
+		assert.True(t, cmd.AllowSh)
+	})
+
+	t.Run("allow_sh present and false", func(t *testing.T) {
+		raw := `{"id":"cmd-2","shell":"system","line":"ls -la","allow_sh":false}`
+		var cmd Command
+		err := json.Unmarshal([]byte(raw), &cmd)
+		require.NoError(t, err)
+		assert.False(t, cmd.AllowSh)
+	})
+
+	t.Run("allow_sh missing defaults to false", func(t *testing.T) {
+		raw := `{"id":"cmd-3","shell":"system","line":"ls -la"}`
+		var cmd Command
+		err := json.Unmarshal([]byte(raw), &cmd)
+		require.NoError(t, err)
+		assert.False(t, cmd.AllowSh)
+	})
+}
+
 func TestNewCommandResponse(t *testing.T) {
 	resp := NewCommandResponse(true, "success output", 1.5)
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -78,11 +78,13 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 		Msg("Executor execute command")
 
 	// Execute command
+	start := time.Now()
 	output, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return 124, string(output) + fmt.Sprintf("\n\nCommand timed out after %s", opts.Timeout), err
+			elapsed := time.Since(start).Truncate(time.Second)
+			return 124, string(output) + fmt.Sprintf("\n\nCommand timed out after %s", elapsed), err
 		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode = exitError.ExitCode()

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -81,6 +81,9 @@ func (e *Executor) Execute(ctx context.Context, opts CommandOptions) (int, strin
 	output, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return 124, string(output) + fmt.Sprintf("\n\nCommand timed out after %s", opts.Timeout), err
+		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode = exitError.ExitCode()
 		} else {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -1,0 +1,45 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecutor_TimeoutReturns124(t *testing.T) {
+	e := NewExecutor()
+	ctx := context.Background()
+
+	exitCode, output, err := e.Execute(ctx, CommandOptions{
+		Args:    []string{"sleep", "10"},
+		Timeout: 500 * time.Millisecond,
+	})
+
+	if exitCode != 124 {
+		t.Errorf("expected exit code 124, got %d", exitCode)
+	}
+	if !strings.Contains(output, "Command timed out after") {
+		t.Errorf("expected timeout message in output, got %q", output)
+	}
+	if err == nil {
+		t.Error("expected non-nil error on timeout")
+	}
+}
+
+func TestExecutor_NoTimeoutOnFastCommand(t *testing.T) {
+	e := NewExecutor()
+	ctx := context.Background()
+
+	exitCode, _, err := e.Execute(ctx, CommandOptions{
+		Args:    []string{"echo", "hello"},
+		Timeout: 5 * time.Second,
+	})
+
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/executor/handlers/common/args.go
+++ b/pkg/executor/handlers/common/args.go
@@ -9,6 +9,7 @@ type CommandArgs struct {
 	URL       string
 	Command   string
 	Timeout   time.Duration
+	AllowSh   bool
 
 	// User management
 	Username                string

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -38,27 +38,33 @@ func NewMockCommandExecutor(t *testing.T) *MockCommandExecutor {
 	}
 }
 
-func (m *MockCommandExecutor) Run(ctx context.Context, name string, args ...string) (int, string, error) {
-	m.commands = append(m.commands, ExecutedCommand{Name: name, Args: args})
+// lookupResult returns the mocked result for a given command key.
+func (m *MockCommandExecutor) lookupResult(name string, args ...string) (int, string, error) {
 	key := name + " " + strings.Join(args, " ")
 	if result, ok := m.results[key]; ok {
 		return result.ExitCode, result.Output, result.Err
 	}
-	// Default behavior: return success for unknown commands to prevent unintended test failures.
 	return 0, "Mock success", nil
+}
+
+func (m *MockCommandExecutor) Run(ctx context.Context, name string, args ...string) (int, string, error) {
+	m.commands = append(m.commands, ExecutedCommand{Name: name, Args: args})
+	return m.lookupResult(name, args...)
 }
 
 func (m *MockCommandExecutor) RunAsUser(ctx context.Context, username string, name string, args ...string) (int, string, error) {
 	m.commands = append(m.commands, ExecutedCommand{Name: name, Args: args, User: username})
-	return m.Run(ctx, name, args...)
+	return m.lookupResult(name, args...)
 }
 
 func (m *MockCommandExecutor) RunWithInput(ctx context.Context, input string, name string, args ...string) (int, string, error) {
-	return m.Run(ctx, name, args...)
+	m.commands = append(m.commands, ExecutedCommand{Name: name, Args: args})
+	return m.lookupResult(name, args...)
 }
 
 func (m *MockCommandExecutor) RunWithTimeout(ctx context.Context, timeout time.Duration, name string, args ...string) (int, string, error) {
-	return m.Run(ctx, name, args...)
+	m.commands = append(m.commands, ExecutedCommand{Name: name, Args: args, Timeout: timeout})
+	return m.lookupResult(name, args...)
 }
 
 func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration) (int, string, error) {
@@ -66,7 +72,7 @@ func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username,
 		return 0, "", nil
 	}
 	m.commands = append(m.commands, ExecutedCommand{Name: args[0], Args: args[1:], User: username, Timeout: timeout})
-	return m.Run(ctx, args[0], args[1:]...)
+	return m.lookupResult(args[0], args[1:]...)
 }
 
 func (m *MockCommandExecutor) SetResult(command string, exitCode int, output string, err error) {

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -17,9 +17,10 @@ type MockCommandExecutor struct {
 
 // ExecutedCommand represents a command that was executed by the mock.
 type ExecutedCommand struct {
-	Name string
-	Args []string
-	User string
+	Name    string
+	Args    []string
+	User    string
+	Timeout time.Duration
 }
 
 // CommandResult represents the result of a mocked command execution.
@@ -64,7 +65,7 @@ func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username,
 	if len(args) == 0 {
 		return 0, "", nil
 	}
-	m.commands = append(m.commands, ExecutedCommand{Name: args[0], Args: args[1:], User: username})
+	m.commands = append(m.commands, ExecutedCommand{Name: args[0], Args: args[1:], User: username, Timeout: timeout})
 	return m.Run(ctx, args[0], args[1:]...)
 }
 

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -39,9 +39,16 @@ func NewMockCommandExecutor(t *testing.T) *MockCommandExecutor {
 }
 
 // lookupResult returns the mocked result for a given command key.
+// makeKey builds a consistent lookup key from a command name and arguments.
+func makeKey(name string, args ...string) string {
+	if len(args) == 0 {
+		return name
+	}
+	return name + " " + strings.Join(args, " ")
+}
+
 func (m *MockCommandExecutor) lookupResult(name string, args ...string) (int, string, error) {
-	key := name + " " + strings.Join(args, " ")
-	if result, ok := m.results[key]; ok {
+	if result, ok := m.results[makeKey(name, args...)]; ok {
 		return result.ExitCode, result.Output, result.Err
 	}
 	return 0, "Mock success", nil

--- a/pkg/executor/handlers/shell/shell.go
+++ b/pkg/executor/handlers/shell/shell.go
@@ -60,35 +60,37 @@ func (h *ShellHandler) handleShellCommand(ctx context.Context, args *common.Comm
 		groupname = username
 	}
 
-	// Get environment variables
 	env := args.Env
 
-	// Get timeout
-	timeout := int(args.Timeout.Seconds())
+	timeout := args.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Minute
+	}
 
 	log.Debug().
 		Str("command", command).
 		Str("user", username).
 		Str("group", groupname).
-		Int("timeout", timeout).
+		Dur("timeout", timeout).
+		Bool("allow_sh", args.AllowSh).
 		Msg("Executing shell command")
 
-	// Parse and execute command with operators support
+	if args.AllowSh {
+		exitCode, result := h.executeCommand(ctx, []string{"/bin/sh", "-c", command}, username, groupname, env, timeout)
+		return exitCode, result, nil
+	}
+
+	// Fallback: direct execution with manual operator parsing
 	return h.executeWithOperators(ctx, command, username, groupname, env, timeout)
 }
 
 // executeWithOperators handles shell operators (&&, ||, ;)
-func (h *ShellHandler) executeWithOperators(ctx context.Context, command, username, groupname string, env map[string]string, timeoutSecs int) (int, string, error) {
+func (h *ShellHandler) executeWithOperators(ctx context.Context, command, username, groupname string, env map[string]string, timeout time.Duration) (int, string, error) {
 	spl := strings.Fields(command)
 	var currentCmd []string
 	var results strings.Builder
 	var exitCode int
 	var result string
-
-	timeout := time.Duration(timeoutSecs) * time.Second
-	if timeout == 0 {
-		timeout = 120 * time.Second // Default timeout
-	}
 
 	for _, arg := range spl {
 		switch arg {

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -313,6 +313,15 @@ func TestShellHandler_DefaultTimeout(t *testing.T) {
 	if exitCode != 0 {
 		t.Errorf("expected exit code 0, got %d", exitCode)
 	}
+
+	// Verify the default 30m timeout was passed to the executor
+	cmds := mockExec.GetExecutedCommands()
+	if len(cmds) == 0 {
+		t.Fatal("expected at least one executed command")
+	}
+	if cmds[0].Timeout != 30*time.Minute {
+		t.Errorf("expected default timeout 30m, got %v", cmds[0].Timeout)
+	}
 }
 
 func TestShellHandler_Validate_Empty(t *testing.T) {

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -43,7 +43,7 @@ func TestShellHandler_Commands(t *testing.T) {
 func TestShellHandler_Execute_Basic(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	// Key format is "name arg1 arg2..." - for single word command it's just "ls "
-	mockExec.SetResult("ls ", 0, "file1.txt\nfile2.txt", nil)
+	mockExec.SetResult("ls", 0, "file1.txt\nfile2.txt", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -90,8 +90,8 @@ func TestShellHandler_Execute_Exec(t *testing.T) {
 func TestShellHandler_Execute_AndOperator(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	// Shell handler uses strings.Fields which splits "cmd1 && cmd2" into ["cmd1", "&&", "cmd2"]
-	mockExec.SetResult("cmd1 ", 0, "output1", nil)
-	mockExec.SetResult("cmd2 ", 0, "output2", nil)
+	mockExec.SetResult("cmd1", 0, "output1", nil)
+	mockExec.SetResult("cmd2", 0, "output2", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -114,8 +114,8 @@ func TestShellHandler_Execute_AndOperator(t *testing.T) {
 
 func TestShellHandler_AndStopsOnFailure(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("cmd1 ", 1, "error output", nil) // First command fails
-	mockExec.SetResult("cmd2 ", 0, "output2", nil)
+	mockExec.SetResult("cmd1", 1, "error output", nil) // First command fails
+	mockExec.SetResult("cmd2", 0, "output2", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -135,8 +135,8 @@ func TestShellHandler_AndStopsOnFailure(t *testing.T) {
 
 func TestShellHandler_Execute_OrOperator(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("cmd1 ", 1, "error", nil) // First fails
-	mockExec.SetResult("cmd2 ", 0, "success", nil)
+	mockExec.SetResult("cmd1", 1, "error", nil) // First fails
+	mockExec.SetResult("cmd2", 0, "success", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -159,8 +159,8 @@ func TestShellHandler_Execute_OrOperator(t *testing.T) {
 
 func TestShellHandler_OrStopsOnSuccess(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("cmd1 ", 0, "success", nil) // First succeeds
-	mockExec.SetResult("cmd2 ", 0, "output2", nil)
+	mockExec.SetResult("cmd1", 0, "success", nil) // First succeeds
+	mockExec.SetResult("cmd2", 0, "output2", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -184,8 +184,8 @@ func TestShellHandler_OrStopsOnSuccess(t *testing.T) {
 
 func TestShellHandler_Execute_Semicolon(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("cmd1 ", 1, "error", nil) // First fails
-	mockExec.SetResult("cmd2 ", 0, "success", nil)
+	mockExec.SetResult("cmd1", 1, "error", nil) // First fails
+	mockExec.SetResult("cmd2", 0, "success", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -210,7 +210,7 @@ func TestShellHandler_Execute_Semicolon(t *testing.T) {
 
 func TestShellHandler_CustomUser(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("whoami ", 0, "testuser", nil)
+	mockExec.SetResult("whoami", 0, "testuser", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -245,7 +245,7 @@ func TestShellHandler_CustomUser(t *testing.T) {
 
 func TestShellHandler_DefaultUser(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("whoami ", 0, "root", nil)
+	mockExec.SetResult("whoami", 0, "root", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -296,7 +296,7 @@ func TestShellHandler_WithTimeout(t *testing.T) {
 
 func TestShellHandler_DefaultTimeout(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("ls ", 0, "output", nil)
+	mockExec.SetResult("ls", 0, "output", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -382,7 +382,7 @@ func TestShellHandler_UnknownCommand(t *testing.T) {
 func TestShellHandler_CommandExecutionError(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	// Set up a command that returns -1 exit code with error
-	mockExec.SetResult("failing_cmd ", -1, "", errors.New("command not found"))
+	mockExec.SetResult("failing_cmd", -1, "", errors.New("command not found"))
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -405,7 +405,7 @@ func TestShellHandler_CommandExecutionError(t *testing.T) {
 
 func TestShellHandler_WithEnv(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("printenv ", 0, "TEST_VAR=test_value", nil)
+	mockExec.SetResult("printenv", 0, "TEST_VAR=test_value", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 
@@ -428,9 +428,9 @@ func TestShellHandler_WithEnv(t *testing.T) {
 
 func TestShellHandler_MixedOperators(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	mockExec.SetResult("cmd1 ", 0, "out1", nil)
-	mockExec.SetResult("cmd2 ", 1, "err2", nil)
-	mockExec.SetResult("cmd3 ", 0, "out3", nil)
+	mockExec.SetResult("cmd1", 0, "out1", nil)
+	mockExec.SetResult("cmd2", 1, "err2", nil)
+	mockExec.SetResult("cmd3", 0, "out3", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()
 

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -302,7 +302,7 @@ func TestShellHandler_DefaultTimeout(t *testing.T) {
 
 	args := &common.CommandArgs{
 		Command: "ls",
-		// Timeout not set - should default to 120 seconds
+		// Timeout not set - should default to 30 minutes
 	}
 
 	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
@@ -443,6 +443,75 @@ func TestShellHandler_MixedOperators(t *testing.T) {
 	// cmd1's output should be present
 	if !strings.Contains(output, "out1") {
 		t.Errorf("expected output to contain 'out1', got %q", output)
+	}
+}
+
+func TestShellHandler_AllowSh(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	// When AllowSh is true, handler calls /bin/sh -c <command>
+	// Mock key: "/bin/sh" + " " + "-c" + " " + "grep err /log | head"
+	mockExec.SetResult("/bin/sh -c grep err /log | head", 0, "error line 1", nil)
+	handler := NewShellHandler(mockExec)
+	ctx := context.Background()
+
+	args := &common.CommandArgs{
+		Command: "grep err /log | head",
+		AllowSh: true,
+	}
+
+	exitCode, output, err := handler.Execute(ctx, common.ShellCmd.String(), args)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "error line 1") {
+		t.Errorf("expected output to contain 'error line 1', got %q", output)
+	}
+
+	// Verify it was called via /bin/sh -c, not split by Fields
+	cmds := mockExec.GetExecutedCommands()
+	if len(cmds) == 0 {
+		t.Fatal("expected at least one executed command")
+	}
+	if cmds[0].Name != "/bin/sh" {
+		t.Errorf("expected command name '/bin/sh', got %q", cmds[0].Name)
+	}
+	if len(cmds[0].Args) != 2 || cmds[0].Args[0] != "-c" || cmds[0].Args[1] != "grep err /log | head" {
+		t.Errorf("expected args ['-c', 'grep err /log | head'], got %v", cmds[0].Args)
+	}
+}
+
+func TestShellHandler_AllowSh_False_UsesDirectExec(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	// Without AllowSh, "echo hello" is split by Fields into ["echo", "hello"]
+	mockExec.SetResult("echo hello", 0, "hello", nil)
+	handler := NewShellHandler(mockExec)
+	ctx := context.Background()
+
+	args := &common.CommandArgs{
+		Command: "echo hello",
+		AllowSh: false,
+	}
+
+	exitCode, _, err := handler.Execute(ctx, common.ShellCmd.String(), args)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+
+	// Verify it was NOT called via /bin/sh
+	cmds := mockExec.GetExecutedCommands()
+	if len(cmds) == 0 {
+		t.Fatal("expected at least one executed command")
+	}
+	if cmds[0].Name == "/bin/sh" {
+		t.Error("expected direct exec, not /bin/sh")
 	}
 }
 

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -42,7 +42,7 @@ func TestShellHandler_Commands(t *testing.T) {
 
 func TestShellHandler_Execute_Basic(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
-	// Key format is "name arg1 arg2..." - for single word command it's just "ls "
+	// Key format is "name arg1 arg2..." - for single word command it's just "ls"
 	mockExec.SetResult("ls", 0, "file1.txt\nfile2.txt", nil)
 	handler := NewShellHandler(mockExec)
 	ctx := context.Background()

--- a/pkg/executor/regression_test.go
+++ b/pkg/executor/regression_test.go
@@ -247,7 +247,7 @@ func TestRegression_CommandExecutorInterface(t *testing.T) {
 	var _ common.CommandExecutor = mockExec
 
 	// Test all methods exist
-	mockExec.SetResult("test ", 0, "output", nil)
+	mockExec.SetResult("test", 0, "output", nil)
 	cmds := mockExec.GetExecutedCommands()
 	if cmds == nil {
 		t.Error("GetExecutedCommands should not return nil")

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -95,6 +95,7 @@ func (cr *CommandRunner) Run(ctx context.Context) error {
 			Username:  cr.command.User,
 			Groupname: cr.command.Group,
 			Env:       cr.command.Env,
+			AllowSh:   cr.command.AllowSh,
 		}
 	default:
 		exitCode = 1


### PR DESCRIPTION
## Summary

- When server sends `allow_sh: true`, execute command via `/bin/sh -c` enabling pipes, redirections, variable expansion, and other shell features
- Without the flag (or older server), existing direct exec behavior is preserved
- Return exit code 124 with explicit timeout message on command timeout
- Increase default shell timeout from 2min to 30min for long-running commands (e.g. `apt upgrade`)

## Deployment

Safe to deploy at any time — backward compatible:
- Server sends `allow_sh: true` → shell execution enabled
- Server doesn't send the field → existing behavior preserved

## Test plan

- [x] `go build -v ./...` succeeds
- [x] `go test -v ./... -p 1` passes
- [x] `AllowSh` JSON deserialization: true, false, missing field (defaults to false)
- [ ] System shell with `allow_sh: true`: pipes, redirections work
- [ ] System shell without `allow_sh`: existing behavior unchanged
- [ ] Command timeout returns exit code 124 with message

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)