### PR TITLE
feat: support deb/rpm package installation and execution in containers without systemd

### DIFF
--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -351,6 +351,7 @@ func startService() error {
 
 	// On non-Linux platforms (e.g., macOS development), skip auto-start
 	if runtime.GOOS != "linux" {
+		fmt.Println("Skipping auto-start (non-Linux platform).")
 		return nil
 	}
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -12,14 +12,20 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
+	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
 )
 
-const configPath = "/etc/alpamon/alpamon.conf"
+const (
+	alpamonBinPath = "/usr/local/bin/alpamon"
+	configPath     = "/etc/alpamon/alpamon.conf"
+	logPath        = "/var/log/alpamon/alpamon.log"
+)
 
 var (
 	serverURL  string
@@ -128,16 +134,26 @@ func runRegister(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create config file: %w", err)
 	}
 
-	// 7. Start systemd service
-	fmt.Println("\nStarting alpamon service...")
-	if err := startSystemdService(); err != nil {
-		fmt.Printf("Warning: Failed to start service: %v\n", err)
-		fmt.Println("Please start the service manually:")
-		fmt.Println("  sudo systemctl start alpamon")
-		fmt.Println("  sudo systemctl enable alpamon")
+	// 7. Create required directories
+	if err := ensureDirectories(); err != nil {
+		fmt.Printf("Warning: Failed to create directories: %v\n", err)
 	}
 
-	// 8. Success message
+	// 8. Start service
+	fmt.Println("\nStarting alpamon service...")
+	if err := startService(); err != nil {
+		fmt.Printf("Warning: Failed to start service: %v\n", err)
+		if utils.HasSystemd() {
+			fmt.Println("Please start the service manually:")
+			fmt.Println("  sudo systemctl start alpamon")
+			fmt.Println("  sudo systemctl enable alpamon")
+		} else {
+			fmt.Println("Please start alpamon manually:")
+			fmt.Println("  /usr/local/bin/alpamon")
+		}
+	}
+
+	// 9. Success message
 	fmt.Printf("\n==========================================\n")
 	fmt.Printf("Server registered successfully!\n")
 	fmt.Printf("==========================================\n")
@@ -304,27 +320,52 @@ debug = false
 	})
 }
 
