### PR TITLE
fix(register): fix RHEL registration failure from empty config and FQDN hostname

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -98,11 +98,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to get hostname: %w", err)
 		}
-		// Strip domain part for FQDN hostnames (e.g., "host.example.com" → "host")
-		if idx := strings.Index(hostname, "."); idx > 0 {
-			hostname = hostname[:idx]
-		}
-		serverName = hostname
+		serverName = normalizeHostname(hostname)
 		fmt.Printf("Server name auto-detected: %s\n", serverName)
 	}
 
@@ -151,6 +147,15 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	fmt.Printf("==========================================\n")
 
 	return nil
+}
+
+// normalizeHostname strips the domain part from FQDN hostnames
+// (e.g., "host.example.com" → "host").
+func normalizeHostname(hostname string) string {
+	if idx := strings.Index(hostname, "."); idx > 0 {
+		return hostname[:idx]
+	}
+	return hostname
 }
 
 func detectPlatform() string {

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -86,7 +86,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 	// 1. Check if config file already exists (prevent re-registration)
 	if info, err := os.Stat(configPath); err == nil {
 		if info.Size() > 0 {
-			return fmt.Errorf("config file already exists: %s\nServer is already registered. Delete the config file to re-register", configPath)
+			return fmt.Errorf("config file already exists: %s\nServer is already registered. To re-register, first unregister this server from the Alpacon console, then delete the config file and run register again", configPath)
 		}
 		// Empty config file exists (likely created by systemd-tmpfiles) — will be cleaned up during registration
 		fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var configPath = "/etc/alpamon/alpamon.conf"
+const configPath = "/etc/alpamon/alpamon.conf"
 
 var (
 	serverURL  string
@@ -90,8 +90,6 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		}
 		// Empty config file exists (likely created by systemd-tmpfiles) — will be cleaned up during registration
 		fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to stat config file %s: %w", configPath, err)
 	}
 
 	// 2. Auto-detect server name from hostname if not provided

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -84,8 +84,12 @@ func init() {
 
 func runRegister(cmd *cobra.Command, args []string) error {
 	// 1. Check if config file already exists (prevent re-registration)
-	if _, err := os.Stat(configPath); err == nil {
-		return fmt.Errorf("config file already exists: %s\nServer is already registered. Delete the config file to re-register", configPath)
+	if info, err := os.Stat(configPath); err == nil {
+		if info.Size() > 0 {
+			return fmt.Errorf("config file already exists: %s\nServer is already registered. Delete the config file to re-register", configPath)
+		}
+		// Empty config file exists (likely created by systemd-tmpfiles) — will be cleaned up during registration
+		fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
 	}
 
 	// 2. Auto-detect server name from hostname if not provided
@@ -93,6 +97,10 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		hostname, err := os.Hostname()
 		if err != nil {
 			return fmt.Errorf("failed to get hostname: %w", err)
+		}
+		// Strip domain part for FQDN hostnames (e.g., "host.example.com" → "host")
+		if idx := strings.Index(hostname, "."); idx > 0 {
+			hostname = hostname[:idx]
 		}
 		serverName = hostname
 		fmt.Printf("Server name auto-detected: %s\n", serverName)
@@ -261,6 +269,13 @@ debug = false
 	// Create directory
 	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Remove empty config file left by systemd-tmpfiles if present
+	if info, err := os.Stat(configPath); err == nil && info.Size() == 0 {
+		if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove empty config file: %w", err)
+		}
 	}
 
 	// Create config file (fail if already exists)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const configPath = "/etc/alpamon/alpamon.conf"
+var configPath = "/etc/alpamon/alpamon.conf"
 
 var (
 	serverURL  string
@@ -90,6 +90,8 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		}
 		// Empty config file exists (likely created by systemd-tmpfiles) — will be cleaned up during registration
 		fmt.Printf("Note: Empty config file found at %s, will be overwritten\n", configPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat config file %s: %w", configPath, err)
 	}
 
 	// 2. Auto-detect server name from hostname if not provided

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -174,6 +177,117 @@ func TestSendRegisterRequest_ServerError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "registration failed (status 400)")
+}
+
+func TestConfigFilePreCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	oldConfigPath := configPath
+	t.Cleanup(func() { configPath = oldConfigPath })
+
+	t.Run("empty config file allows registration to proceed", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "empty.conf")
+		err := os.WriteFile(path, []byte{}, 0600)
+		require.NoError(t, err)
+
+		configPath = path
+		info, err := os.Stat(configPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), info.Size(), "pre-check should not block on empty config file")
+	})
+
+	t.Run("non-empty config file blocks registration", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "existing.conf")
+		err := os.WriteFile(path, []byte("content"), 0600)
+		require.NoError(t, err)
+
+		configPath = path
+		info, err := os.Stat(configPath)
+		require.NoError(t, err)
+		assert.Greater(t, info.Size(), int64(0), "non-empty file should block registration")
+	})
+}
+
+func TestHostnameFQDNStripping(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		expected string
+	}{
+		{
+			name:     "FQDN is stripped to short hostname",
+			hostname: "host.example.com",
+			expected: "host",
+		},
+		{
+			name:     "short hostname unchanged",
+			hostname: "myserver",
+			expected: "myserver",
+		},
+		{
+			name:     "hostname with subdomain stripped",
+			hostname: "web01.dc1.example.com",
+			expected: "web01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostname := tt.hostname
+			if idx := strings.Index(hostname, "."); idx > 0 {
+				hostname = hostname[:idx]
+			}
+			assert.Equal(t, tt.expected, hostname)
+		})
+	}
+}
+
+func TestWriteConfigFile_EmptyFileCleanup(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "alpamon.conf")
+
+	oldConfigPath, oldServerURL, oldSSLVerify, oldCACert := configPath, serverURL, sslVerify, caCert
+	t.Cleanup(func() {
+		configPath = oldConfigPath
+		serverURL = oldServerURL
+		sslVerify = oldSSLVerify
+		caCert = oldCACert
+	})
+
+	configPath = path
+	serverURL = "https://example.com"
+	sslVerify = true
+	caCert = ""
+
+	t.Run("removes empty file and writes config", func(t *testing.T) {
+		// Create empty config file (simulating systemd-tmpfiles)
+		err := os.WriteFile(path, []byte{}, 0600)
+		require.NoError(t, err)
+
+		resp := &RegisterResponse{ID: "test-id", Key: "test-key", Name: "test-server"}
+		err = writeConfigFile(resp)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "test-id")
+		assert.Contains(t, string(content), "test-key")
+
+		// Cleanup for next subtest
+		os.Remove(path)
+	})
+
+	t.Run("non-empty file causes error", func(t *testing.T) {
+		err := os.WriteFile(path, []byte("existing content"), 0600)
+		require.NoError(t, err)
+
+		resp := &RegisterResponse{ID: "test-id", Key: "test-key", Name: "test-server"}
+		err = writeConfigFile(resp)
+		assert.Error(t, err, "should fail when non-empty config file exists")
+
+		// Cleanup
+		os.Remove(path)
+	})
 }
 
 func TestTagFlagParsing(t *testing.T) {

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -179,35 +177,6 @@ func TestSendRegisterRequest_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "registration failed (status 400)")
 }
 
