### PR TITLE
docs: update CLAUDE.md, add copilot instructions, apply sentence case

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,12 +2,13 @@
 
 ## Project overview
 
-Alpamon is a lightweight Go-based server agent for Alpacon — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. It establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution. Metrics are stored locally in SQLite (Ent ORM).
+Alpamon is a lightweight Go-based server agent for Alpacon—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. It establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution. Every action is supervised and audited for compliance. Metrics are stored locally in SQLite (Ent ORM).
 
 ## Writing conventions
 
 - **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
 - **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
+- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word").
 
 ## Architecture
 
@@ -19,11 +20,11 @@ Commands flow through a handler-based executor pattern:
 4. `pkg/executor/executor.go` runs system commands with privilege demotion and timeout handling
 
 Key packages:
-- `pkg/collector/` — System metric collection (realtime and batch)
-- `pkg/db/` — Ent ORM with SQLite backend
-- `pkg/agent/` — Centralized lifecycle management
-- `internal/protocol/` — Command and message protocol definitions
-- `internal/pool/` — Worker pool for concurrent tasks
+- `pkg/collector/`—System metric collection (realtime and batch)
+- `pkg/db/`—Ent ORM with SQLite backend
+- `pkg/agent/`—Centralized lifecycle management
+- `internal/protocol/`—Command and message protocol definitions
+- `internal/pool/`—Worker pool for concurrent tasks
 
 ## Code conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ Alpamon is a lightweight Go-based server agent for Alpacon—the infrastructure 
 
 - **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
 - **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
-- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word").
+- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word"). Use colons instead of em-dashes for itemized descriptions (e.g., "`shell/`: description").
 
 ## Architecture
 
@@ -20,11 +20,11 @@ Commands flow through a handler-based executor pattern:
 4. `pkg/executor/executor.go` runs system commands with privilege demotion and timeout handling
 
 Key packages:
-- `pkg/collector/`—System metric collection (realtime and batch)
-- `pkg/db/`—Ent ORM with SQLite backend
-- `pkg/agent/`—Centralized lifecycle management
-- `internal/protocol/`—Command and message protocol definitions
-- `internal/pool/`—Worker pool for concurrent tasks
+- `pkg/collector/`: System metric collection (realtime and batch)
+- `pkg/db/`: Ent ORM with SQLite backend
+- `pkg/agent/`: Centralized lifecycle management
+- `internal/protocol/`: Command and message protocol definitions
+- `internal/pool/`: Worker pool for concurrent tasks
 
 ## Code conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+# Copilot instructions
+
+## Project overview
+
+Alpamon is a Go-based secure server agent for Alpacon. It collects system metrics and executes remote commands, communicating via WebSocket and storing metrics in SQLite (Ent ORM).
+
+## Writing conventions
+
+- **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
+- **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
+
+## Architecture
+
+Commands flow through a handler-based executor pattern:
+
+1. `pkg/runner/` receives WebSocket commands
+2. `pkg/executor/dispatcher.go` routes to registered handlers via registry
+3. `pkg/executor/handlers/` contains modular handlers: shell, system, file, firewall, terminal, tunnel, user, group, info
+4. `pkg/executor/executor.go` runs system commands with privilege demotion and timeout handling
+
+Key packages:
+- `pkg/collector/` — System metric collection (realtime and batch)
+- `pkg/db/` — Ent ORM with SQLite backend
+- `pkg/agent/` — Centralized lifecycle management
+- `internal/protocol/` — Command and message protocol definitions
+- `internal/pool/` — Worker pool for concurrent tasks
+
+## Code conventions
+
+- Run `go test -v ./... -p 1` for tests (sequential due to SQLite locking)
+- Run Ent code generation after schema changes; never edit `pkg/db/ent/` manually
+- Platform-specific files use `_darwin.go` / `_linux.go` suffixes
+- Timeout exit code is 124 (GNU `timeout` convention)
+- Default shell command timeout is 30 minutes
+- Firewall operations: backup state before changes, rollback on failure

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Alpamon is a Go-based secure server agent for Alpacon. It collects system metrics and executes remote commands, communicating via WebSocket and storing metrics in SQLite (Ent ORM).
+Alpamon is a lightweight Go-based server agent for Alpacon — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. It establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution. Metrics are stored locally in SQLite (Ent ORM).
 
 ## Writing conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Commands from the Alpacon console flow through:
 - User privilege demotion for safer command execution
 - Firewall state backup before rule changes with automatic rollback on failure
 - Command argument validation in executor handlers
