### PR TITLE
fix(register): create required directories before starting service

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -285,6 +285,11 @@ debug = false
 }
 
 func startSystemdService() error {
+	// Create required directories via systemd-tmpfiles
+	if output, err := exec.Command("systemd-tmpfiles", "--create").CombinedOutput(); err != nil {
+		return fmt.Errorf("tmpfiles creation failed: %w\n%s", err, string(output))
+	}
+
 	// Reload systemd daemon
 	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
 		return fmt.Errorf("daemon-reload failed: %w", err)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -286,7 +286,7 @@ debug = false
 
 func startSystemdService() error {
 	// Create required directories via systemd-tmpfiles
-	if output, err := exec.Command("systemd-tmpfiles", "--create").CombinedOutput(); err != nil {
+	if output, err := exec.Command("systemd-tmpfiles", "--create", "alpamon.conf").CombinedOutput(); err != nil {
 		return fmt.Errorf("tmpfiles creation failed: %w\n%s", err, string(output))
 	}
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -291,18 +291,18 @@ func startSystemdService() error {
 	}
 
 	// Reload systemd daemon
-	if err := exec.Command("systemctl", "daemon-reload").Run(); err != nil {
-		return fmt.Errorf("daemon-reload failed: %w", err)
+	if output, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("daemon-reload failed: %w\n%s", err, string(output))
 	}
 
 	// Start the service
-	if err := exec.Command("systemctl", "start", "alpamon.service").Run(); err != nil {
-		return fmt.Errorf("start failed: %w", err)
+	if output, err := exec.Command("systemctl", "start", "alpamon.service").CombinedOutput(); err != nil {
+		return fmt.Errorf("start failed: %w\n%s", err, string(output))
 	}
 
 	// Enable the service
-	if err := exec.Command("systemctl", "enable", "alpamon.service").Run(); err != nil {
-		return fmt.Errorf("enable failed: %w", err)
+	if output, err := exec.Command("systemctl", "enable", "alpamon.service").CombinedOutput(); err != nil {
+		return fmt.Errorf("enable failed: %w\n%s", err, string(output))
 	}
 
 	fmt.Println("Alpamon service started and enabled.")


### PR DESCRIPTION
## Summary

- Add `systemd-tmpfiles --create` call in `startSystemdService()` before `systemctl daemon-reload` to create required directories (`/var/lib/alpamon`, `/var/log/alpamon`, `/var/run/alpamon`)
- This fixes the service failing with `CHDIR` error because `WorkingDirectory=/var/lib/alpamon` does not exist

## Root cause

PR #180 added the `register` command and changed `postinstall.sh` to skip `setup_alpamon()` for generic installations (no `PLUGIN_ID`/`PLUGIN_KEY` env vars). However, `setup_alpamon()` was responsible for calling `alpamon setup`, which calls `systemd-tmpfiles --create` to create required directories. The `register` command did not include this step, leaving the directories uncreated.

## Changes

- `cmd/alpamon/command/register/register.go`: Add `systemd-tmpfiles --create` call in `startSystemdService()`, matching the existing pattern in `setup.go:64`

## Test plan

- [ ] Build: `go build -v ./cmd/alpamon`
- [ ] Unit tests: `go test -v ./cmd/alpamon/command/register/ -p 1`
- [ ] Debian: install alpamon via apt, run `alpamon register`, verify service starts
- [ ] RHEL: install alpamon via yum, run `alpamon register`, verify service starts

Closes #237
