### PR TITLE
feat(sync): implement hash-based sync protocol to reduce unnecessary API calls

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -32,7 +32,7 @@ const (
 	commitURL       = "/api/servers/servers/-/commit/"
 	eventURL        = "/api/events/events/"
 	accessPolicyURL = "/api/servers/servers/-/access-policy/"
-	syncCheckURL = "/api/servers/servers/-/sync-check/"
+	syncCheckURL    = "/api/servers/servers/-/sync-check/"
 
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"
@@ -780,6 +780,7 @@ func getPartitions() ([]Partition, error) {
 
 	var partitionList []Partition
 	for _, partition := range seen {
+		slices.Sort(partition.MountPoints)
 		partitionList = append(partitionList, partition)
 	}
 	slices.SortFunc(partitionList, func(a, b Partition) int {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ const (
 	commitURL       = "/api/servers/servers/-/commit/"
 	eventURL        = "/api/events/events/"
 	accessPolicyURL = "/api/servers/servers/-/access-policy/"
+	syncCheckURL = "/api/servers/servers/-/sync-check/"
 
 	passwdFilePath = "/etc/passwd"
 	groupFilePath  = "/etc/group"
@@ -113,23 +115,25 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 	defer syncMutex.Unlock()
 
 	fullSync := len(keys) == 0
-	if fullSync {
-		keys = allSyncKeys()
-	}
 
-	for _, key := range keys {
-		switch key {
-		case "server":
-			syncServerData(session)
-		case "firewall":
-			syncFirewallData()
-		default:
+	// server is always synced unconditionally (not hashed).
+	syncServerData(session)
+
+	// Step 1: collect data and compute hashes for data categories.
+	snap := collectSnapshot(keys)
+
+	// Step 2 & 3: check hashes with server and sync changed categories.
+	if !snap.empty() {
+		for _, key := range syncRequiredKeys(session, snap) {
 			if s, ok := syncerMap[key]; ok {
-				s.syncWith(session)
-			} else {
-				log.Warn().Msgf("Unknown key: %s", key)
+				s.syncData(session, snap.data[key])
 			}
 		}
+	}
+
+	// firewall is always synced separately (not hashed).
+	if fullSync || slices.Contains(keys, "firewall") {
+		syncFirewallData()
 	}
 
 	if fullSync {
@@ -185,6 +189,47 @@ func syncAccessPolicy(session *scheduler.Session) {
 	if authManager != nil {
 		authManager.UpdateBlockLocalSudo(accessPolicy.BlockLocalSudo)
 	}
+}
+
+// syncRequiredKeys sends hashes to the server and returns the list of categories
+// that need syncing. On server error, falls back to all collected categories
+// in the original syncers registration order for predictable behavior.
+func syncRequiredKeys(session *scheduler.Session, snap syncSnapshot) []string {
+	required, err := checkSyncHashes(session, snap.hashes)
+	if err != nil {
+		log.Debug().Err(err).Msg("Sync-check failed, falling back to full sync.")
+		required = make([]string, 0, len(snap.data))
+		for _, s := range syncers {
+			if _, ok := snap.data[s.Key()]; ok {
+				required = append(required, s.Key())
+			}
+		}
+	}
+	return required
+}
+
+// checkSyncHashes sends per-category data hashes to the server and returns the
+// list of categories that need syncing. On error (old server returning 404,
+// network failure, etc.), the caller should fall back to syncing all categories.
+func checkSyncHashes(session *scheduler.Session, hashes map[string]string) ([]string, error) {
+	payload := map[string]any{"hashes": hashes}
+
+	resp, statusCode, err := session.Post(syncCheckURL, payload, 10)
+	if err != nil {
+		return nil, fmt.Errorf("sync-check request failed: %w", err)
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("sync-check returned HTTP %d", statusCode)
+	}
+
+	var result struct {
+		SyncRequired []string `json:"sync_required"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("sync-check response parse failed: %w", err)
+	}
+
+	return result.SyncRequired, nil
 }
 
 func compareData(entry commitDef, currentData, remoteData ComparableData) {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -146,7 +146,7 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 				log.Warn().Str("key", key).Msg("Server returned unknown sync category, skipping.")
 				continue
 			}
-			s.syncData(session, data)
+			s.syncData(session, data, snap.hashes[key])
 		}
 	}
 
@@ -272,7 +272,7 @@ func checkSyncHashes(session *scheduler.Session, hashes map[string]string) ([]st
 	return result.SyncRequired, nil
 }
 
-func compareData(entry commitDef, currentData, remoteData ComparableData) {
+func compareData(entry commitDef, currentData, remoteData ComparableData, syncHash string) {
 	var createData, updateData interface{}
 
 	if remoteData == nil {
@@ -284,14 +284,17 @@ func compareData(entry commitDef, currentData, remoteData ComparableData) {
 			updateData = currentData.GetData()
 		}
 	}
+	h := syncHashHeader(syncHash)
 	if createData != nil {
-		scheduler.Rqueue.Post(entry.URL, createData, 80, time.Time{})
+		scheduler.Rqueue.PostWithHeaders(entry.URL, createData, 80, time.Time{}, h)
 	} else if updateData != nil {
-		scheduler.Rqueue.Patch(entry.URL+remoteData.GetID()+"/", updateData, 80, time.Time{})
+		scheduler.Rqueue.PatchWithHeaders(entry.URL+remoteData.GetID()+"/", updateData, 80, time.Time{}, h)
 	}
 }
 
-func compareListData[T ComparableData](entry commitDef, currentData, remoteData []T) {
+func compareListData[T ComparableData](entry commitDef, currentData, remoteData []T, syncHash string) {
+	h := syncHashHeader(syncHash)
+
 	currentMap := make(map[interface{}]ComparableData)
 	for _, currentItem := range currentData {
 		currentMap[currentItem.GetKey()] = currentItem
@@ -302,11 +305,11 @@ func compareListData[T ComparableData](entry commitDef, currentData, remoteData 
 			// Compare using GetComparableData() to exclude fields not stored by server
 			if !cmp.Equal(currentItem.GetComparableData(), remoteItem.GetComparableData()) {
 				// Transmit using GetData() to include all raw data for server-side processing
-				scheduler.Rqueue.Patch(entry.URL+remoteItem.GetID()+"/", currentItem.GetData(), 80, time.Time{})
+				scheduler.Rqueue.PatchWithHeaders(entry.URL+remoteItem.GetID()+"/", currentItem.GetData(), 80, time.Time{}, h)
 			}
 			delete(currentMap, currentItem.GetKey())
 		} else {
-			scheduler.Rqueue.Delete(entry.URL+remoteItem.GetID()+"/", nil, 80, time.Time{})
+			scheduler.Rqueue.DeleteWithHeaders(entry.URL+remoteItem.GetID()+"/", nil, 80, time.Time{}, h)
 		}
 	}
 
@@ -315,7 +318,7 @@ func compareListData[T ComparableData](entry commitDef, currentData, remoteData 
 		createData = append(createData, currentItem.GetData())
 	}
 	if len(createData) > 0 {
-		scheduler.Rqueue.Post(entry.URL, createData, 80, time.Time{})
+		scheduler.Rqueue.PostWithHeaders(entry.URL, createData, 80, time.Time{}, h)
 	}
 }
 
@@ -788,4 +791,3 @@ func getPartitions() ([]Partition, error) {
 	})
 	return partitionList, nil
 }
-

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -116,6 +116,17 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 
 	fullSync := len(keys) == 0
 
+	// Warn about unknown keys from caller (e.g., info sync command).
+	if !fullSync {
+		for _, key := range keys {
+			if key != "server" && key != "firewall" {
+				if _, ok := syncerMap[key]; !ok {
+					log.Warn().Str("key", key).Msg("Unknown sync key requested, ignoring.")
+				}
+			}
+		}
+	}
+
 	// server is always synced unconditionally (not hashed).
 	syncServerData(session)
 
@@ -224,7 +235,11 @@ func syncRequiredKeys(session *scheduler.Session, snap syncSnapshot) []string {
 	for _, s := range syncers {
 		if _, ok := requiredSet[s.Key()]; ok {
 			normalized = append(normalized, s.Key())
+			delete(requiredSet, s.Key())
 		}
+	}
+	for key := range requiredSet {
+		log.Warn().Str("key", key).Msg("Server returned unknown sync category, ignoring.")
 	}
 	return normalized
 }

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -255,11 +255,11 @@ func checkSyncHashes(session *scheduler.Session, hashes map[string]string) ([]st
 		return nil, fmt.Errorf("sync-check request failed: %w", err)
 	}
 	if statusCode != http.StatusOK {
-		body := string(resp)
-		if len(body) > 256 {
-			body = body[:256]
+		snippet := resp
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
 		}
-		return nil, fmt.Errorf("sync-check returned HTTP %d: %s", statusCode, body)
+		return nil, fmt.Errorf("sync-check returned HTTP %d: %s", statusCode, snippet)
 	}
 
 	var result struct {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -125,8 +125,13 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 	// Step 2 & 3: check hashes with server and sync changed categories.
 	if !snap.empty() {
 		for _, key := range syncRequiredKeys(session, snap) {
+			data, exists := snap.data[key]
+			if !exists {
+				log.Warn().Str("key", key).Msg("Server requested sync for uncollected category, skipping.")
+				continue
+			}
 			if s, ok := syncerMap[key]; ok {
-				s.syncData(session, snap.data[key])
+				s.syncData(session, data)
 			}
 		}
 	}
@@ -204,8 +209,21 @@ func syncRequiredKeys(session *scheduler.Session, snap syncSnapshot) []string {
 				required = append(required, s.Key())
 			}
 		}
+		return required
 	}
-	return required
+
+	// Normalize server-provided keys to the deterministic syncers registration order.
+	requiredSet := make(map[string]struct{}, len(required))
+	for _, key := range required {
+		requiredSet[key] = struct{}{}
+	}
+	normalized := make([]string, 0, len(required))
+	for _, s := range syncers {
+		if _, ok := requiredSet[s.Key()]; ok {
+			normalized = append(normalized, s.Key())
+		}
+	}
+	return normalized
 }
 
 // checkSyncHashes sends per-category data hashes to the server and returns the
@@ -219,7 +237,11 @@ func checkSyncHashes(session *scheduler.Session, hashes map[string]string) ([]st
 		return nil, fmt.Errorf("sync-check request failed: %w", err)
 	}
 	if statusCode != http.StatusOK {
-		return nil, fmt.Errorf("sync-check returned HTTP %d", statusCode)
+		body := string(resp)
+		if len(body) > 256 {
+			body = body[:256]
+		}
+		return nil, fmt.Errorf("sync-check returned HTTP %d: %s", statusCode, body)
 	}
 
 	var result struct {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -745,6 +745,9 @@ func getDisks() ([]Disk, error) {
 		})
 	}
 
+	slices.SortFunc(disks, func(a, b Disk) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return disks, nil
 }
 
@@ -779,7 +782,9 @@ func getPartitions() ([]Partition, error) {
 	for _, partition := range seen {
 		partitionList = append(partitionList, partition)
 	}
-
+	slices.SortFunc(partitionList, func(a, b Partition) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return partitionList, nil
 }
 

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -130,9 +130,12 @@ func SyncSystemInfo(session *scheduler.Session, keys []string) {
 				log.Warn().Str("key", key).Msg("Server requested sync for uncollected category, skipping.")
 				continue
 			}
-			if s, ok := syncerMap[key]; ok {
-				s.syncData(session, data)
+			s, ok := syncerMap[key]
+			if !ok {
+				log.Warn().Str("key", key).Msg("Server returned unknown sync category, skipping.")
+				continue
 			}
+			s.syncData(session, data)
 		}
 	}
 

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -382,5 +383,77 @@ func TestSyncerCollect(t *testing.T) {
 		}
 		_ = result
 	}
+}
+
+func TestComputeFingerprint(t *testing.T) {
+	data := map[string]string{"key": "value"}
+	hash := computeFingerprint(data)
+
+	assert.True(t, strings.HasPrefix(hash, "sha256:"), "Hash should have sha256: prefix")
+	assert.Len(t, hash, 7+64, "sha256: prefix (7) + 64 hex chars")
+
+	// Determinism: same input produces same hash
+	hash2 := computeFingerprint(data)
+	assert.Equal(t, hash, hash2, "Same input should produce same hash")
+
+	// Different input produces different hash
+	hash3 := computeFingerprint(map[string]string{"key": "other"})
+	assert.NotEqual(t, hash, hash3, "Different input should produce different hash")
+}
+
+func TestComputeFingerprintEmptyOnError(t *testing.T) {
+	// Channels cannot be marshaled to JSON
+	hash := computeFingerprint(make(chan int))
+	assert.Equal(t, "", hash, "Should return empty string on marshal error")
+}
+
+func TestSyncerComputeHash(t *testing.T) {
+	for _, s := range syncers {
+		result, err := s.Collect()
+		if err != nil {
+			t.Logf("Collect returned error for %s: %v (skipping hash test)", s.Key(), err)
+			continue
+		}
+		hash := s.ComputeHash(result)
+		assert.True(t, strings.HasPrefix(hash, "sha256:"),
+			"Syncer %s should produce sha256-prefixed hash, got: %s", s.Key(), hash)
+		assert.Len(t, hash, 7+64,
+			"Syncer %s hash should be 71 chars (sha256: + 64 hex)", s.Key())
+	}
+}
+
+func TestTimeSyncerComputeHash(t *testing.T) {
+	timeSyncer := syncerMap["time"]
+	assert.NotNil(t, timeSyncer, "time syncer should exist")
+
+	// Same timezone, different datetime/uptime should produce same hash
+	time1 := TimeData{Datetime: "2024-01-01T00:00:00Z", Timezone: "Asia/Seoul", Uptime: 86400}
+	time2 := TimeData{Datetime: "2024-01-01T01:00:00Z", Timezone: "Asia/Seoul", Uptime: 90000}
+	assert.Equal(t, timeSyncer.ComputeHash(time1), timeSyncer.ComputeHash(time2),
+		"Same timezone with different datetime/uptime should produce same hash")
+
+	// Different timezone should produce different hash
+	time3 := TimeData{Datetime: "2024-01-01T00:00:00Z", Timezone: "US/Pacific", Uptime: 86400}
+	assert.NotEqual(t, timeSyncer.ComputeHash(time1), timeSyncer.ComputeHash(time3),
+		"Different timezone should produce different hash")
+}
+
+func TestComputeFingerprintStructDeterminism(t *testing.T) {
+	// Verify struct field ordering is deterministic across calls
+	data := SystemData{
+		UUID:             "test-uuid",
+		CPUType:          "x86_64",
+		CPUBrand:         "Intel",
+		CPUPhysicalCores: 4,
+		CPULogicalCores:  8,
+		PhysicalMemory:   16000000000,
+		Hostname:         "testhost",
+	}
+
+	hashes := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		hashes[computeFingerprint(data)] = true
+	}
+	assert.Len(t, hashes, 1, "Same struct should always produce the same hash")
 }
 

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -63,7 +63,10 @@ func (s *singleRowSyncer[T]) Collect() (any, error) { return s.collect() }
 func (s *singleRowSyncer[T]) Def() commitDef { return commitDefs[s.key] }
 
 func (s *singleRowSyncer[T]) ComputeHash(data any) string {
-	typed := data.(T)
+	typed, ok := data.(T)
+	if !ok {
+		return ""
+	}
 	if s.hashTransform != nil {
 		return computeFingerprint(s.hashTransform(typed))
 	}
@@ -71,7 +74,11 @@ func (s *singleRowSyncer[T]) ComputeHash(data any) string {
 }
 
 func (s *singleRowSyncer[T]) syncData(session *scheduler.Session, data any) {
-	current := data.(T)
+	current, ok := data.(T)
+	if !ok {
+		log.Error().Msgf("Invalid data type for %s, skipping sync.", s.key)
+		return
+	}
 	entry := s.Def()
 	resp, statusCode, err := session.Get(utils.JoinPath(entry.URL, entry.URLSuffix), 10)
 	if err != nil {
@@ -110,7 +117,11 @@ func (s *multiRowSyncer[T]) ComputeHash(data any) string {
 }
 
 func (s *multiRowSyncer[T]) syncData(session *scheduler.Session, data any) {
-	current := data.([]T)
+	current, ok := data.([]T)
+	if !ok {
+		log.Error().Msgf("Invalid data type for %s, skipping sync.", s.key)
+		return
+	}
 	entry := s.Def()
 	resp, statusCode, err := session.Get(utils.JoinPath(entry.URL, entry.URLSuffix), 10)
 	if err != nil {

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -26,7 +26,9 @@ type syncable interface {
 	// syncData syncs using pre-collected data from Collect().
 	// The hash protocol collects data once in Step 1 for hashing
 	// and reuses it here in Step 3 for syncing.
-	syncData(session *scheduler.Session, data any)
+	// The hash is sent as X-Sync-Hash header on write requests
+	// so the server can store it for future sync-check comparisons.
+	syncData(session *scheduler.Session, data any, hash string)
 }
 
 // syncers registers all 9 syncable data categories.
@@ -74,7 +76,7 @@ func (s *singleRowSyncer[T]) ComputeHash(data any) string {
 	return computeFingerprint(typed)
 }
 
-func (s *singleRowSyncer[T]) syncData(session *scheduler.Session, data any) {
+func (s *singleRowSyncer[T]) syncData(session *scheduler.Session, data any, hash string) {
 	current, ok := data.(T)
 	if !ok {
 		log.Error().Msgf("Invalid data type for %s, skipping sync.", s.key)
@@ -93,9 +95,9 @@ func (s *singleRowSyncer[T]) syncData(session *scheduler.Session, data any) {
 			log.Error().Err(err).Msgf("Failed to unmarshal remote data for %s.", s.key)
 			return
 		}
-		compareData(entry, current, remote)
+		compareData(entry, current, remote, hash)
 	case http.StatusNotFound:
-		compareData(entry, current, nil)
+		compareData(entry, current, nil, hash)
 	default:
 		log.Error().Msgf("Unexpected HTTP %d when syncing %s.", statusCode, s.key)
 	}
@@ -117,7 +119,7 @@ func (s *multiRowSyncer[T]) ComputeHash(data any) string {
 	return computeFingerprint(data)
 }
 
-func (s *multiRowSyncer[T]) syncData(session *scheduler.Session, data any) {
+func (s *multiRowSyncer[T]) syncData(session *scheduler.Session, data any, hash string) {
 	current, ok := data.([]T)
 	if !ok {
 		log.Error().Msgf("Invalid data type for %s, skipping sync.", s.key)
@@ -136,9 +138,9 @@ func (s *multiRowSyncer[T]) syncData(session *scheduler.Session, data any) {
 			log.Error().Err(err).Msgf("Failed to unmarshal remote data for %s.", s.key)
 			return
 		}
-		compareListData(entry, current, remote)
+		compareListData(entry, current, remote, hash)
 	case http.StatusNotFound:
-		compareListData(entry, current, nil)
+		compareListData(entry, current, nil, hash)
 	default:
 		log.Error().Msgf("Unexpected HTTP %d when syncing %s.", statusCode, s.key)
 	}
@@ -187,6 +189,14 @@ var syncerMap = func() map[string]syncable {
 	}
 	return m
 }()
+
+// syncHashHeader returns headers with X-Sync-Hash, or nil if hash is empty.
+func syncHashHeader(hash string) scheduler.Headers {
+	if hash == "" {
+		return nil
+	}
+	return scheduler.Headers{"X-Sync-Hash": hash}
+}
 
 // computeFingerprint returns a SHA-256 hash of the JSON-serialized data.
 // Returns an empty string on serialization error, causing the server to always flag the category for sync.

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -1,8 +1,11 @@
 package runner
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"slices"
 
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -14,12 +17,16 @@ type Syncer interface {
 	Key() string
 	Collect() (any, error)
 	Def() commitDef
+	ComputeHash(data any) string
 }
 
-// syncable extends Syncer with sync execution capability.
+// syncable extends Syncer with sync execution using pre-collected data.
 type syncable interface {
 	Syncer
-	syncWith(session *scheduler.Session)
+	// syncData syncs using pre-collected data from Collect().
+	// The hash protocol collects data once in Step 1 for hashing
+	// and reuses it here in Step 3 for syncing.
+	syncData(session *scheduler.Session, data any)
 }
 
 // syncers registers all 9 syncable data categories.
@@ -27,7 +34,13 @@ type syncable interface {
 var syncers = []syncable{
 	&singleRowSyncer[SystemData]{key: "info", collect: getSystemData},
 	&singleRowSyncer[OSData]{key: "os", collect: getOsData},
-	&singleRowSyncer[TimeData]{key: "time", collect: getTimeData},
+	&singleRowSyncer[TimeData]{
+		key:     "time",
+		collect: getTimeData,
+		hashTransform: func(td TimeData) any {
+			return td.GetComparableData()
+		},
+	},
 	&multiRowSyncer[UserData]{key: "users", collect: getUserData},
 	&multiRowSyncer[GroupData]{key: "groups", collect: getGroupData},
 	&multiRowSyncer[Interface]{key: "interfaces", collect: getNetworkInterfaces},
@@ -38,8 +51,9 @@ var syncers = []syncable{
 
 // singleRowSyncer handles categories with a single data row (info, os, time).
 type singleRowSyncer[T ComparableData] struct {
-	key     string
-	collect func() (T, error)
+	key           string
+	collect       func() (T, error)
+	hashTransform func(T) any
 }
 
 func (s *singleRowSyncer[T]) Key() string { return s.key }
@@ -48,13 +62,16 @@ func (s *singleRowSyncer[T]) Collect() (any, error) { return s.collect() }
 
 func (s *singleRowSyncer[T]) Def() commitDef { return commitDefs[s.key] }
 
-func (s *singleRowSyncer[T]) syncWith(session *scheduler.Session) {
-	current, err := s.collect()
-	if err != nil {
-		log.Debug().Err(err).Msgf("Failed to collect %s data.", s.key)
-		return
+func (s *singleRowSyncer[T]) ComputeHash(data any) string {
+	typed := data.(T)
+	if s.hashTransform != nil {
+		return computeFingerprint(s.hashTransform(typed))
 	}
+	return computeFingerprint(typed)
+}
 
+func (s *singleRowSyncer[T]) syncData(session *scheduler.Session, data any) {
+	current := data.(T)
 	entry := s.Def()
 	resp, statusCode, err := session.Get(utils.JoinPath(entry.URL, entry.URLSuffix), 10)
 	if err != nil {
@@ -88,13 +105,12 @@ func (s *multiRowSyncer[T]) Collect() (any, error) { return s.collect() }
 
 func (s *multiRowSyncer[T]) Def() commitDef { return commitDefs[s.key] }
 
-func (s *multiRowSyncer[T]) syncWith(session *scheduler.Session) {
-	current, err := s.collect()
-	if err != nil {
-		log.Debug().Err(err).Msgf("Failed to collect %s data.", s.key)
-		return
-	}
+func (s *multiRowSyncer[T]) ComputeHash(data any) string {
+	return computeFingerprint(data)
+}
 
+func (s *multiRowSyncer[T]) syncData(session *scheduler.Session, data any) {
+	current := data.([]T)
 	entry := s.Def()
 	resp, statusCode, err := session.Get(utils.JoinPath(entry.URL, entry.URLSuffix), 10)
 	if err != nil {
@@ -116,6 +132,37 @@ func (s *multiRowSyncer[T]) syncWith(session *scheduler.Session) {
 	}
 }
 
+// syncSnapshot holds the result of Step 1: per-category collected data and their hashes.
+type syncSnapshot struct {
+	hashes map[string]string
+	data   map[string]any
+}
+
+// collectSnapshot collects data and computes hashes for the given syncers.
+// If keys is empty, all syncers are collected (full sync).
+func collectSnapshot(keys []string) syncSnapshot {
+	fullSync := len(keys) == 0
+	snap := syncSnapshot{
+		hashes: make(map[string]string, len(syncers)),
+		data:   make(map[string]any, len(syncers)),
+	}
+	for _, s := range syncers {
+		if !fullSync && !slices.Contains(keys, s.Key()) {
+			continue
+		}
+		d, err := s.Collect()
+		if err != nil {
+			log.Debug().Err(err).Msgf("Failed to collect %s data.", s.Key())
+			continue
+		}
+		snap.data[s.Key()] = d
+		snap.hashes[s.Key()] = s.ComputeHash(d)
+	}
+	return snap
+}
+
+func (s syncSnapshot) empty() bool { return len(s.hashes) == 0 }
+
 // syncerMap is a lookup map from key to syncable, built from syncers.
 var syncerMap = func() map[string]syncable {
 	m := make(map[string]syncable, len(syncers))
@@ -129,16 +176,15 @@ var syncerMap = func() map[string]syncable {
 	return m
 }()
 
-// allSyncKeys returns all sync keys including server and firewall.
-// server is first (patches version/load before data syncs), firewall is last (delegated to executor).
-func allSyncKeys() []string {
-	keys := make([]string, 0, len(syncers)+2)
-	keys = append(keys, "server")
-	for _, s := range syncers {
-		keys = append(keys, s.Key())
+// computeFingerprint returns a SHA-256 hash of the JSON-serialized data.
+// Returns an empty string on serialization error, causing the server to always flag the category for sync.
+func computeFingerprint(data any) string {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return ""
 	}
-	keys = append(keys, "firewall")
-	return keys
+	hash := sha256.Sum256(jsonBytes)
+	return "sha256:" + hex.EncodeToString(hash[:])
 }
 
 // assignToCommitData maps a syncer's collected data to the appropriate commitData field.

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -65,6 +65,7 @@ func (s *singleRowSyncer[T]) Def() commitDef { return commitDefs[s.key] }
 func (s *singleRowSyncer[T]) ComputeHash(data any) string {
 	typed, ok := data.(T)
 	if !ok {
+		log.Debug().Str("key", s.key).Msg("Unexpected data type in ComputeHash, forcing sync.")
 		return ""
 	}
 	if s.hashTransform != nil {

--- a/pkg/scheduler/queue.go
+++ b/pkg/scheduler/queue.go
@@ -37,10 +37,15 @@ func lessFunc(elem, otherElem PriorityEntry) bool {
 	return elem.priority < otherElem.priority
 }
 
-func (rq *RequestQueue) request(method, url string, data interface{}, priority int, due time.Time) {
+func (rq *RequestQueue) request(method, url string, data interface{}, priority int, due time.Time, headers Headers) {
 	// time.Time{}: 0001-01-01 00:00:00 +0000 UTC
 	if due.IsZero() {
 		due = time.Now()
+	}
+
+	var h *Headers
+	if len(headers) > 0 {
+		h = &headers
 	}
 
 	entry := PriorityEntry{
@@ -48,6 +53,7 @@ func (rq *RequestQueue) request(method, url string, data interface{}, priority i
 		method:   method,
 		url:      url,
 		data:     data,
+		headers:  h,
 		due:      due,
 		// expiry:
 		retry: RetryLimit,
@@ -64,17 +70,29 @@ func (rq *RequestQueue) request(method, url string, data interface{}, priority i
 }
 
 func (rq *RequestQueue) Post(url string, data interface{}, priority int, due time.Time) {
-	rq.request(http.MethodPost, url, data, priority, due)
+	rq.request(http.MethodPost, url, data, priority, due, nil)
+}
+
+func (rq *RequestQueue) PostWithHeaders(url string, data interface{}, priority int, due time.Time, headers Headers) {
+	rq.request(http.MethodPost, url, data, priority, due, headers)
 }
 
 func (rq *RequestQueue) Patch(url string, data interface{}, priority int, due time.Time) {
-	rq.request(http.MethodPatch, url, data, priority, due)
+	rq.request(http.MethodPatch, url, data, priority, due, nil)
+}
+
+func (rq *RequestQueue) PatchWithHeaders(url string, data interface{}, priority int, due time.Time, headers Headers) {
+	rq.request(http.MethodPatch, url, data, priority, due, headers)
 }
 
 func (rq *RequestQueue) Put(url string, data interface{}, priority int, due time.Time) {
-	rq.request(http.MethodPut, url, data, priority, due)
+	rq.request(http.MethodPut, url, data, priority, due, nil)
 }
 
 func (rq *RequestQueue) Delete(url string, data interface{}, priority int, due time.Time) {
-	rq.request(http.MethodDelete, url, data, priority, due)
+	rq.request(http.MethodDelete, url, data, priority, due, nil)
+}
+
+func (rq *RequestQueue) DeleteWithHeaders(url string, data interface{}, priority int, due time.Time, headers Headers) {
+	rq.request(http.MethodDelete, url, data, priority, due, headers)
 }

--- a/pkg/scheduler/reporter.go
+++ b/pkg/scheduler/reporter.go
@@ -100,7 +100,11 @@ func reportStartupEvent() {
 
 func (r *Reporter) query(entry PriorityEntry) {
 	t1 := time.Now()
-	resp, statusCode, err := r.session.Request(entry.method, entry.url, entry.data, 5)
+	var headers Headers
+	if entry.headers != nil {
+		headers = *entry.headers
+	}
+	resp, statusCode, err := r.session.RequestWithHeaders(entry.method, entry.url, entry.data, 5, headers)
 	t2 := time.Now()
 
 	r.counters.delay = r.counters.delay*0.9 + (t2.Sub(entry.due).Seconds())*0.1

--- a/pkg/scheduler/session.go
+++ b/pkg/scheduler/session.go
@@ -137,9 +137,16 @@ func (session *Session) do(req *http.Request, timeout time.Duration) ([]byte, in
 }
 
 func (session *Session) Request(method, url string, rawBody interface{}, timeout time.Duration) ([]byte, int, error) {
+	return session.RequestWithHeaders(method, url, rawBody, timeout, nil)
+}
+
+func (session *Session) RequestWithHeaders(method, url string, rawBody interface{}, timeout time.Duration, headers Headers) ([]byte, int, error) {
 	req, err := session.newRequest(method, url, rawBody)
 	if err != nil {
 		return nil, 0, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, statusCode, err := session.do(req, timeout)

--- a/pkg/scheduler/types.go
+++ b/pkg/scheduler/types.go
@@ -13,12 +13,16 @@ type Session struct {
 	Authorization string
 }
 
+// Headers is a named map type for HTTP headers attached to queue entries.
+type Headers map[string]string
+
 // queue //
 type PriorityEntry struct {
 	priority int
 	method   string
 	url      string
 	data     interface{}
+	headers  *Headers
 	due      time.Time
 	expiry   time.Time
 	retry    int


### PR DESCRIPTION
### Summary

- Implement 2-phase hash-based sync protocol: agent sends per-category SHA-256 hashes to the server via `POST /sync-check/`, and the server responds with only the categories that need syncing
- Reduce full sync cycle from 10+ sequential HTTP calls to 1-2, eliminating unnecessary GET/PATCH round-trips for unchanged data
- Send computed hash back to server via `X-Sync-Hash` header on write requests (POST/PATCH/DELETE), so the server can store it for future sync-check comparisons
- Falls back to full sync automatically when the server does not support the `sync-check` endpoint (backward compatible with older servers)

### Changes

**`pkg/scheduler/types.go`**
- Add `Headers` named map type (`map[string]string`) for custom HTTP headers on queue entries
- Add `headers *Headers` field to `PriorityEntry` (pointer to satisfy `comparable` constraint)

**`pkg/scheduler/queue.go`**
- Add `PostWithHeaders`, `PatchWithHeaders`, `DeleteWithHeaders` methods for enqueueing requests with custom headers
- Unify internal `request()` to accept `Headers` and convert to `*Headers` for storage

**`pkg/scheduler/session.go`**
- Add `RequestWithHeaders()` method accepting `Headers` parameter
- Refactor `Request()` to delegate to `RequestWithHeaders(nil)`

**`pkg/scheduler/reporter.go`**
- Pass `entry.headers` to `RequestWithHeaders()` when processing queue entries

**`pkg/runner/syncer.go`**
- Add `ComputeHash(data any) string` to `Syncer` interface
- Add `syncData(session, data any, hash string)` to `syncable` interface for syncing with pre-collected data and hash propagation
- Add `syncSnapshot` struct to bundle collected data and hashes from Step 1
- Add `collectSnapshot(keys)` to encapsulate the collect + hash loop
- Add `computeFingerprint(data any) string` utility (SHA-256 with `sha256:` prefix)
- Add `syncHashHeader(hash string) scheduler.Headers` helper to convert hash to `X-Sync-Hash` header
- Add `hashTransform func(T) any` field on `singleRowSyncer` for category-specific hash logic (`time` hashes only `Timezone` via `GetComparableData()`)

**`pkg/runner/commit.go`**
- Rewrite `SyncSystemInfo()` with 3-step hash flow: collect+hash → check with server → selective sync
- Add `checkSyncHashes()` to POST hashes to `/api/servers/servers/-/sync-check/`
- Add `syncRequiredKeys()` to handle server response with fallback in deterministic syncer order
- Pass sync hash through `compareData()` and `compareListData()` to all write requests (POST/PATCH/DELETE)

**`pkg/runner/commit_test.go`**
- Add `TestComputeFingerprint`: determinism, prefix format, different input
- Add `TestComputeFingerprintEmptyOnError`: empty string on marshal failure
- Add `TestSyncerComputeHash`: all 9 syncers produce valid hashes
- Add `TestTimeSyncerComputeHash`: timezone-only hashing verified
- Add `TestComputeFingerprintStructDeterminism`: 100-iteration consistency

### Hash computation rules

| Category | Hash input | Reason |
|----------|-----------|--------|
| `server` | Not hashed | Always PATCHed (version, load) |
| `firewall` | Not hashed | Delegated to executor |
| `time` | `Timezone` only | `Datetime`/`Uptime` change every cycle |
| Others (7) | Full JSON data | Change detection target |
| On error | Empty string `""` | Server always flags for sync |

### Backward compatibility

When `checkSyncHashes()` returns an error (old server 404, network failure), the agent falls back to syncing all collected categories via the existing full-sync path. No version negotiation needed.

### Server-side dependency

This PR requires the corresponding server-side implementation:
- `POST /api/servers/servers/-/sync-check/` endpoint
- `Server.sync_hashes` DB field and migration
- Hash storage on successful write requests via `X-Sync-Hash` header

Deploy order: server DB migration → both code deployments simultaneously. Agent works correctly even if the server is not yet updated (fallback).

### Test plan

- [x] Build passes: `go build ./pkg/runner/`
- [x] All tests pass: `go test -v ./pkg/runner/ -p 1` (49 tests)
- [x] `go vet` and `gofmt` pass
- [ ] Hash match: all hashes match → no GET/PATCH calls (only sync-check POST)
- [ ] Hash mismatch: some categories differ → only those categories sync
- [ ] Fallback on 404: old server → full sync via existing path
- [ ] Fallback on network error: POST fails → full sync
- [ ] `time` category: only timezone change triggers different hash
- [ ] Agent restart: server retains stored hashes, unchanged categories skip sync
- [ ] X-Sync-Hash header: server receives and stores hash on POST/PATCH/DELETE

Closes #247