-- WebSocket message validation via protocol package
+- JSON message parsing and envelope checks via protocol package
 - PID file management and signal handling
 
 ## Key patterns
@@ -154,11 +154,11 @@ type Handler interface {
     Name() string
     Commands() []string
     Execute(ctx context.Context, cmd string, args *CommandArgs) (int, string, error)
-    Close() error
+    Validate(cmd string, args *CommandArgs) error
 }
 
 // Handlers are registered in the factory and dispatched via registry
-dispatcher := executor.NewCommandDispatcher(wsClient, executor)
+dispatcher := executor.NewCommandDispatcher(pool, ctxManager)
 ```
 
 ### Database operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## Project overview
 
 Alpamon is a Go-based secure server agent for Alpacon that collects system metrics and executes remote commands. It runs as a daemon that communicates with the Alpacon console via WebSocket connections and stores metrics in a local SQLite database using Ent ORM.
 
-## Development Commands
+## Writing conventions
 
-### Code Generation
+- **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
+- **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
+
+## Development commands
+
+### Code generation
 ```bash
 # Generate Ent schema code (required before building)
 go run -mod=mod entgo.io/ent/cmd/ent@v0.14.5 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
@@ -17,7 +22,7 @@ go run -mod=mod entgo.io/ent/cmd/ent@v0.14.5 generate --feature sql/modifier --t
 go generate ./pkg/db/ent
 ```
 
-### Database Schema Changes (Development Only)
+### Database schema changes (development only)
 ```bash
 # Install Atlas CLI (only needed for generating new migration files)
 curl -sSf https://atlasgo.sh | sh
@@ -35,8 +40,7 @@ atlas migrate diff <migration_name> \
 ### Building
 ```bash
 # Build the main binary
-cd cmd/alpamon
-go build -v .
+go build -v ./cmd/alpamon
 
 # Install dependencies
 go mod tidy
@@ -51,18 +55,17 @@ go test -v ./... -p 1
 go test -v ./pkg/collector/check/realtime/cpu
 ```
 
-### Running Locally
+### Running locally
 ```bash
-# Run from source (ensure you're in cmd/alpamon directory)
-cd cmd/alpamon
-go run main.go
+# Run from source
+go run ./cmd/alpamon
 
 # Configuration file locations (in order of precedence):
 # - ~/.alpamon.conf (development)
 # - /etc/alpamon/alpamon.conf (production)
 ```
 
-### Docker Testing
+### Docker testing
 ```bash
 # Build all distribution images
 ./Dockerfiles/build.sh
@@ -71,95 +74,120 @@ go run main.go
 docker run alpamon:ubuntu-22.04
 ```
 
-## Architecture Overview
+## Architecture overview
 
-### Core Components
+### Command execution (executor pattern)
 
-**Runner Package (`pkg/runner/`)**
-- `WebsocketClient`: Maintains WebSocket connection to Alpacon console
-- `command.go`: Command execution with privilege escalation/demotion
-- `shell.go`: Shell command execution with stdin/stdout handling
-- `firewall_backup.go`: Firewall state backup/restore using iptables/nftables
-- `ftp.go`: FTP server functionality for file transfers
+Commands from the Alpacon console flow through:
 