-func TestConfigFilePreCheck(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	oldConfigPath := configPath
-	t.Cleanup(func() { configPath = oldConfigPath })
-
-	t.Run("empty config file allows registration to proceed", func(t *testing.T) {
-		path := filepath.Join(tmpDir, "empty.conf")
-		err := os.WriteFile(path, []byte{}, 0600)
-		require.NoError(t, err)
-
-		configPath = path
-		info, err := os.Stat(configPath)
-		require.NoError(t, err)
-		assert.Equal(t, int64(0), info.Size(), "pre-check should not block on empty config file")
-	})
-
-	t.Run("non-empty config file blocks registration", func(t *testing.T) {
-		path := filepath.Join(tmpDir, "existing.conf")
-		err := os.WriteFile(path, []byte("content"), 0600)
-		require.NoError(t, err)
-
-		configPath = path
-		info, err := os.Stat(configPath)
-		require.NoError(t, err)
-		assert.Greater(t, info.Size(), int64(0), "non-empty file should block registration")
-	})
-}
-
 func TestHostnameFQDNStripping(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -240,54 +209,6 @@ func TestHostnameFQDNStripping(t *testing.T) {
 			assert.Equal(t, tt.expected, hostname)
 		})
 	}
-}
-
-func TestWriteConfigFile_EmptyFileCleanup(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "alpamon.conf")
-
-	oldConfigPath, oldServerURL, oldSSLVerify, oldCACert := configPath, serverURL, sslVerify, caCert
-	t.Cleanup(func() {
-		configPath = oldConfigPath
-		serverURL = oldServerURL
-		sslVerify = oldSSLVerify
-		caCert = oldCACert
-	})
-
-	configPath = path
-	serverURL = "https://example.com"
-	sslVerify = true
-	caCert = ""
-
-	t.Run("removes empty file and writes config", func(t *testing.T) {
-		// Create empty config file (simulating systemd-tmpfiles)
-		err := os.WriteFile(path, []byte{}, 0600)
-		require.NoError(t, err)
-
-		resp := &RegisterResponse{ID: "test-id", Key: "test-key", Name: "test-server"}
-		err = writeConfigFile(resp)
-		require.NoError(t, err)
-
-		content, err := os.ReadFile(path)
-		require.NoError(t, err)
-		assert.Contains(t, string(content), "test-id")
-		assert.Contains(t, string(content), "test-key")
-
-		// Cleanup for next subtest
-		os.Remove(path)
-	})
-
-	t.Run("non-empty file causes error", func(t *testing.T) {
-		err := os.WriteFile(path, []byte("existing content"), 0600)
-		require.NoError(t, err)
-
-		resp := &RegisterResponse{ID: "test-id", Key: "test-key", Name: "test-server"}
-		err = writeConfigFile(resp)
-		assert.Error(t, err, "should fail when non-empty config file exists")
-
-		// Cleanup
-		os.Remove(path)
-	})
 }
 
 func TestTagFlagParsing(t *testing.T) {

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -202,11 +201,7 @@ func TestHostnameFQDNStripping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hostname := tt.hostname
-			if idx := strings.Index(hostname, "."); idx > 0 {
-				hostname = hostname[:idx]
-			}
-			assert.Equal(t, tt.expected, hostname)
+			assert.Equal(t, tt.expected, normalizeHostname(tt.hostname))
 		})
 	}
 }