-func startSystemdService() error {
-	// Create required directories via systemd-tmpfiles
-	if output, err := exec.Command("systemd-tmpfiles", "--create", "alpamon.conf").CombinedOutput(); err != nil {
-		return fmt.Errorf("tmpfiles creation failed: %w\n%s", err, string(output))
+func ensureDirectories() error {
+	if utils.HasSystemd() {
+		if output, err := exec.Command("systemd-tmpfiles", "--create", "alpamon.conf").CombinedOutput(); err != nil {
+			return fmt.Errorf("tmpfiles creation failed: %w\n%s", err, string(output))
+		}
+		return nil
+	}
+	return utils.EnsureDirectories()
+}
+
+func startService() error {
+	if utils.HasSystemd() {
+		if output, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+			return fmt.Errorf("daemon-reload failed: %w\n%s", err, string(output))
+		}
+
+		if output, err := exec.Command("systemctl", "start", "alpamon.service").CombinedOutput(); err != nil {
+			return fmt.Errorf("start failed: %w\n%s", err, string(output))
+		}
+
+		if output, err := exec.Command("systemctl", "enable", "alpamon.service").CombinedOutput(); err != nil {
+			return fmt.Errorf("enable failed: %w\n%s", err, string(output))
+		}
+
+		fmt.Println("Alpamon service started and enabled.")
+		return nil
 	}
 
-	// Reload systemd daemon
-	if output, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
-		return fmt.Errorf("daemon-reload failed: %w\n%s", err, string(output))
+	// Start alpamon as a background process (containers without systemd)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to open log file %s: %w", logPath, err)
 	}
 
-	// Start the service
-	if output, err := exec.Command("systemctl", "start", "alpamon.service").CombinedOutput(); err != nil {
-		return fmt.Errorf("start failed: %w\n%s", err, string(output))
+	cmd := exec.Command(alpamonBinPath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed to start alpamon process: %w", err)
 	}
+	// logFile is inherited by the child process; closing here does not affect the child
+	_ = logFile.Close()
 
-	// Enable the service
-	if output, err := exec.Command("systemctl", "enable", "alpamon.service").CombinedOutput(); err != nil {
-		return fmt.Errorf("enable failed: %w\n%s", err, string(output))
-	}
-
-	fmt.Println("Alpamon service started and enabled.")
+	fmt.Printf("Alpamon started (PID: %d).\n", cmd.Process.Pid)
+	fmt.Printf("Logs: %s\n", logPath)
 	return nil
 }

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"text/template"
@@ -345,6 +346,11 @@ func startService() error {
 		}
 
 		fmt.Println("Alpamon service started and enabled.")
+		return nil
+	}
+
+	// On non-Linux platforms (e.g., macOS development), skip auto-start
+	if runtime.GOOS != "linux" {
 		return nil
 	}
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -137,7 +137,7 @@ func runRegister(cmd *cobra.Command, args []string) error {
 
 	// 7. Create required directories
 	if err := ensureDirectories(); err != nil {
-		fmt.Printf("Warning: Failed to create directories: %v\n", err)
+		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
 	// 8. Start service
@@ -372,7 +372,10 @@ func startService() error {
 	_ = logFile.Close()
 
 	pid := cmd.Process.Pid
-	// Release OS resources for the detached child process
+	// Release OS resources for the detached child process.
+	// When the register process exits, the child is reparented to PID 1.
+	// In containers without a proper init (no zombie reaping), this could
+	// leave zombies. Most container runtimes use tini or --init by default.
 	_ = cmd.Process.Release()
 
 	fmt.Printf("Alpamon started (PID: %d).\n", pid)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -371,7 +371,11 @@ func startService() error {
 	// logFile is inherited by the child process; closing here does not affect the child
 	_ = logFile.Close()
 
-	fmt.Printf("Alpamon started (PID: %d).\n", cmd.Process.Pid)
+	pid := cmd.Process.Pid
+	// Release OS resources for the detached child process
+	_ = cmd.Process.Release()
+
+	fmt.Printf("Alpamon started (PID: %d).\n", pid)
 	fmt.Printf("Logs: %s\n", logPath)
 	return nil
 }

--- a/cmd/alpamon/command/setup/setup.go
+++ b/cmd/alpamon/command/setup/setup.go
@@ -61,12 +61,18 @@ var SetupCmd = &cobra.Command{
 
 		fmt.Println("Applying a new configuration automatically...")
 
-		output, err := exec.Command("systemd-tmpfiles", "--create").CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("%w\n%s", err, string(output))
+		if utils.HasSystemd() {
+			output, err := exec.Command("systemd-tmpfiles", "--create").CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("%w\n%s", err, string(output))
+			}
+		} else {
+			if err := utils.EnsureDirectories(); err != nil {
+				return fmt.Errorf("failed to create directories: %w", err)
+			}
 		}
 
-		err = writeConfig()
+		err := writeConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/executor/handlers/firewall/detection.go
+++ b/pkg/executor/handlers/firewall/detection.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
@@ -122,28 +123,32 @@ func (d *FirewallDetector) GetBackendType() BackendType {
 
 // detectHighLevelFirewall detects if high-level firewall management tools are active
 func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLevelFirewall {
-	// Check ufw via systemctl (most reliable)
-	exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "ufw")
-	if exitCode == 0 && strings.TrimSpace(output) == "active" {
-		log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
-		return HighLevelUFW
+	if utils.HasSystemd() {
+		// Check ufw via systemctl (most reliable)
+		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "ufw")
+		if exitCode == 0 && strings.TrimSpace(output) == "active" {
+			log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
+			return HighLevelUFW
+		}
 	}
 
-	// Fallback: Check ufw via direct command
-	exitCode, output, _ = d.executor.RunWithTimeout(ctx, 5*time.Second, "ufw", "status")
+	// Check ufw via direct command
+	exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "ufw", "status")
 	if exitCode == 0 && strings.Contains(strings.ToLower(output), "status: active") {
 		log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
 		return HighLevelUFW
 	}
 
-	// Check firewalld via systemctl
-	exitCode, output, _ = d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "firewalld")
-	if exitCode == 0 && strings.TrimSpace(output) == "active" {
-		log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
-		return HighLevelFirewalld
+	if utils.HasSystemd() {
+		// Check firewalld via systemctl
+		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "firewalld")
+		if exitCode == 0 && strings.TrimSpace(output) == "active" {
+			log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
+			return HighLevelFirewalld
+		}
 	}
 
-	// Fallback: Check firewalld via firewall-cmd
+	// Check firewalld via firewall-cmd
 	exitCode, output, _ = d.executor.RunWithTimeout(ctx, 5*time.Second, "firewall-cmd", "--state")
 	if exitCode == 0 && strings.Contains(strings.ToLower(output), "running") {
 		log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")

--- a/pkg/executor/handlers/firewall/detection.go
+++ b/pkg/executor/handlers/firewall/detection.go
@@ -123,7 +123,9 @@ func (d *FirewallDetector) GetBackendType() BackendType {
 
 // detectHighLevelFirewall detects if high-level firewall management tools are active
 func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLevelFirewall {
-	if utils.HasSystemd() {
+	hasSystemd := utils.HasSystemd()
+
+	if hasSystemd {
 		// Check ufw via systemctl (most reliable)
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "ufw")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {
@@ -139,7 +141,7 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 		return HighLevelUFW
 	}
 
-	if utils.HasSystemd() {
+	if hasSystemd {
 		// Check firewalld via systemctl
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "firewalld")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {

--- a/pkg/executor/handlers/firewall/detection.go
+++ b/pkg/executor/handlers/firewall/detection.go
@@ -129,7 +129,7 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 		// Check ufw via systemctl (most reliable)
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "ufw")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {
-			log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
+			log.Info().Msg("Detected active ufw firewall - Alpacon firewall management will be disabled")
 			return HighLevelUFW
 		}
 	}
@@ -137,7 +137,7 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 	// Check ufw via direct command
 	exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "ufw", "status")
 	if exitCode == 0 && strings.Contains(strings.ToLower(output), "status: active") {
-		log.Info().Msg("Detected active ufw firewall - alpacon firewall management will be disabled")
+		log.Info().Msg("Detected active ufw firewall - Alpacon firewall management will be disabled")
 		return HighLevelUFW
 	}
 
@@ -145,7 +145,7 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 		// Check firewalld via systemctl
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "firewalld")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {
-			log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
+			log.Info().Msg("Detected active firewalld - Alpacon firewall management will be disabled")
 			return HighLevelFirewalld
 		}
 	}
@@ -153,11 +153,11 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 	// Check firewalld via firewall-cmd
 	exitCode, output, _ = d.executor.RunWithTimeout(ctx, 5*time.Second, "firewall-cmd", "--state")
 	if exitCode == 0 && strings.Contains(strings.ToLower(output), "running") {
-		log.Info().Msg("Detected active firewalld - alpacon firewall management will be disabled")
+		log.Info().Msg("Detected active firewalld - Alpacon firewall management will be disabled")
 		return HighLevelFirewalld
 	}
 
-	log.Debug().Msg("No high-level firewall detected - alpacon firewall management enabled")
+	log.Debug().Msg("No high-level firewall detected - Alpacon firewall management enabled")
 	return HighLevelNone
 }
 

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -261,9 +261,9 @@ func (h *SystemHandler) executeUninstall() {
 		}
 	} else {
 		// Defer the uninstall so the process can shut down cleanly first.
-		// Use a shell that starts the actual uninstall in the background
-		// so that RunAsUser (which uses CombinedOutput) does not block on it.
-		deferredCmd := fmt.Sprintf("nohup sh -c 'sleep 5 && %s' >/dev/null 2>&1 &", cmd)
+		// Use a subshell background pattern instead of nohup, which may not
+		// be available in minimal container images.
+		deferredCmd := fmt.Sprintf("(sleep 5 && %s) >/dev/null 2>&1 &", cmd)
 		log.Info().Msg("Systemd not available, scheduling deferred uninstall.")
 		_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", deferredCmd)
 	}

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -263,7 +263,7 @@ func (h *SystemHandler) executeUninstall() {
 		// Defer the uninstall so the process can shut down cleanly first.
 		// Use a subshell background pattern instead of nohup, which may not
 		// be available in minimal container images.
-		deferredCmd := fmt.Sprintf("(sleep 5 && %s) >/dev/null 2>&1 &", cmd)
+		deferredCmd := fmt.Sprintf("(sleep 5 && %s) >>/var/log/alpamon/alpamon.log 2>&1 &", cmd)
 		log.Info().Msg("Systemd not available, scheduling deferred uninstall.")
 		_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", deferredCmd)
 	}

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -230,33 +230,40 @@ func (h *SystemHandler) executeUninstall() {
 		return
 	}
 
-	// Build the complete uninstall command that includes:
-	// 1. Package removal
-	// 2. Cleanup of transient systemd units created by this operation
-	uninstallCmd := fmt.Sprintf("%s; systemctl reset-failed alpamon-uninstall.service 2>/dev/null || true; systemctl reset-failed alpamon-uninstall.timer 2>/dev/null || true", cmd)
-
-	// This ensures the uninstall continues even after the current process terminates
-	// The service will start 5 seconds after being scheduled
-	// --collect: Automatically clean up transient units after they complete (systemd 236+)
-	scheduleCmdArgs := []string{
-		"systemd-run",
-		"--collect",
-		"--uid=0",
-		"--gid=0",
-		"--unit=alpamon-uninstall",
-		"--timer-property=OnActiveSec=5",
-		"--timer-property=AccuracySec=1s",
-		"--description=Alpamon Uninstall Service",
-		"/bin/sh", "-c", uninstallCmd,
-	}
-
 	ctx := context.Background()
-	exitCode, output, _ := h.Executor.RunWithTimeout(ctx, 30*time.Second, scheduleCmdArgs[0], scheduleCmdArgs[1:]...)
 
-	if exitCode != 0 {
-		log.Error().Msgf("Failed to schedule uninstall: %s", output)
-		// Fallback to direct execution
-		_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	if utils.HasSystemd() {
+		// Build the complete uninstall command that includes:
+		// 1. Package removal
+		// 2. Cleanup of transient systemd units created by this operation
+		uninstallCmd := fmt.Sprintf("%s; systemctl reset-failed alpamon-uninstall.service 2>/dev/null || true; systemctl reset-failed alpamon-uninstall.timer 2>/dev/null || true", cmd)
+
+		// This ensures the uninstall continues even after the current process terminates
+		// The service will start 5 seconds after being scheduled
+		// --collect: Automatically clean up transient units after they complete (systemd 236+)
+		scheduleCmdArgs := []string{
+			"systemd-run",
+			"--collect",
+			"--uid=0",
+			"--gid=0",
+			"--unit=alpamon-uninstall",
+			"--timer-property=OnActiveSec=5",
+			"--timer-property=AccuracySec=1s",
+			"--description=Alpamon Uninstall Service",
+			"/bin/sh", "-c", uninstallCmd,
+		}
+
+		exitCode, output, _ := h.Executor.RunWithTimeout(ctx, 30*time.Second, scheduleCmdArgs[0], scheduleCmdArgs[1:]...)
+
+		if exitCode != 0 {
+			log.Error().Msgf("Failed to schedule uninstall: %s", output)
+			_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+		}
+	} else {
+		// Defer the uninstall so the process can shut down cleanly first
+		deferredCmd := fmt.Sprintf("sleep 5 && %s", cmd)
+		log.Info().Msg("Systemd not available, scheduling deferred uninstall.")
+		_, _, _ = h.Executor.RunAsUser(ctx, "root", "nohup", "sh", "-c", deferredCmd)
 	}
 
 	// Shutdown the process after scheduling

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -260,10 +260,12 @@ func (h *SystemHandler) executeUninstall() {
 			_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
 		}
 	} else {
-		// Defer the uninstall so the process can shut down cleanly first
-		deferredCmd := fmt.Sprintf("sleep 5 && %s", cmd)
+		// Defer the uninstall so the process can shut down cleanly first.
+		// Use a shell that starts the actual uninstall in the background
+		// so that RunAsUser (which uses CombinedOutput) does not block on it.
+		deferredCmd := fmt.Sprintf("nohup sh -c 'sleep 5 && %s' >/dev/null 2>&1 &", cmd)
 		log.Info().Msg("Systemd not available, scheduling deferred uninstall.")
-		_, _, _ = h.Executor.RunAsUser(ctx, "root", "nohup", "sh", "-c", deferredCmd)
+		_, _, _ = h.Executor.RunAsUser(ctx, "root", "sh", "-c", deferredCmd)
 	}
 
 	// Shutdown the process after scheduling

--- a/pkg/utils/systemd.go
+++ b/pkg/utils/systemd.go
@@ -23,13 +23,6 @@ func HasSystemd() bool {
 	return systemdAvailable
 }
 
-// resetSystemdCacheForTesting resets the cached detection result.
-// This must only be called from tests.
-func resetSystemdCacheForTesting() {
-	systemdOnce = sync.Once{}
-	systemdAvailable = false
-}
-
 func detectSystemd() bool {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return false

--- a/pkg/utils/systemd.go
+++ b/pkg/utils/systemd.go
@@ -27,14 +27,17 @@ func detectSystemd() bool {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return false
 	}
-	if runtime.GOOS == "linux" {
-		data, err := os.ReadFile("/proc/1/comm")
-		if err != nil {
-			return false
-		}
-		return strings.TrimSpace(string(data)) == "systemd"
+	// Only Linux uses /proc/1/comm to verify PID 1 is systemd.
+	// Other platforms (macOS, etc.) always return false even if
+	// systemctl happens to be in PATH (e.g., via Homebrew).
+	if runtime.GOOS != "linux" {
+		return false
 	}
-	return false
+	data, err := os.ReadFile("/proc/1/comm")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "systemd"
 }
 
 // alpamonDirs defines required directories matching configs/tmpfile.conf

--- a/pkg/utils/systemd.go
+++ b/pkg/utils/systemd.go
@@ -23,9 +23,9 @@ func HasSystemd() bool {
 	return systemdAvailable
 }
 
-// ResetSystemdCacheForTesting resets the cached detection result.
+// resetSystemdCacheForTesting resets the cached detection result.
 // This must only be called from tests.
-func ResetSystemdCacheForTesting() {
+func resetSystemdCacheForTesting() {
 	systemdOnce = sync.Once{}
 	systemdAvailable = false
 }

--- a/pkg/utils/systemd.go
+++ b/pkg/utils/systemd.go
@@ -56,7 +56,8 @@ var alpamonDirs = []struct {
 	{"/run/alpamon", 0750},
 }
 
-// EnsureDirectories creates required alpamon directories.
+// EnsureDirectories creates required alpamon directories with permissions
+// and root:root ownership matching configs/tmpfile.conf.
 // Replaces systemd-tmpfiles when systemd is unavailable.
 func EnsureDirectories() error {
 	return ensureDirectoriesWithRoot("")
@@ -70,6 +71,13 @@ func ensureDirectoriesWithRoot(root string) error {
 		}
 		if err := os.Chmod(path, d.Mode); err != nil {
 			return fmt.Errorf("failed to set permissions on %s: %w", path, err)
+		}
+		// Enforce root:root ownership to match tmpfile.conf.
+		// Skip in tests (non-empty root) where we may not be running as root.
+		if root == "" {
+			if err := os.Chown(path, 0, 0); err != nil {
+				return fmt.Errorf("failed to set ownership on %s: %w", path, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/utils/systemd.go
+++ b/pkg/utils/systemd.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var (
+	systemdAvailable bool
+	systemdOnce      sync.Once
+)
+
+// HasSystemd returns true if systemd is available and running as PID 1.
+func HasSystemd() bool {
+	systemdOnce.Do(func() {
+		systemdAvailable = detectSystemd()
+	})
+	return systemdAvailable
+}
+
+// ResetSystemdCacheForTesting resets the cached detection result.
+// This must only be called from tests.
+func ResetSystemdCacheForTesting() {
+	systemdOnce = sync.Once{}
+	systemdAvailable = false
+}
+
+func detectSystemd() bool {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return false
+	}
+	if runtime.GOOS == "linux" {
+		data, err := os.ReadFile("/proc/1/comm")
+		if err != nil {
+			return false
+		}
+		return strings.TrimSpace(string(data)) == "systemd"
+	}
+	return false
+}
+
+// alpamonDirs defines required directories matching configs/tmpfile.conf
+// and scripts/postinstall.sh:create_directories(). Keep all three in sync.
+var alpamonDirs = []struct {
+	Path string
+	Mode os.FileMode
+}{
+	{"/etc/alpamon", 0700},
+	{"/var/lib/alpamon", 0750},
+	{"/var/log/alpamon", 0750},
+	{"/run/alpamon", 0750},
+}
+
+// EnsureDirectories creates required alpamon directories.
+// Replaces systemd-tmpfiles when systemd is unavailable.
+func EnsureDirectories() error {
+	return ensureDirectoriesWithRoot("")
+}
+
+func ensureDirectoriesWithRoot(root string) error {
+	for _, d := range alpamonDirs {
+		path := filepath.Join(root, d.Path)
+		if err := os.MkdirAll(path, d.Mode); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", path, err)
+		}
+		if err := os.Chmod(path, d.Mode); err != nil {
+			return fmt.Errorf("failed to set permissions on %s: %w", path, err)
+		}
+	}
+	return nil
+}

--- a/pkg/utils/systemd_test.go
+++ b/pkg/utils/systemd_test.go
@@ -4,8 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 )
+
+// resetSystemdCacheForTesting resets the cached detection result.
+func resetSystemdCacheForTesting() {
+	systemdOnce = sync.Once{}
+	systemdAvailable = false
+}
 
 func TestDetectSystemd_Darwin(t *testing.T) {
 	if runtime.GOOS != "darwin" {

--- a/pkg/utils/systemd_test.go
+++ b/pkg/utils/systemd_test.go
@@ -4,15 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 )
-
-// resetSystemdCacheForTesting resets the cached detection result.
-func resetSystemdCacheForTesting() {
-	systemdOnce = sync.Once{}
-	systemdAvailable = false
-}
 
 func TestDetectSystemd_Darwin(t *testing.T) {
 	if runtime.GOOS != "darwin" {

--- a/pkg/utils/systemd_test.go
+++ b/pkg/utils/systemd_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDetectSystemd_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("skipping darwin-specific test")
+	}
+	// On macOS, detectSystemd should always return false
+	if detectSystemd() {
+		t.Error("detectSystemd() should return false on darwin")
+	}
+}
+
+func TestEnsureDirectoriesWithRoot(t *testing.T) {
+	root := t.TempDir()
+
+	if err := ensureDirectoriesWithRoot(root); err != nil {
+		t.Fatalf("ensureDirectoriesWithRoot() error: %v", err)
+	}
+
+	for _, d := range alpamonDirs {
+		path := filepath.Join(root, d.Path)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("directory %s not created: %v", d.Path, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s is not a directory", d.Path)
+		}
+		if info.Mode().Perm() != d.Mode {
+			t.Errorf("%s permissions = %o, want %o", d.Path, info.Mode().Perm(), d.Mode)
+		}
+	}
+}
+
+func TestEnsureDirectoriesWithRoot_Idempotent(t *testing.T) {
+	root := t.TempDir()
+
+	// Call twice to verify idempotency
+	if err := ensureDirectoriesWithRoot(root); err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	if err := ensureDirectoriesWithRoot(root); err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	for _, d := range alpamonDirs {
+		path := filepath.Join(root, d.Path)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("directory %s not found after second call: %v", d.Path, err)
+			continue
+		}
+		if info.Mode().Perm() != d.Mode {
+			t.Errorf("%s permissions = %o, want %o", d.Path, info.Mode().Perm(), d.Mode)
+		}
+	}
+}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -95,6 +95,11 @@ setup_alpamon() {
 
 start_alpamon_process() {
   local log_file="/var/log/alpamon/alpamon.log"
+  # Create log file with restrictive permissions (0640) to match register.go behavior
+  if [ ! -e "$log_file" ]; then
+    touch "$log_file"
+    chmod 0640 "$log_file" 2>/dev/null || true
+  fi
   echo "Starting Alpamon as a background process..."
   nohup "$ALPAMON_BIN" >>"$log_file" 2>&1 &
   echo "Alpamon started (PID: $!)."

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -101,7 +101,10 @@ start_alpamon_process() {
     chmod 0640 "$log_file" 2>/dev/null || true
   fi
   echo "Starting Alpamon as a background process..."
-  nohup "$ALPAMON_BIN" >>"$log_file" 2>&1 &
+  # Trap SIGHUP to prevent the child from being killed when the
+  # postinstall script (and its parent shell session) exits.
+  # Uses exec to replace the subshell with alpamon directly.
+  (trap '' HUP; exec "$ALPAMON_BIN" >>"$log_file" 2>&1) &
   echo "Alpamon started (PID: $!)."
   echo "Logs: $log_file"
 }
@@ -109,7 +112,17 @@ start_alpamon_process() {
 restart_alpamon_process() {
   echo "Restarting Alpamon process for upgrade..."
   pkill -x alpamon 2>/dev/null || true
-  sleep 1
+  # Wait for graceful shutdown, then force-kill if still running
+  local i=0
+  while [ $i -lt 5 ] && pgrep -x alpamon >/dev/null 2>&1; do
+    sleep 1
+    i=$((i + 1))
+  done
+  if pgrep -x alpamon >/dev/null 2>&1; then
+    echo "Warning: Alpamon did not shut down within 5 seconds, force-killing." >&2
+    pkill -9 -x alpamon 2>/dev/null || true
+    sleep 1
+  fi
   create_directories
   start_alpamon_process
 }

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -45,9 +45,10 @@ check_systemd_status() {
     SYSTEMD_AVAILABLE=false
     return
   fi
-  # Detect containers that install systemctl but don't run systemd as init
-  if [ -f /proc/1/comm ] && [ "$(cat /proc/1/comm)" != "systemd" ]; then
-    echo "Notice: systemd is installed but not running as init. Skipping service setup."
+  # Require positive confirmation that PID 1 is systemd.
+  # Treat missing/unreadable /proc/1/comm as "no systemd" to align with utils.HasSystemd().
+  if [ ! -f /proc/1/comm ] || [ "$(cat /proc/1/comm 2>/dev/null)" != "systemd" ]; then
+    echo "Notice: systemd is not running as init. Skipping service setup."
     SYSTEMD_AVAILABLE=false
     return
   fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -56,9 +56,11 @@ check_systemd_status() {
 # Create required directories matching configs/tmpfile.conf
 # and pkg/utils/systemd.go:alpamonDirs. Keep all three in sync.
 create_directories() {
-  mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+  alpamon_dirs="/etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon"
+  mkdir -p $alpamon_dirs
   chmod 0700 /etc/alpamon
   chmod 0750 /var/lib/alpamon /var/log/alpamon /run/alpamon
+  chown root:root $alpamon_dirs 2>/dev/null || true
 }
 
 check_alpamon_binary() {

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -41,13 +41,17 @@ check_root_permission() {
 check_systemd_status() {
   if ! command -v systemctl &> /dev/null; then
     echo "Notice: systemd is not available. Skipping systemd service setup."
-    echo "Alpamon will need to be started manually or via a container entrypoint."
     SYSTEMD_AVAILABLE=false
     return
   fi
   # Require positive confirmation that PID 1 is systemd.
   # Treat missing/unreadable /proc/1/comm as "no systemd" to align with utils.HasSystemd().
-  if [ ! -f /proc/1/comm ] || [ "$(cat /proc/1/comm 2>/dev/null)" != "systemd" ]; then
+  # Use -r (readable) to avoid set -e exit on unreadable files.
+  local pid1_comm=""
+  if [ -r /proc/1/comm ]; then
+    pid1_comm=$(cat /proc/1/comm 2>/dev/null) || true
+  fi
+  if [ "$pid1_comm" != "systemd" ]; then
     echo "Notice: systemd is not running as init. Skipping service setup."
     SYSTEMD_AVAILABLE=false
     return

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -60,7 +60,9 @@ create_directories() {
   mkdir -p $alpamon_dirs
   chmod 0700 /etc/alpamon
   chmod 0750 /var/lib/alpamon /var/log/alpamon /run/alpamon
-  chown root:root $alpamon_dirs 2>/dev/null || true
+  if ! chown root:root $alpamon_dirs; then
+    echo "Warning: Failed to set ownership to root:root for Alpamon directories: $alpamon_dirs" >&2
+  fi
 }
 
 check_alpamon_binary() {

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -61,10 +61,12 @@ check_systemd_status() {
 # Create required directories matching configs/tmpfile.conf
 # and pkg/utils/systemd.go:alpamonDirs. Keep all three in sync.
 create_directories() {
-  alpamon_dirs="/etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon"
+  local alpamon_dirs="/etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon"
+  # shellcheck disable=SC2086
   mkdir -p $alpamon_dirs
   chmod 0700 /etc/alpamon
   chmod 0750 /var/lib/alpamon /var/log/alpamon /run/alpamon
+  # shellcheck disable=SC2086
   if ! chown root:root $alpamon_dirs; then
     echo "Warning: Failed to set ownership to root:root for Alpamon directories: $alpamon_dirs" >&2
   fi
@@ -105,7 +107,13 @@ start_alpamon_process() {
   # postinstall script (and its parent shell session) exits.
   # Uses exec to replace the subshell with alpamon directly.
   (trap '' HUP; exec "$ALPAMON_BIN" >>"$log_file" 2>&1) &
-  echo "Alpamon started (PID: $!)."
+  local pid=$!
+  sleep 0.5
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "Warning: Alpamon process (PID: $pid) exited immediately. Check $log_file for details." >&2
+    return
+  fi
+  echo "Alpamon started (PID: $pid)."
   echo "Logs: $log_file"
 }
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -2,6 +2,7 @@
 
 ALPAMON_BIN="/usr/local/bin/alpamon"
 TEMPLATE_FILE="/etc/alpamon/alpamon.config.tmpl"
+SYSTEMD_AVAILABLE=true
 
 main() {
   check_root_permission
@@ -9,12 +10,21 @@ main() {
   check_alpamon_binary
 
   if is_upgrade "$@"; then
-    restart_alpamon_by_timer
+    if [ "$SYSTEMD_AVAILABLE" = "true" ]; then
+      restart_alpamon_by_timer
+    else
+      restart_alpamon_process
+    fi
   else
     # setup_alpamon returns 1 if ENV not set (generic installation)
     # In that case, skip start_systemd_service - user will run 'alpamon register'
     if setup_alpamon; then
-      start_systemd_service
+      if [ "$SYSTEMD_AVAILABLE" = "true" ]; then
+        start_systemd_service
+      else
+        create_directories
+        start_alpamon_process
+      fi
     fi
   fi
 
@@ -30,9 +40,25 @@ check_root_permission() {
 
 check_systemd_status() {
   if ! command -v systemctl &> /dev/null; then
-    echo "Error: systemctl is required but could not be found. Please ensure systemd is installed and systemctl is available."
-    exit 1
+    echo "Notice: systemd is not available. Skipping systemd service setup."
+    echo "Alpamon will need to be started manually or via a container entrypoint."
+    SYSTEMD_AVAILABLE=false
+    return
   fi
+  # Detect containers that install systemctl but don't run systemd as init
+  if [ -f /proc/1/comm ] && [ "$(cat /proc/1/comm)" != "systemd" ]; then
+    echo "Notice: systemd is installed but not running as init. Skipping service setup."
+    SYSTEMD_AVAILABLE=false
+    return
+  fi
+}
+
+# Create required directories matching configs/tmpfile.conf
+# and pkg/utils/systemd.go:alpamonDirs. Keep all three in sync.
+create_directories() {
+  mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+  chmod 0700 /etc/alpamon
+  chmod 0750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 }
 
 check_alpamon_binary() {
@@ -56,6 +82,22 @@ setup_alpamon() {
     echo "Error: Alpamon setup command failed."
     exit 1
   fi
+}
+
+start_alpamon_process() {
+  local log_file="/var/log/alpamon/alpamon.log"
+  echo "Starting Alpamon as a background process..."
+  nohup "$ALPAMON_BIN" >>"$log_file" 2>&1 &
+  echo "Alpamon started (PID: $!)."
+  echo "Logs: $log_file"
+}
+
+restart_alpamon_process() {
+  echo "Restarting Alpamon process for upgrade..."
+  pkill -x alpamon 2>/dev/null || true
+  sleep 1
+  create_directories
+  start_alpamon_process
 }
 
 start_systemd_service() {
@@ -87,7 +129,7 @@ cleanup_tmpl_files() {
   fi
 }
 
-# debain
+# debian
 # Initial installation: $1 == configure
 # Upgrade: $1 == configure, $2 == old version
 


### PR DESCRIPTION
### Summary

Enable Alpamon's deb/rpm packages to be installed and run in Docker containers (Debian/RHEL families) where systemd is not available. Existing behavior on systemd environments remains unchanged.

#### Background

Alpamon's Linux packages currently assume systemd is present:
- `postinstall.sh` blocks installation with `exit 1` when `systemctl` is not found
- `alpamon register` and `alpamon setup` call `systemd-tmpfiles` and `systemctl`, which fail in containers
- Running Alpamon in containers requires the `--privileged` flag to run systemd as PID 1, which disables container isolation

The binary itself is already container-friendly (foreground process, SIGTERM handling, stderr logging, static linking), so conditionally handling systemd dependencies is all that's needed to enable container support.

### Changes

#### 1. systemd detection utility (`pkg/utils/systemd.go`)
- `HasSystemd()`: detects systemd via `systemctl` in PATH + `/proc/1/comm == "systemd"`, cached with `sync.Once`
- `EnsureDirectories()`: creates the 4 directories defined in `configs/tmpfile.conf` with matching permissions (replaces `systemd-tmpfiles`)
- `ResetSystemdCacheForTesting()`: resets cached detection result for test isolation

#### 2. Package installation script (`scripts/postinstall.sh`)
- Replace `exit 1` in `check_systemd_status()` with `SYSTEMD_AVAILABLE=false` flag
- Add `/proc/1/comm` check to detect containers that install systemctl but don't run systemd as init
- `start_alpamon_process()`: auto-start alpamon as a background process via `nohup`, logging to `/var/log/alpamon/alpamon.log`
- `restart_alpamon_process()`: stop old process and restart on package upgrade in containers

#### 3. Register command (`cmd/alpamon/command/register/register.go`)
- Split `startSystemdService()` into `ensureDirectories()` + `startService()`
- When systemd is unavailable, start alpamon as a detached background process (`exec.Command` + `Setsid: true`)
- Redirect stderr/stdout to log file to prevent log loss
- Extract path constants (`alpamonBinPath`, `configPath`, `logPath`)

#### 4. Setup command (`cmd/alpamon/command/setup/setup.go`)
- Wrap `systemd-tmpfiles --create` with `HasSystemd()` conditional
- Use `utils.EnsureDirectories()` when systemd is unavailable

#### 5. Uninstall (`pkg/executor/handlers/system/system.go`)
- Guard `systemd-run --collect` block with `HasSystemd()` conditional
- When systemd is unavailable, defer package removal via `nohup sh -c "sleep 5 && ..."` to allow the process to shut down cleanly first

#### 6. Firewall detection (`pkg/executor/handlers/firewall/detection.go`)
- Guard `systemctl is-active ufw/firewalld` calls with `HasSystemd()` conditional
- When systemd is unavailable, skip directly to fallback commands (`ufw status`, `firewall-cmd --state`)

### Unchanged files

- `scripts/preremove.sh`: already has `command -v systemctl` guard
- `scripts/postremove.sh`: already has `command -v systemctl` guard

### Behavior comparison by environment

| Operation | systemd environment (unchanged) | Container (new) |
|---|---|---|
| Package install | `systemctl start/enable` | `nohup alpamon &` + log file |
| `alpamon register` | `systemctl daemon-reload/start/enable` | `exec.Command().Start()` + `Setsid` |
| `alpamon setup` | `systemd-tmpfiles --create` | `utils.EnsureDirectories()` |
| Package upgrade | `alpamon-restart.timer` (5min delay) | `pkill` + restart |
| Uninstall | `systemd-run --collect` (5s delay) | `nohup sleep 5 && purge` (5s delay) |
| Firewall detection | `systemctl is-active` + fallback | Fallback only |
| Logging | stderr → journald | stderr → `/var/log/alpamon/alpamon.log` |
| Foreground execution | N/A | stderr → `docker logs` |

### Directory definitions sync

The following 3 locations must maintain identical directory definitions. Cross-reference comments have been added:

1. `configs/tmpfile.conf`
2. `pkg/utils/systemd.go` — `alpamonDirs`
3. `scripts/postinstall.sh` — `create_directories()`

```
/etc/alpamon     0700
/var/lib/alpamon 0750
/var/log/alpamon 0750
/run/alpamon     0750
```

### Supported environments

| Container base | Package format | Supported |
|---|---|---|
| Ubuntu, Debian | deb | Yes |
| RHEL, Rocky, CentOS, Amazon Linux | rpm | Yes |
| Alpine | apk (not available) | No |

### Test plan

- [ ] `go test -v ./pkg/utils/... -p 1` — systemd detection and directory creation tests pass
- [ ] `go test -v ./... -p 1` — no regressions in full test suite
- [ ] `go build -v ./cmd/alpamon` — build succeeds
- [ ] deb package installation in Ubuntu container — completes without errors, alpamon auto-starts
- [ ] rpm package installation in Rocky Linux container — completes without errors, alpamon auto-starts
- [ ] `alpamon register` in container — directories created + config written + alpamon auto-starts
- [ ] Log file in container — `/var/log/alpamon/alpamon.log` written correctly
- [ ] Package installation on systemd host (VM) — systemd service starts as before

```bash
# Debian family test
docker run --rm -it ubuntu:22.04 bash -c "\
  dpkg -i /tmp/alpamon_*.deb && \
  alpamon register --url https://... --token ... && \
  cat /var/log/alpamon/alpamon.log"

# RHEL family test
docker run --rm -it rockylinux:9 bash -c "\
  rpm -i /tmp/alpamon-*.rpm && \
  alpamon register --url https://... --token ... && \
  cat /var/log/alpamon/alpamon.log"
```

### Commits

| # | Commit | Description |
|---|---|---|
| 1 | `feat: add systemd detection and directory creation utilities` | `HasSystemd()`, `EnsureDirectories()`, tests |
| 2 | `feat: allow package installation in containers without systemd` | `postinstall.sh` graceful skip + auto-start |
| 3 | `feat: support container environments in register command` | Conditional systemd-tmpfiles/systemctl + background start |
| 4 | `feat: support container environments in setup command` | Conditional systemd-tmpfiles |
| 5 | `feat: add deferred uninstall fallback for containers without systemd` | Conditional systemd-run + deferred execution |
| 6 | `refactor: skip unnecessary systemctl calls in firewall detection` | Optimize systemctl calls |

### Related

Closes #248