-**Collector Package (`pkg/collector/`)**
-- **Realtime collectors**: CPU, memory, disk I/O, network traffic metrics
-- **Batch collectors**: Hourly and daily aggregated metrics
-- **Scheduler**: Metric collection scheduling and coordination
-- **Transporter**: Metric transmission to Alpacon console
+1. `pkg/runner/` receives WebSocket commands and dispatches them
+2. `pkg/executor/dispatcher.go` routes commands to registered handlers via the registry
+3. `pkg/executor/handlers/` contains modular handlers for each command domain:
+   - `shell/` — Shell command execution (supports `/bin/sh -c` via `allow_sh` flag)
+   - `system/` — System operations (upgrade, restart, reboot, shutdown)
+   - `file/` — File upload/download
+   - `firewall/` — Firewall rule management (iptables/nftables)
+   - `terminal/` — PTY session management
+   - `tunnel/` — Tunnel operations
+   - `user/` — User management
+   - `group/` — Group management
+   - `info/` — System info queries (ping, help, commit, sync)
+   - `common/` — Shared interfaces, types, base handler, and test utilities
+4. `pkg/executor/executor.go` runs system commands with privilege demotion, environment setup, and timeout handling (exit code 124 on timeout)
 
-**Database Layer (`pkg/db/`)**
-- **Ent ORM**: Code-generated database models and queries
-- **Schema definitions**: Located in `pkg/db/schema/`
-- **Migrations**: Versioned schema changes in `pkg/db/migration/`
-- **SQLite backend**: Local storage with automatic migration
+### Core packages
+
+**Runner (`pkg/runner/`)**
+- `WebsocketClient`: WebSocket connection to Alpacon console
+- `command.go`: Command dispatch to executor handlers
+- `ftp.go`: FTP server for file transfers
+- `terminal_manager.go`: PTY session lifecycle
+- `tunnel_client.go`, `tunnel_daemon.go`: Tunnel operations
+- `auth_manager.go`: PAM authentication and sudo approval
+
+**Collector (`pkg/collector/`)**
+- `check/realtime/` — CPU, memory, disk I/O, network traffic (via gopsutil)
+- `check/batch/hourly/`, `check/batch/daily/` — Aggregated metrics
+- `scheduler/` — Collection scheduling
+- `transporter/` — Metric transmission to Alpacon console
+
+**Database (`pkg/db/`)**
+- Ent ORM with code-generated models (`pkg/db/ent/`)
+- Schema definitions in `pkg/db/schema/`
+- Versioned SQL migrations in `pkg/db/migration/`
+- SQLite backend with automatic migration
+
+**Agent (`pkg/agent/`)**
+- `ContextManager`: Centralized lifecycle and graceful shutdown
+
+**Internal packages (`internal/`)**
+- `protocol/` — Command and message protocol definitions
+- `pool/` — Worker pool for concurrent task execution
 
 **Configuration (`pkg/config/`)**
 - INI-based configuration parsing
 - Environment variable support
-- Multi-location config file loading
 
-### Data Flow
+### Data flow
 
 1. **Startup**: Agent initializes database, establishes WebSocket connection
-2. **Metric Collection**: Scheduled collectors gather system metrics → local database
-3. **Command Execution**: WebSocket receives commands → runner executes → results sent back
-4. **Firewall Management**: Backup/restore operations for iptables/nftables rules
-5. **FTP Operations**: File transfer capabilities with authentication
+2. **Metric collection**: Scheduled collectors gather system metrics → local database
+3. **Command execution**: WebSocket receives commands → dispatcher routes to handler → results sent back
+4. **Firewall management**: Backup/restore operations for iptables/nftables rules
+5. **File transfers**: FTP server with authentication
 
-### Security Architecture
+### Security architecture
 
-**Privilege Management**
 - Root execution for system-level operations
-- User demotion for safer command execution
+- User privilege demotion for safer command execution
+- Firewall state backup before rule changes with automatic rollback on failure
+- Command argument validation in executor handlers
+- WebSocket message validation via protocol package
 - PID file management and signal handling
 
-**Firewall Operations**
-- State backup before rule changes
-- Automatic rollback on failure
-- Support for both iptables and nftables
+## Key patterns
 
