### PR TITLE
fix: check alpamon and pam versions independently during upgrade

### DIFF
--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -81,7 +81,7 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
 	latestVersion := utils.GetLatestVersion()
 	if latestVersion == "" {
-		return 1, "Failed to retrieve the latest version from GitHub.", nil
+		return 1, "", fmt.Errorf("failed to retrieve the latest Alpamon version from GitHub")
 	}
 
 	needAlpamon := version.Version != latestVersion
@@ -90,7 +90,11 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	needPam := currentPamVersion != "" && currentPamVersion != latestVersion
 
 	if !needAlpamon && !needPam {
-		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: %s)", version.Version, currentPamVersion), nil
+		pamDisplay := currentPamVersion
+		if pamDisplay == "" {
+			pamDisplay = "not installed"
+		}
+		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: %s)", version.Version, pamDisplay), nil
 	}
 
 	var packages []string

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -81,7 +81,8 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
 	latestVersion := utils.GetLatestVersion()
 	if latestVersion == "" {
-		return 1, "", fmt.Errorf("failed to retrieve the latest Alpamon version from GitHub")
+		msg := "Failed to retrieve the latest Alpamon version from GitHub."
+		return 1, msg, fmt.Errorf("%s", msg)
 	}
 
 	needAlpamon := version.Version != latestVersion

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -80,10 +80,14 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 // alpamon is already at the latest version.
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
 	latestVersion := utils.GetLatestVersion()
-	needAlpamon := latestVersion != "" && version.Version != latestVersion
+	if latestVersion == "" {
+		return 1, "Failed to retrieve the latest version from GitHub.", nil
+	}
+
+	needAlpamon := version.Version != latestVersion
 
 	currentPamVersion := utils.GetPamVersion()
-	needPam := currentPamVersion != "" && latestVersion != "" && currentPamVersion != latestVersion
+	needPam := currentPamVersion != "" && currentPamVersion != latestVersion
 
 	if !needAlpamon && !needPam {
 		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: %s)", version.Version, currentPamVersion), nil
@@ -110,7 +114,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 
 	log.Debug().Msgf("Upgrading %s...", pkgList)
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
-	if exitCode == 0 {
+	if exitCode == 0 && needPam {
 		utils.InvalidatePamCache()
 	}
 	return exitCode, output, err

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -82,7 +83,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	latestVersion := utils.GetLatestVersion()
 	if latestVersion == "" {
 		msg := "Failed to retrieve the latest Alpamon version from GitHub."
-		return 1, msg, fmt.Errorf("%s", msg)
+		return 1, msg, errors.New(msg)
 	}
 
 	needAlpamon := version.Version != latestVersion

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -82,8 +82,8 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
 	latestVersion := utils.GetLatestVersion()
 	if latestVersion == "" {
-		msg := "Failed to retrieve the latest Alpamon version from GitHub."
-		return 1, msg, errors.New(msg)
+		return 1, "Failed to retrieve the latest Alpamon version from GitHub.",
+			errors.New("failed to retrieve the latest Alpamon version from GitHub")
 	}
 
 	needAlpamon := version.Version != latestVersion

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/alpacax/alpamon/internal/pool"
@@ -73,27 +74,45 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 	return nil
 }
 
-// handleUpgrade handles the upgrade command
+// handleUpgrade handles the upgrade command.
+// It checks alpamon and alpamon-pam versions independently and upgrades only
+// the packages that need it. This prevents skipping a pam-only upgrade when
+// alpamon is already at the latest version.
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
 	latestVersion := utils.GetLatestVersion()
+	needAlpamon := latestVersion != "" && version.Version != latestVersion
 
-	if version.Version == latestVersion {
-		return 0, fmt.Sprintf("Alpamon is already up-to-date (version: %s)", version.Version), nil
+	currentPamVersion := utils.GetPamVersion()
+	needPam := currentPamVersion != "" && latestVersion != "" && currentPamVersion != latestVersion
+
+	if !needAlpamon && !needPam {
+		return 0, fmt.Sprintf("Already up-to-date (alpamon: %s, pam: %s)", version.Version, currentPamVersion), nil
 	}
+
+	var packages []string
+	if needAlpamon {
+		packages = append(packages, "alpamon")
+	}
+	if needPam {
+		packages = append(packages, "alpamon-pam")
+	}
+	pkgList := strings.Join(packages, " ")
 
 	var cmd string
 	switch utils.PlatformLike {
 	case "debian":
-		cmd = "apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade alpamon alpamon-pam -y -o Acquire::Retries=3"
+		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
 	case "rhel":
-		cmd = "yum update -y alpamon alpamon-pam"
+		cmd = fmt.Sprintf("yum update -y %s", pkgList)
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
 	}
 
-	log.Debug().Msgf("Upgrading alpamon from %s to %s using command: '%s'...", version.Version, latestVersion, cmd)
-
+	log.Debug().Msgf("Upgrading %s...", pkgList)
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	if exitCode == 0 {
+		utils.InvalidatePamCache()
+	}
 	return exitCode, output, err
 }
 

--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -19,6 +19,15 @@ var (
 	pamCacheMutex sync.Mutex
 )
 
+// InvalidatePamCache clears the cached pam version so the next call to
+// GetPamVersion will re-query the system. Call this after upgrading alpamon-pam
+// to avoid reporting a stale version for up to pamCacheTTL.
+func InvalidatePamCache() {
+	pamCacheMutex.Lock()
+	defer pamCacheMutex.Unlock()
+	pamCacheTime = time.Time{}
+}
+
 // GetPamVersion returns the installed alpamon-pam package version.
 // Returns empty string if the package is not installed.
 // Results are cached with a TTL to avoid spawning external processes on every sync.

--- a/pkg/utils/pam.go
+++ b/pkg/utils/pam.go
@@ -25,6 +25,7 @@ var (
 func InvalidatePamCache() {
 	pamCacheMutex.Lock()
 	defer pamCacheMutex.Unlock()
+	pamCache = ""
 	pamCacheTime = time.Time{}
 }
 


### PR DESCRIPTION
## Summary

- `handleUpgrade()` previously only checked the alpamon version against the latest GitHub release. If alpamon was already up-to-date but alpamon-pam was outdated, the entire upgrade was skipped.
- Now each package version is checked independently, and only packages that actually need upgrading are included in the install command.
- Invalidates the pam version cache after a successful upgrade so the next sync cycle reports the correct version immediately (instead of waiting up to 3 hours).

## Changes

- **`pkg/executor/handlers/system/system.go`**: Modified `handleUpgrade()` to compare alpamon and pam versions independently, build a selective package list, and call `InvalidatePamCache()` on success.
- **`pkg/utils/pam.go`**: Added `InvalidatePamCache()` to clear the cached pam version after upgrade.

## Testing

- [x] `go build ./cmd/alpamon` passes
- [x] `go vet` passes on changed packages
- [x] `go test ./pkg/utils/ ./pkg/executor/handlers/system/ -p 1` all pass

---
Generated with AlpacaX Claude Plugin