### PR TITLE
fix(auth): create socket directory fallback in startSocketListener

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -161,9 +161,13 @@ func (am *AuthManager) Start(ctx context.Context) {
 
 func (am *AuthManager) startSocketListener(ctx context.Context) error {
 	const socketPath = "/var/run/alpamon/auth.sock"
+	const socketDir = "/var/run/alpamon"
 
-	// systemd tmpfile will manage the /var/run/alpamon directory
-	// No need to create directory manually
+	// Ensure socket directory exists as a fallback when systemd-tmpfiles
+	// has not run yet (e.g., service restart after package upgrade without reboot).
+	if err := os.MkdirAll(socketDir, 0750); err != nil {
+		return fmt.Errorf("failed to create socket directory: %w", err)
+	}
 
 	if _, err := os.Stat(socketPath); err == nil {
 		_ = os.Remove(socketPath)

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -161,12 +162,12 @@ func (am *AuthManager) Start(ctx context.Context) {
 
 func (am *AuthManager) startSocketListener(ctx context.Context) error {
 	const socketPath = "/var/run/alpamon/auth.sock"
-	const socketDir = "/var/run/alpamon"
+	socketDir := filepath.Dir(socketPath)
 
 	// Ensure socket directory exists as a fallback when systemd-tmpfiles
 	// has not run yet (e.g., service restart after package upgrade without reboot).
 	if err := os.MkdirAll(socketDir, 0750); err != nil {
-		return fmt.Errorf("failed to create socket directory: %w", err)
+		return fmt.Errorf("failed to create socket directory %q: %w", socketDir, err)
 	}
 
 	if _, err := os.Stat(socketPath); err == nil {


### PR DESCRIPTION
## Summary
After an alpamon package upgrade, if the service restarts without a full system reboot, `systemd-tmpfiles` may not have created the `/var/run/alpamon` directory yet. This causes the unix socket listener to fail, breaking PAM authentication.

## Changes
- Add `os.MkdirAll` fallback in `startSocketListener` to ensure the socket directory exists before creating the socket
- No longer relies solely on systemd-tmpfiles for directory creation

## Testing
- [ ] `go build ./...` passes
- [ ] Socket created successfully after package upgrade without reboot
- [ ] Existing directory case works correctly (MkdirAll is a no-op if it already exists)

---
Generated with AlpacaX Claude Plugin