-**Input Validation**
-- Command argument sanitization in runner package
-- WebSocket message validation
-- Configuration parameter validation
-
-## Key Patterns
-
-### Command Execution
+### Handler-based command execution
 ```go
-// Standard command execution
-exitCode, output := runCmdWithOutput([]string{"command", "args"}, user, group, env, timeout)
+// Handlers implement the common.Handler interface
+type Handler interface {
+    Name() string
+    Commands() []string
+    Execute(ctx context.Context, cmd string, args *CommandArgs) (int, string, error)
+    Close() error
+}
 
-// Command with stdin input (for firewall rules, etc.)
-exitCode, output := runCmdWithOutputAndInput([]string{"command"}, inputData, user, group, env, timeout)
+// Handlers are registered in the factory and dispatched via registry
+dispatcher := executor.NewCommandDispatcher(wsClient, executor)
 ```
 
-### Database Operations
+### Database operations
 ```go
 // Ent client usage
 client := db.InitDB()
 cpu := client.CPU.Create().SetUsage(usage).SetTimestamp(time.Now()).SaveX(ctx)
 ```
 
-### Metric Collection
+### Metric collection
 - Collectors implement `Check` interface with `Collect()` method
-- Realtime: Direct system calls using `gopsutil`
+- Realtime: Direct system calls using gopsutil
 - Batch: Database aggregation queries for hourly/daily summaries
 
-### WebSocket Communication
+### WebSocket communication
 - JSON message protocol with command/response pattern
 - Automatic reconnection with exponential backoff
 - Context-based cancellation for graceful shutdown
 
-## Important Implementation Notes
+## Important implementation notes
 
-**Ent Code Generation**: Always run Ent code generation after schema changes. The generated code in `pkg/db/ent/` should not be manually edited.
+**Ent code generation**: Always run Ent code generation after schema changes. The generated code in `pkg/db/ent/` should not be manually edited.
 
-**Testing Constraints**: Tests run with `-p 1` (sequential execution) due to SQLite database file locking and system resource measurement conflicts.
+**Testing constraints**: Tests run with `-p 1` (sequential execution) due to SQLite database file locking and system resource measurement conflicts.
 
-**Platform Compatibility**: Codebase includes platform-specific implementations (darwin/linux) for PTY and PID file operations.
+**Platform compatibility**: Codebase includes platform-specific implementations (darwin/linux) for PTY and PID file operations.
 
-**Firewall Operations**: Use `runCmdWithOutputAndInput` for piping rules via stdin to `nft -f -` and `iptables-restore` commands.
+**Firewall operations**: Use executor's `RunWithInput` for piping rules via stdin to `nft -f -` and `iptables-restore` commands.
 
-**Database Migrations**: Migration system uses direct SQL execution via Go's `database/sql` package. Migration files in `pkg/db/migration/` are pure SQLite SQL. The `RunMigration()` function tracks applied migrations in the `atlas_schema_revisions` table and executes unapplied migrations in transactions. No external tools required.
+**Database migrations**: Migration system uses direct SQL execution via Go's `database/sql` package. Migration files in `pkg/db/migration/` are pure SQLite SQL. The `RunMigration()` function tracks applied migrations in the `atlas_schema_revisions` table and executes unapplied migrations in transactions. No external tools required.
+
+**Timeout handling**: Commands that exceed their timeout return exit code 124 with an elapsed time message, matching the GNU `timeout` convention. Default shell command timeout is 30 minutes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Alpamon is a lightweight Go-based server agent for Alpacon — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. Installed on each server, it establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution without VPNs or SSH keys. It stores metrics locally in SQLite using Ent ORM.
+Alpamon is a lightweight Go-based server agent for Alpacon—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. Installed on each server, it establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution without VPNs or SSH keys. Every action is supervised and audited for compliance. It stores metrics locally in SQLite using Ent ORM.
 
 ## Writing conventions
 
 - **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
 - **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
+- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word").
 
 ## Development commands
 