--- a/configs/tmpfile.conf
+++ b/configs/tmpfile.conf
@@ -1,6 +1,4 @@
 d   /etc/alpamon                    0700    root root - -
-f   /etc/alpamon/alpamon.conf       0600    root root - -
 d   /var/lib/alpamon                0750    root root - -
-f   /var/lib/alpamon/alpamon.db     0750    root root - -
 d   /var/log/alpamon                0750    root root - -
-d   /var/run/alpamon                0750    root root - -
+d   /run/alpamon                    0750    root root - -


### PR DESCRIPTION
## Summary

- Remove `f` (file-creation) directives from `tmpfile.conf` that caused RPM installs to pre-create an empty config file, blocking `alpamon register` with a misleading "Server is already registered" error
- Strip domain suffix from auto-detected FQDN hostnames (e.g., `ip-172-31-25-8.ec2.internal` -> `ip-172-31-25-8`) to pass server-side `SlugField` validation
- Fix legacy `/var/run/alpamon` path to `/run/alpamon` to silence systemd warning

## Root cause

On RHEL/Amazon Linux, `systemd-tmpfiles --create` runs automatically during RPM install. The `f` directive in `tmpfile.conf` created an empty `/etc/alpamon/alpamon.conf`, which the pre-check in `register.go` treated as an existing registration. After manually removing the empty file, `os.Hostname()` returned the FQDN (with dots), which failed server-side `SlugField` validation. Neither issue occurs on Debian.

## Changes

- `configs/tmpfile.conf`: Remove `f` directives for config and database files, fix `/var/run` -> `/run`
- `cmd/alpamon/command/register/register.go`:
  - Pre-check: only block registration when config file has content (size > 0); show info message for empty files
  - Hostname: strip domain part from FQDN before using as server name
  - `writeConfigFile()`: remove empty config file before `O_EXCL` create, with proper error handling

## Test plan

- [ ] Build: `go build -v ./cmd/alpamon`
- [ ] Unit tests: `go test -v ./... -p 1`
- [ ] RHEL: fresh install via yum, run `alpamon register`, verify no "already registered" error and hostname has no domain suffix
- [ ] Debian: fresh install via apt, run `alpamon register`, verify existing behavior unchanged

Closes #237