@@ -83,16 +84,16 @@ Commands from the Alpacon console flow through:
 1. `pkg/runner/` receives WebSocket commands and dispatches them
 2. `pkg/executor/dispatcher.go` routes commands to registered handlers via the registry
 3. `pkg/executor/handlers/` contains modular handlers for each command domain:
-   - `shell/` — Shell command execution (supports `/bin/sh -c` via `allow_sh` flag)
-   - `system/` — System operations (upgrade, restart, reboot, shutdown)
-   - `file/` — File upload/download
-   - `firewall/` — Firewall rule management (iptables/nftables)
-   - `terminal/` — PTY session management
-   - `tunnel/` — Tunnel operations
-   - `user/` — User management
-   - `group/` — Group management
-   - `info/` — System info queries (ping, help, commit, sync)
-   - `common/` — Shared interfaces, types, base handler, and test utilities
+   - `shell/`—Shell command execution (supports `/bin/sh -c` via `allow_sh` flag)
+   - `system/`—System operations (upgrade, restart, reboot, shutdown)
+   - `file/`—File upload/download
+   - `firewall/`—Firewall rule management (iptables/nftables)
+   - `terminal/`—PTY session management
+   - `tunnel/`—Tunnel operations
+   - `user/`—User management
+   - `group/`—Group management
+   - `info/`—System info queries (ping, help, commit, sync)
+   - `common/`—Shared interfaces, types, base handler, and test utilities
 4. `pkg/executor/executor.go` runs system commands with privilege demotion, environment setup, and timeout handling (exit code 124 on timeout)
 
 ### Core packages
@@ -106,10 +107,10 @@ Commands from the Alpacon console flow through:
 - `auth_manager.go`: PAM authentication and sudo approval
 
 **Collector (`pkg/collector/`)**
-- `check/realtime/` — CPU, memory, disk I/O, network traffic (via gopsutil)
-- `check/batch/hourly/`, `check/batch/daily/` — Aggregated metrics
-- `scheduler/` — Collection scheduling
-- `transporter/` — Metric transmission to Alpacon console
+- `check/realtime/`—CPU, memory, disk I/O, network traffic (via gopsutil)
+- `check/batch/hourly/`, `check/batch/daily/`—Aggregated metrics
+- `scheduler/`—Collection scheduling
+- `transporter/`—Metric transmission to Alpacon console
 
 **Database (`pkg/db/`)**
 - Ent ORM with code-generated models (`pkg/db/ent/`)
@@ -121,8 +122,8 @@ Commands from the Alpacon console flow through:
 - `ContextManager`: Centralized lifecycle and graceful shutdown
 
 **Internal packages (`internal/`)**
-- `protocol/` — Command and message protocol definitions
-- `pool/` — Worker pool for concurrent task execution
+- `protocol/`—Command and message protocol definitions
+- `pool/`—Worker pool for concurrent task execution
 
 **Configuration (`pkg/config/`)**
 - INI-based configuration parsing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Alpamon is a lightweight Go-based server agent for Alpacon—the infrastructure 
 
 - **Product names**: Use "Websh" (not "WebSH", "websh", or "WEBSH"). Proper nouns like Alpamon, Alpacon, and Websh should always be capitalized as shown.
 - **Sentence case**: Use sentence case for all headings, labels, and documentation (e.g., "Architecture overview" not "Architecture Overview"). Only capitalize the first word and proper nouns.
-- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word").
+- **Em-dashes**: No spaces around em-dashes (e.g., "word—word" not "word — word"). Use colons instead of em-dashes for itemized descriptions (e.g., "`shell/`: description").
 
 ## Development commands
 
@@ -84,16 +84,16 @@ Commands from the Alpacon console flow through:
 1. `pkg/runner/` receives WebSocket commands and dispatches them
 2. `pkg/executor/dispatcher.go` routes commands to registered handlers via the registry
 3. `pkg/executor/handlers/` contains modular handlers for each command domain:
-   - `shell/`—Shell command execution (supports `/bin/sh -c` via `allow_sh` flag)
-   - `system/`—System operations (upgrade, restart, reboot, shutdown)
-   - `file/`—File upload/download
-   - `firewall/`—Firewall rule management (iptables/nftables)
-   - `terminal/`—PTY session management
-   - `tunnel/`—Tunnel operations
-   - `user/`—User management
-   - `group/`—Group management
-   - `info/`—System info queries (ping, help, commit, sync)
-   - `common/`—Shared interfaces, types, base handler, and test utilities
+   - `shell/`: Shell command execution (supports `/bin/sh -c` via `allow_sh` flag)
+   - `system/`: System operations (upgrade, restart, reboot, shutdown)
+   - `file/`: File upload/download
+   - `firewall/`: Firewall rule management (iptables/nftables)
+   - `terminal/`: PTY session management
+   - `tunnel/`: Tunnel operations
+   - `user/`: User management
+   - `group/`: Group management
+   - `info/`: System info queries (ping, help, commit, sync)
+   - `common/`: Shared interfaces, types, base handler, and test utilities
 4. `pkg/executor/executor.go` runs system commands with privilege demotion, environment setup, and timeout handling (exit code 124 on timeout)
 
 ### Core packages
@@ -107,10 +107,10 @@ Commands from the Alpacon console flow through:
 - `auth_manager.go`: PAM authentication and sudo approval
 
 **Collector (`pkg/collector/`)**
-- `check/realtime/`—CPU, memory, disk I/O, network traffic (via gopsutil)
-- `check/batch/hourly/`, `check/batch/daily/`—Aggregated metrics
-- `scheduler/`—Collection scheduling
-- `transporter/`—Metric transmission to Alpacon console
+- `check/realtime/`: CPU, memory, disk I/O, network traffic (via gopsutil)
+- `check/batch/hourly/`, `check/batch/daily/`: Aggregated metrics
+- `scheduler/`: Collection scheduling
+- `transporter/`: Metric transmission to Alpacon console
 
 **Database (`pkg/db/`)**
 - Ent ORM with code-generated models (`pkg/db/ent/`)
@@ -122,8 +122,8 @@ Commands from the Alpacon console flow through:
 - `ContextManager`: Centralized lifecycle and graceful shutdown
 
 **Internal packages (`internal/`)**
-- `protocol/`—Command and message protocol definitions
-- `pool/`—Worker pool for concurrent task execution
+- `protocol/`: Command and message protocol definitions
+- `pool/`: Worker pool for concurrent task execution
 
 **Configuration (`pkg/config/`)**
 - INI-based configuration parsing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-Alpamon is a Go-based secure server agent for Alpacon that collects system metrics and executes remote commands. It runs as a daemon that communicates with the Alpacon console via WebSocket connections and stores metrics in a local SQLite database using Ent ORM.
+Alpamon is a lightweight Go-based server agent for Alpacon — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines. Installed on each server, it establishes an outbound-only WebSocket connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution without VPNs or SSH keys. It stores metrics locally in SQLite using Ent ORM.
 
 ## Writing conventions
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Alpamon
-New Go-based Secure Server Agent for Alpacon
+New Go-based secure server agent for Alpacon
 
 **Alpamon** is a server agent for **Alpacon**. Each server should have Alpamon installed to be controlled via Alpacon.
 
 This guide outlines the step-by-step process for installing Alpamon within a development environment. The installation requires an active Internet connection or the appropriate configuration of a proxy server.
 
-## System Requirements
+## System requirements
 
 To run Alpamon, ensure your system meets the following requirements:
 - Operating system: Linux, macOS, or Windows (via WSL)
@@ -39,9 +39,9 @@ sudo yum install alpamon
 > [!TIP]
 > To use Alpacon-managed sudo authentication, install the optional PAM module:
 > `sudo apt-get install alpamon-pam` (Debian/Ubuntu) or `sudo yum install alpamon-pam` (CentOS/RHEL).
-> See [PAM Module](#pam-module) for details.
+> See [PAM module](#pam-module) for details.
 
-### PAM Module
+### PAM module
 
 The optional `alpamon-pam` package provides PAM (Pluggable Authentication Modules) integration for Alpacon-managed sudo authentication:
 - **pam_alpamon.so**: Verifies Alpacon users during sudo authentication
@@ -83,13 +83,13 @@ To get started on macOS, clone the source code from the repository:
 git clone https://github.com/alpacax/alpamon.git
 ```
 
-#### Generate Ent Schema Code with Entgo
+#### Generate Ent schema code with Entgo
 To generate Ent schema code with custom features, navigate to the root of the project and use the following command:
 ```bash
 go run -mod=mod entgo.io/ent/cmd/ent@v0.14.2 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
 ```
 
-#### Install Atlas CLI (Development Only)
+#### Install Atlas CLI (development only)
 Atlas CLI is **only required for development** when you need to generate new migration files after modifying database schemas in `pkg/db/schema/`. Production deployments do not require Atlas CLI as migrations are executed directly from embedded SQL files.
 
 To install Atlas CLI for development:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Alpamon
-New Go-based secure server agent for Alpacon
 
-**Alpamon** is a server agent for **Alpacon**. Each server should have Alpamon installed to be controlled via Alpacon.
+**Alpamon** is a lightweight server agent for [Alpacon](https://www.alpacax.com) — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
 
-This guide outlines the step-by-step process for installing Alpamon within a development environment. The installation requires an active Internet connection or the appropriate configuration of a proxy server.
+Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution — all without VPNs, SSH keys, or firewall changes.
+
+This guide outlines the step-by-step process for installing Alpamon within a development environment.
 
 ## System requirements
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Alpamon
 
-**Alpamon** is a lightweight server agent for [Alpacon](https://www.alpacax.com) — the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
+**Alpamon** is a lightweight server agent for [Alpacon](https://www.alpacax.com)—the infrastructure access platform that provides secure, unified server access for humans, AI agents, and CI/CD pipelines.
 
-Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution — all without VPNs, SSH keys, or firewall changes.
+Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution—all without VPNs, SSH keys, or firewall changes. Every action is supervised and audited for compliance.
 
 This guide outlines the step-by-step process for installing Alpamon within a development environment.
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ This guide outlines the step-by-step process for installing Alpamon within a dev
 
 To run Alpamon, ensure your system meets the following requirements:
 - Operating system: Linux, macOS, or Windows (via WSL)
-- Go version: 1.24.4 or higher
+- Go version: 1.25.7 or higher
 - Memory: At least 512MB RAM
 - Disk space: At least 100MB free space
 
 ## Getting started
 To build Alpamon, ensure you have:
-- [Go](https://go.dev/doc/install) version 1.24.4 or higher installed(required for building).
-  - The module is compatible with Go **1.23** and above for usage (importing and running pre-built binaries).
+- [Go](https://go.dev/doc/install) version 1.25.7 or higher installed (required for building).
   - Make sure `$GOPATH` is set and `$GOPATH/bin` is added to your system’s `PATH`.
   
 ## Installation
@@ -87,7 +86,7 @@ git clone https://github.com/alpacax/alpamon.git
 #### Generate Ent schema code with Entgo
 To generate Ent schema code with custom features, navigate to the root of the project and use the following command:
 ```bash
-go run -mod=mod entgo.io/ent/cmd/ent@v0.14.2 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
+go run -mod=mod entgo.io/ent/cmd/ent@v0.14.5 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
 ```
 
 #### Install Atlas CLI (development only)


### PR DESCRIPTION
## Summary
- Rewrite CLAUDE.md to reflect current executor/handler architecture, new packages (agent, internal/protocol, internal/pool), and updated command patterns
- Create `.github/copilot-instructions.md` with project context and coding conventions
- Add writing conventions: Websh naming (not WebSH) and sentence case rule
- Apply sentence case to README.md headings

## Test plan
- [ ] Verify CLAUDE.md accurately describes current codebase structure
- [ ] Verify copilot-instructions.md is picked up by GitHub Copilot
- [ ] Confirm all headings follow sentence case convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)