### PR TITLE
fix: improve handler timeout consistency and fix flaky upgrade test

### DIFF
--- a/Dockerfiles/build.sh
+++ b/Dockerfiles/build.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+#
+# Build all Docker images for testing.
+#
+# Usage (run from the repo root):
+#   ./Dockerfiles/build.sh
+#
+# Running a container:
+#   docker run \
+#     --add-host="<your-domain>:host-gateway" \
+#     -e ALPACON_URL="http://host.docker.internal:8000" \
+#     -e PLUGIN_ID="<your-plugin-id>" \
+#     -e PLUGIN_KEY="<your-plugin-key>" \
+#     alpamon:<distro>
+#
+# Notes:
+#   --add-host is required so the container can resolve the Alpacon domain
+#   to the host machine instead of 127.0.0.1 (which would be the container itself).
+#   ALPACON_URL must point to the HTTP API port (default 8000), not the
+#   backhaul WebSocket port (8081).
 
 docker build -t alpamon:debian-10 -f Dockerfiles/debian/10/Dockerfile .
 docker build -t alpamon:debian-11 -f Dockerfiles/debian/11/Dockerfile .

--- a/Dockerfiles/centos/7/entrypoint.sh
+++ b/Dockerfiles/centos/7/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/centos/7/entrypoint.sh
+++ b/Dockerfiles/centos/7/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"959ae5c7-84b0-4fba-8c1e-5b8a3d6dcadc"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/debian/10/Dockerfile
+++ b/Dockerfiles/debian/10/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM debian:10
 
-RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/debian/10/entrypoint.sh
+++ b/Dockerfiles/debian/10/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081}
-PLUGIN_ID=${PLUGIN_ID:-"d59bc536-2f33-43e0-8d78-bca3ecd91b8e"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/debian/10/entrypoint.sh
+++ b/Dockerfiles/debian/10/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/debian/11/Dockerfile
+++ b/Dockerfiles/debian/11/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM debian:11
 
-RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/debian/11/entrypoint.sh
+++ b/Dockerfiles/debian/11/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/debian/11/entrypoint.sh
+++ b/Dockerfiles/debian/11/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"71e4e4f9-3553-4554-8695-6425c34eb955"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/redhat/8/entrypoint.sh
+++ b/Dockerfiles/redhat/8/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"ff79dd66-0cfa-4a29-902a-b023038b12e3"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/redhat/8/entrypoint.sh
+++ b/Dockerfiles/redhat/8/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/redhat/9/entrypoint.sh
+++ b/Dockerfiles/redhat/9/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/redhat/9/entrypoint.sh
+++ b/Dockerfiles/redhat/9/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"97a27261-6029-48b3-89df-b31040a43722"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/18.04/Dockerfile
+++ b/Dockerfiles/ubuntu/18.04/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM ubuntu:18.04
 
-RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/18.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/18.04/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"756d1a97-a4ec-4d76-a9a0-688f15416abf"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/18.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/18.04/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/20.04/Dockerfile
+++ b/Dockerfiles/ubuntu/20.04/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 
 FROM ubuntu:20.04
 
-RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends systemd ca-certificates
+RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/20.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/20.04/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/20.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/20.04/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"617cfd44-a25e-4fc7-90e1-bfafe429c649"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/22.04/Dockerfile
+++ b/Dockerfiles/ubuntu/22.04/Dockerfile
@@ -20,14 +20,7 @@ RUN go build -o alpamon ./cmd/alpamon/main.go
 FROM ubuntu:22.04
 
 RUN apt-get update -o Acquire::Retries=3 && apt-get install -y -o Acquire::Retries=3 --no-install-recommends \
-    curl \
-    systemd \
-    ca-certificates \
-    sudo \
-    vim \
-    build-essential \
-    libpam0g-dev \
-    libjansson-dev
+    ca-certificates
 
 WORKDIR /usr/local/alpamon
 

--- a/Dockerfiles/ubuntu/22.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/22.04/entrypoint.sh
@@ -9,8 +9,9 @@ if [ -z "$PLUGIN_ID" ]; then
     exit 1
 fi
 
-mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
-chmod 750 /var/run/alpamon
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]

--- a/Dockerfiles/ubuntu/22.04/entrypoint.sh
+++ b/Dockerfiles/ubuntu/22.04/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8081"}
-PLUGIN_ID=${PLUGIN_ID:-"a7282bea-31d7-4b55-a43e-97e1240c90ab"}
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
 PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
 
-mkdir -p /etc/alpamon
+if [ -z "$PLUGIN_ID" ]; then
+    echo "Error: PLUGIN_ID environment variable is required."
+    echo "Usage: docker run -e PLUGIN_ID=<your-plugin-id> [-e ALPACON_URL=...] [-e PLUGIN_KEY=...] <image>"
+    exit 1
+fi
+
+mkdir -p /etc/alpamon /var/run/alpamon /var/log/alpamon /var/lib/alpamon
+chmod 750 /var/run/alpamon
 
 cat > /etc/alpamon/alpamon.conf <<EOL
 [server]
@@ -18,10 +24,5 @@ EOL
 
 echo -e "\nThe following configuration file is being used:\n"
 cat /etc/alpamon/alpamon.conf
-
-echo "[entrypoint] creating /var/run/alpamon..."
-mkdir -p /var/run/alpamon
-chown root:root /var/run/alpamon
-chmod 750 /var/run/alpamon
 
 exec /usr/local/alpamon/alpamon

--- a/pkg/executor/factory.go
+++ b/pkg/executor/factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alpacax/alpamon/pkg/executor/services"
 	"github.com/alpacax/alpamon/pkg/runner"
 	"github.com/alpacax/alpamon/pkg/scheduler"
+	"github.com/alpacax/alpamon/pkg/utils"
 )
 
 // SystemInfoCallbacks contains function callbacks for system info operations
@@ -59,7 +60,7 @@ func (f *HandlerFactory) RegisterAll(
 
 	// Define all handlers in a slice for streamlined registration
 	handlers := []common.Handler{
-		system.NewSystemHandler(f.cmdExec, wsClient, ctxManager, pool),
+		system.NewSystemHandler(f.cmdExec, wsClient, ctxManager, pool, utils.NewDefaultVersionResolver()),
 		group.NewGroupHandler(f.cmdExec, infoAdapter),
 		info.NewInfoHandler(infoAdapter),
 		shell.NewShellHandler(f.cmdExec),

--- a/pkg/executor/handlers/common/interfaces.go
+++ b/pkg/executor/handlers/common/interfaces.go
@@ -61,3 +61,10 @@ type SystemInfoManager interface {
 type APISession interface {
 	MultipartRequest(url string, body bytes.Buffer, contentType string, timeout time.Duration) ([]byte, int, error)
 }
+
+// VersionResolver provides version information for upgrade decisions.
+type VersionResolver interface {
+	GetLatestVersion() string
+	GetPamVersion() string
+	InvalidatePamCache()
+}

--- a/pkg/executor/handlers/common/timeout.go
+++ b/pkg/executor/handlers/common/timeout.go
@@ -21,7 +21,7 @@ const (
 	InfoTimeout       = 30 * time.Second
 )
 
-// TimeoutResult is returned when a handler-level timeout is exceeded.
+// TimeoutExitCode is returned when a handler-level timeout is exceeded.
 const TimeoutExitCode = 124
 
 // WithHandlerTimeout wraps ctx with the given timeout and returns a

--- a/pkg/executor/handlers/firewall/firewall.go
+++ b/pkg/executor/handlers/firewall/firewall.go
@@ -117,7 +117,7 @@ func (h *FirewallHandler) Execute(ctx context.Context, cmd string, args *common.
 		return 1, "", fmt.Errorf("unknown firewall command: %s", cmd)
 	}
 
-	if common.IsTimeout(ctx) {
+	if err != nil && common.IsTimeout(ctx) {
 		return common.TimeoutError(common.FirewallTimeout)
 	}
 	return exitCode, output, err

--- a/pkg/executor/handlers/firewall/firewall.go
+++ b/pkg/executor/handlers/firewall/firewall.go
@@ -117,6 +117,9 @@ func (h *FirewallHandler) Execute(ctx context.Context, cmd string, args *common.
 		return 1, "", fmt.Errorf("unknown firewall command: %s", cmd)
 	}
 
+	if common.IsTimeout(ctx) {
+		return common.TimeoutError(common.FirewallTimeout)
+	}
 	return exitCode, output, err
 }
 

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -50,7 +50,7 @@ func (h *GroupHandler) Execute(ctx context.Context, cmd string, args *common.Com
 		return 1, "", fmt.Errorf("unknown group command: %s", cmd)
 	}
 
-	if common.IsTimeout(ctx) {
+	if err != nil && common.IsTimeout(ctx) {
 		return common.TimeoutError(common.GroupTimeout)
 	}
 

--- a/pkg/executor/handlers/group/group.go
+++ b/pkg/executor/handlers/group/group.go
@@ -50,6 +50,10 @@ func (h *GroupHandler) Execute(ctx context.Context, cmd string, args *common.Com
 		return 1, "", fmt.Errorf("unknown group command: %s", cmd)
 	}
 
+	if common.IsTimeout(ctx) {
+		return common.TimeoutError(common.GroupTimeout)
+	}
+
 	// Sync system info after successful command execution
 	if exitCode == 0 && h.syncManager != nil {
 		h.syncManager.SyncSystemInfo([]string{"groups", "users"})

--- a/pkg/executor/handlers/info/info.go
+++ b/pkg/executor/handlers/info/info.go
@@ -34,19 +34,31 @@ func NewInfoHandler(infoManager common.SystemInfoManager) *InfoHandler {
 }
 
 // Execute runs the info command
-func (h *InfoHandler) Execute(_ context.Context, cmd string, args *common.CommandArgs) (int, string, error) {
+func (h *InfoHandler) Execute(ctx context.Context, cmd string, args *common.CommandArgs) (int, string, error) {
+	ctx, cancel := common.WithHandlerTimeout(ctx, common.InfoTimeout)
+	defer cancel()
+
+	var exitCode int
+	var output string
+	var err error
+
 	switch cmd {
 	case common.Ping.String():
-		return h.handlePing()
+		exitCode, output, err = h.handlePing()
 	case common.Help.String():
-		return h.handleHelp()
+		exitCode, output, err = h.handleHelp()
 	case common.Commit.String():
-		return h.handleCommit()
+		exitCode, output, err = h.handleCommit()
 	case common.Sync.String():
-		return h.handleSync(args)
+		exitCode, output, err = h.handleSync(args)
 	default:
 		return 1, "", fmt.Errorf("unknown info command: %s", cmd)
 	}
+
+	if common.IsTimeout(ctx) {
+		return common.TimeoutError(common.InfoTimeout)
+	}
+	return exitCode, output, err
 }
 
 // Validate checks if the arguments are valid for the command

--- a/pkg/executor/handlers/info/info.go
+++ b/pkg/executor/handlers/info/info.go
@@ -55,7 +55,7 @@ func (h *InfoHandler) Execute(ctx context.Context, cmd string, args *common.Comm
 		return 1, "", fmt.Errorf("unknown info command: %s", cmd)
 	}
 
-	if common.IsTimeout(ctx) {
+	if err != nil && common.IsTimeout(ctx) {
 		return common.TimeoutError(common.InfoTimeout)
 	}
 	return exitCode, output, err

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -18,13 +18,14 @@ import (
 // SystemHandler handles system-level commands like restart, reboot, shutdown, upgrade
 type SystemHandler struct {
 	*common.BaseHandler
-	wsClient   common.WSClient
-	ctxManager *agent.ContextManager
-	pool       *pool.Pool
+	wsClient        common.WSClient
+	ctxManager      *agent.ContextManager
+	pool            *pool.Pool
+	versionResolver common.VersionResolver
 }
 
 // NewSystemHandler creates a new system handler
-func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClient, ctxManager *agent.ContextManager, pool *pool.Pool) *SystemHandler {
+func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClient, ctxManager *agent.ContextManager, pool *pool.Pool, versionResolver common.VersionResolver) *SystemHandler {
 	h := &SystemHandler{
 		BaseHandler: common.NewBaseHandler(
 			common.System,
@@ -39,9 +40,10 @@ func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClie
 			},
 			cmdExecutor,
 		),
-		wsClient:   wsClient,
-		ctxManager: ctxManager,
-		pool:       pool,
+		wsClient:        wsClient,
+		ctxManager:      ctxManager,
+		pool:            pool,
+		versionResolver: versionResolver,
 	}
 	return h
 }
@@ -52,14 +54,24 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 	case common.Upgrade.String():
 		return h.withTimeout(ctx, common.UpgradeTimeout, h.handleUpgrade)
 	case common.Restart.String():
+		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		defer cancel()
 		return h.handleRestart(args)
 	case common.Quit.String():
+		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		defer cancel()
 		return h.handleQuit()
 	case common.ByeBye.String():
+		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		defer cancel()
 		return h.handleUninstall()
 	case common.Reboot.String():
+		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		defer cancel()
 		return h.handleReboot()
 	case common.Shutdown.String():
+		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		defer cancel()
 		return h.handleShutdown()
 	case common.Update.String():
 		return h.withTimeout(ctx, common.UpgradeTimeout, h.handleSystemUpdate)
@@ -72,7 +84,11 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 func (h *SystemHandler) withTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context) (int, string, error)) (int, string, error) {
 	ctx, cancel := common.WithHandlerTimeout(ctx, timeout)
 	defer cancel()
-	return fn(ctx)
+	exitCode, output, err := fn(ctx)
+	if common.IsTimeout(ctx) {
+		return common.TimeoutError(timeout)
+	}
+	return exitCode, output, err
 }
 
 // Validate checks if the arguments are valid for the command
@@ -86,7 +102,7 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 // the packages that need it. This prevents skipping a pam-only upgrade when
 // alpamon is already at the latest version.
 func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
-	latestVersion := utils.GetLatestVersion()
+	latestVersion := h.versionResolver.GetLatestVersion()
 	if latestVersion == "" {
 		return 1, "Failed to retrieve the latest Alpamon version from GitHub.",
 			errors.New("failed to retrieve the latest Alpamon version from GitHub")
@@ -94,7 +110,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 
 	needAlpamon := version.Version != latestVersion
 
-	currentPamVersion := utils.GetPamVersion()
+	currentPamVersion := h.versionResolver.GetPamVersion()
 	needPam := currentPamVersion != "" && currentPamVersion != latestVersion
 
 	if !needAlpamon && !needPam {
@@ -127,12 +143,16 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	log.Debug().Msgf("Upgrading %s...", pkgList)
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
 	if exitCode == 0 && needPam {
-		utils.InvalidatePamCache()
+		h.versionResolver.InvalidatePamCache()
 	}
 	return exitCode, output, err
 }
 
-// handleRestart handles the restart command
+// handleRestart handles the restart command.
+// This is a fire-and-forget command: the response is returned immediately and
+// the actual restart runs asynchronously via the pool with its own context
+// from ctxManager. The handler-level timeout in Execute() covers the synchronous
+// dispatch; the pool task manages its own lifecycle via ctxManager.NewContext().
 func (h *SystemHandler) handleRestart(args *common.CommandArgs) (int, string, error) {
 	target := args.Target
 	if target == "" {
@@ -171,7 +191,8 @@ func (h *SystemHandler) handleRestart(args *common.CommandArgs) (int, string, er
 	return 0, message, nil
 }
 
-// handleQuit handles the quit command
+// handleQuit handles the quit command.
+// See handleRestart for the fire-and-forget pattern.
 func (h *SystemHandler) handleQuit() (int, string, error) {
 	// Submit to worker pool for managed execution
 	poolCtx, cancel := h.ctxManager.NewContext(2 * time.Second)
@@ -196,7 +217,10 @@ func (h *SystemHandler) handleQuit() (int, string, error) {
 	return 0, "Alpamon will shutdown in 1 second.", nil
 }
 
-// handleUninstall handles the byebye (uninstall) command
+// handleUninstall handles the byebye (uninstall) command.
+// See handleRestart for the fire-and-forget pattern. executeUninstall uses
+// context.Background() intentionally because the uninstall must complete even
+// after the agent's own context tree is shut down.
 func (h *SystemHandler) handleUninstall() (int, string, error) {
 	log.Info().Msg("Uninstall request received.")
 
@@ -272,11 +296,14 @@ func (h *SystemHandler) executeUninstall() {
 	h.wsClient.ShutDown()
 }
 
-// handleReboot handles the reboot command
+// handleReboot handles the reboot command.
+// A separate context is created via ctxManager.NewContext instead of using the
+// handler's ctx because the response must be sent before the reboot executes.
+// The pool task runs asynchronously after the handler returns. The context is
+// still derived from ContextManager.root, so shutdown propagation works correctly.
 func (h *SystemHandler) handleReboot() (int, string, error) {
 	log.Info().Msg("Reboot request received.")
 
-	// Submit to worker pool for managed execution
 	poolCtx, cancel := h.ctxManager.NewContext(common.SystemCmdTimeout)
 	submitted := false
 	defer func() {
@@ -300,11 +327,11 @@ func (h *SystemHandler) handleReboot() (int, string, error) {
 	return 0, "Server will reboot in 1 second", nil
 }
 
-// handleShutdown handles the shutdown command
+// handleShutdown handles the shutdown command.
+// See handleReboot for why a separate context is created.
 func (h *SystemHandler) handleShutdown() (int, string, error) {
 	log.Info().Msg("Shutdown request received.")
 
-	// Submit to worker pool for managed execution
 	poolCtx, cancel := h.ctxManager.NewContext(common.SystemCmdTimeout)
 	submitted := false
 	defer func() {

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -24,8 +24,12 @@ type SystemHandler struct {
 	versionResolver common.VersionResolver
 }
 
-// NewSystemHandler creates a new system handler
+// NewSystemHandler creates a new system handler.
+// versionResolver must not be nil; pass utils.NewDefaultVersionResolver() for production.
 func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClient, ctxManager *agent.ContextManager, pool *pool.Pool, versionResolver common.VersionResolver) *SystemHandler {
+	if versionResolver == nil {
+		panic("system: versionResolver must not be nil")
+	}
 	h := &SystemHandler{
 		BaseHandler: common.NewBaseHandler(
 			common.System,
@@ -54,25 +58,45 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 	case common.Upgrade.String():
 		return h.withTimeout(ctx, common.UpgradeTimeout, h.handleUpgrade)
 	case common.Restart.String():
-		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
-		return h.handleRestart(args)
+		exitCode, output, err := h.handleRestart(args)
+		if common.IsTimeout(ctx) {
+			return common.TimeoutError(common.SystemCmdTimeout)
+		}
+		return exitCode, output, err
 	case common.Quit.String():
-		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
-		return h.handleQuit()
+		exitCode, output, err := h.handleQuit()
+		if common.IsTimeout(ctx) {
+			return common.TimeoutError(common.SystemCmdTimeout)
+		}
+		return exitCode, output, err
 	case common.ByeBye.String():
-		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
-		return h.handleUninstall()
+		exitCode, output, err := h.handleUninstall()
+		if common.IsTimeout(ctx) {
+			return common.TimeoutError(common.SystemCmdTimeout)
+		}
+		return exitCode, output, err
 	case common.Reboot.String():
-		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
-		return h.handleReboot()
+		exitCode, output, err := h.handleReboot()
+		if common.IsTimeout(ctx) {
+			return common.TimeoutError(common.SystemCmdTimeout)
+		}
+		return exitCode, output, err
 	case common.Shutdown.String():
-		_, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
+		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
-		return h.handleShutdown()
+		exitCode, output, err := h.handleShutdown()
+		if common.IsTimeout(ctx) {
+			return common.TimeoutError(common.SystemCmdTimeout)
+		}
+		return exitCode, output, err
 	case common.Update.String():
 		return h.withTimeout(ctx, common.UpgradeTimeout, h.handleSystemUpdate)
 	default:

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -61,7 +61,7 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
 		exitCode, output, err := h.handleRestart(args)
-		if common.IsTimeout(ctx) {
+		if err != nil && common.IsTimeout(ctx) {
 			return common.TimeoutError(common.SystemCmdTimeout)
 		}
 		return exitCode, output, err
@@ -69,7 +69,7 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
 		exitCode, output, err := h.handleQuit()
-		if common.IsTimeout(ctx) {
+		if err != nil && common.IsTimeout(ctx) {
 			return common.TimeoutError(common.SystemCmdTimeout)
 		}
 		return exitCode, output, err
@@ -77,7 +77,7 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
 		exitCode, output, err := h.handleUninstall()
-		if common.IsTimeout(ctx) {
+		if err != nil && common.IsTimeout(ctx) {
 			return common.TimeoutError(common.SystemCmdTimeout)
 		}
 		return exitCode, output, err
@@ -85,7 +85,7 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
 		exitCode, output, err := h.handleReboot()
-		if common.IsTimeout(ctx) {
+		if err != nil && common.IsTimeout(ctx) {
 			return common.TimeoutError(common.SystemCmdTimeout)
 		}
 		return exitCode, output, err
@@ -93,7 +93,7 @@ func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.Co
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
 		exitCode, output, err := h.handleShutdown()
-		if common.IsTimeout(ctx) {
+		if err != nil && common.IsTimeout(ctx) {
 			return common.TimeoutError(common.SystemCmdTimeout)
 		}
 		return exitCode, output, err
@@ -109,7 +109,7 @@ func (h *SystemHandler) withTimeout(ctx context.Context, timeout time.Duration, 
 	ctx, cancel := common.WithHandlerTimeout(ctx, timeout)
 	defer cancel()
 	exitCode, output, err := fn(ctx)
-	if common.IsTimeout(ctx) {
+	if err != nil && common.IsTimeout(ctx) {
 		return common.TimeoutError(timeout)
 	}
 	return exitCode, output, err

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alpacax/alpamon/internal/pool"
 	"github.com/alpacax/alpamon/pkg/agent"
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
+	"github.com/alpacax/alpamon/pkg/version"
 )
 
 // MockWSClient is a mock implementation of WSClient for testing
@@ -30,6 +31,29 @@ func (m *MockWSClient) RestartCollector() {
 	m.RestartCollectorCalled = true
 }
 
+// MockVersionResolver is a mock implementation of VersionResolver for testing
+type MockVersionResolver struct {
+	LatestVersion       string
+	PamVersion          string
+	InvalidatePamCalled bool
+}
+
+func (m *MockVersionResolver) GetLatestVersion() string {
+	return m.LatestVersion
+}
+
+func (m *MockVersionResolver) GetPamVersion() string {
+	return m.PamVersion
+}
+
+func (m *MockVersionResolver) InvalidatePamCache() {
+	m.InvalidatePamCalled = true
+}
+
+func newMockVersionResolver() *MockVersionResolver {
+	return &MockVersionResolver{LatestVersion: "v0.0.0-test", PamVersion: ""}
+}
+
 func TestSystemHandler_Name(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}
@@ -38,7 +62,7 @@ func TestSystemHandler_Name(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	if handler.Name() != common.System.String() {
 		t.Errorf("expected name %q, got %q", common.System.String(), handler.Name())
 	}
@@ -52,7 +76,7 @@ func TestSystemHandler_Commands(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	commands := handler.Commands()
 
 	expected := []string{
@@ -85,7 +109,7 @@ func TestSystemHandler_Restart_Collector(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -116,7 +140,7 @@ func TestSystemHandler_Restart_Default(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -146,7 +170,7 @@ func TestSystemHandler_Restart_Alpamon(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{
@@ -174,7 +198,7 @@ func TestSystemHandler_Quit(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -200,7 +224,7 @@ func TestSystemHandler_Reboot(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -226,7 +250,7 @@ func TestSystemHandler_Shutdown(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -252,7 +276,7 @@ func TestSystemHandler_UnknownCommand(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -278,7 +302,7 @@ func TestSystemHandler_Validate(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 
 	testCases := []struct {
 		name string
@@ -310,7 +334,7 @@ func TestSystemHandler_PoolShutdown(t *testing.T) {
 	ctxManager := agent.NewContextManager()
 	workerPool := pool.NewPool(2, 10)
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	// Shutdown pool first
@@ -344,30 +368,25 @@ func TestSystemHandler_Upgrade_UpToDate(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	mockVersions := &MockVersionResolver{
+		LatestVersion: version.Version, // same as current -> up-to-date
+		PamVersion:    "",
+	}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions)
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
 
-	// This test depends on the actual version comparison
-	// GetLatestVersion() makes an HTTP call, so this test will behave differently
-	// depending on network availability
 	exitCode, output, err := handler.Execute(ctx, common.Upgrade.String(), args)
 
-	// Should not return an error regardless of version comparison result
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// exitCode could be 0 (up-to-date or upgrade success) or 1 (platform not supported)
-	if exitCode != 0 && exitCode != 1 {
-		t.Errorf("expected exit code 0 or 1, got %d", exitCode)
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
 	}
-	// Output should mention either "up-to-date", "Upgrading", or "not supported"
-	if !strings.Contains(output, "up-to-date") &&
-		!strings.Contains(output, "Upgrading") &&
-		!strings.Contains(output, "not supported") &&
-		!strings.Contains(output, "Alpamon") {
-		t.Errorf("expected meaningful output, got %q", output)
+	if !strings.Contains(output, "up-to-date") {
+		t.Errorf("expected output to contain 'up-to-date', got %q", output)
 	}
 }
 
@@ -379,7 +398,7 @@ func TestSystemHandler_Update(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}
@@ -409,7 +428,7 @@ func TestSystemHandler_Uninstall(t *testing.T) {
 	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
 	defer ctxManager.Shutdown()
 
-	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool)
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver())
 	ctx := context.Background()
 
 	args := &common.CommandArgs{}

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -64,7 +64,7 @@ func (h *UserHandler) Execute(ctx context.Context, cmd string, args *common.Comm
 		return 1, "", fmt.Errorf("unknown user command: %s", cmd)
 	}
 
-	if common.IsTimeout(ctx) {
+	if err != nil && common.IsTimeout(ctx) {
 		return common.TimeoutError(timeout)
 	}
 

--- a/pkg/executor/handlers/user/user.go
+++ b/pkg/executor/handlers/user/user.go
@@ -64,6 +64,10 @@ func (h *UserHandler) Execute(ctx context.Context, cmd string, args *common.Comm
 		return 1, "", fmt.Errorf("unknown user command: %s", cmd)
 	}
 
+	if common.IsTimeout(ctx) {
+		return common.TimeoutError(timeout)
+	}
+
 	// Sync system info after successful command execution
 	if exitCode == 0 && h.syncManager != nil {
 		h.syncManager.SyncSystemInfo([]string{"groups", "users"})

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -290,12 +290,15 @@ func (wc *WebsocketClient) handleCommand(command protocol.Command, data protocol
 	commandRunner := NewCommandRunner(wc, wc.apiSession, command, data, wc.dispatcher)
 
 	// Each handler manages its own timeout; safety net prevents leaked goroutines.
-	// Ensure the pool timeout always exceeds the longest handler timeout (ShellTimeout)
-	// so handler-level timeouts take effect before the safety net.
+	// When PoolDefaultTimeout > 0, ensure it always exceeds the longest handler
+	// timeout (ShellTimeout) so handler-level timeouts fire before the safety net.
+	// When PoolDefaultTimeout == 0, the safety net is explicitly disabled by config.
 	safetyTimeout := time.Duration(config.GlobalSettings.PoolDefaultTimeout) * time.Second
-	minSafetyTimeout := common.ShellTimeout + 5*time.Minute
-	if safetyTimeout < minSafetyTimeout {
-		safetyTimeout = minSafetyTimeout
+	if safetyTimeout > 0 {
+		minSafetyTimeout := common.ShellTimeout + 5*time.Minute
+		if safetyTimeout < minSafetyTimeout {
+			safetyTimeout = minSafetyTimeout
+		}
 	}
 	ctx, cancel := wc.ctxManager.NewContext(safetyTimeout)
 

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alpacax/alpamon/internal/protocol"
 	"github.com/alpacax/alpamon/pkg/agent"
 	"github.com/alpacax/alpamon/pkg/config"
+	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/cenkalti/backoff"
@@ -288,10 +289,13 @@ func (wc *WebsocketClient) handleCommand(command protocol.Command, data protocol
 	// Create CommandRunner with dispatcher for direct execution
 	commandRunner := NewCommandRunner(wc, wc.apiSession, command, data, wc.dispatcher)
 
-	// Each handler manages its own timeout; safety net prevents leaked goroutines
+	// Each handler manages its own timeout; safety net prevents leaked goroutines.
+	// Ensure the pool timeout always exceeds the longest handler timeout (ShellTimeout)
+	// so handler-level timeouts take effect before the safety net.
 	safetyTimeout := time.Duration(config.GlobalSettings.PoolDefaultTimeout) * time.Second
-	if safetyTimeout <= 0 {
-		safetyTimeout = 1 * time.Hour
+	minSafetyTimeout := common.ShellTimeout + 5*time.Minute
+	if safetyTimeout < minSafetyTimeout {
+		safetyTimeout = minSafetyTimeout
 	}
 	ctx, cancel := wc.ctxManager.NewContext(safetyTimeout)
 

--- a/pkg/utils/version_resolver.go
+++ b/pkg/utils/version_resolver.go
@@ -1,0 +1,21 @@
+package utils
+
+// DefaultVersionResolver implements common.VersionResolver using
+// real GitHub API calls and system package queries.
+type DefaultVersionResolver struct{}
+
+func NewDefaultVersionResolver() *DefaultVersionResolver {
+	return &DefaultVersionResolver{}
+}
+
+func (r *DefaultVersionResolver) GetLatestVersion() string {
+	return GetLatestVersion()
+}
+
+func (r *DefaultVersionResolver) GetPamVersion() string {
+	return GetPamVersion()
+}
+
+func (r *DefaultVersionResolver) InvalidatePamCache() {
+	InvalidatePamCache()
+}


### PR DESCRIPTION
### Summary

- Standardize handler-level timeout patterns across all command handlers, completing the work started in #245
- Fix `TestSystemHandler_Upgrade_UpToDate` flaky test by injecting `VersionResolver` interface (closes #246)
- Update Dockerfiles for container support without systemd (follow-up to #249)

### Context

PR #245 introduced per-handler timeouts to replace the single 30-second pool timeout. While the core architecture works correctly, several handlers had gaps: missing `IsTimeout` checks, no timeout applied, or an inconsistent application pattern. This PR addresses all remaining inconsistencies to ensure every handler follows a uniform timeout contract.

### Changes

#### Handler timeout consistency

| Handler | Before | After |
|---------|--------|-------|
| Info | `_ context.Context` — timeout not applied | `WithHandlerTimeout` + `IsTimeout` check |
| Firewall | `WithHandlerTimeout` without `IsTimeout` check | Added `IsTimeout` check |
| Group | `WithHandlerTimeout` without `IsTimeout` check | Added `IsTimeout` check |
| User | `WithHandlerTimeout` without `IsTimeout` check | Added `IsTimeout` check |
| System (Upgrade, Update) | `withTimeout` helper without `IsTimeout` check | Added `IsTimeout` check in helper |
| System (Restart, Quit, ByeBye, Reboot, Shutdown) | No handler-level timeout | `SystemCmdTimeout` applied in `Execute()` |

All handlers that use `WithHandlerTimeout` now follow the same pattern:

```go
ctx, cancel := common.WithHandlerTimeout(ctx, common.FooTimeout)
defer cancel()
// ... execute ...
if common.IsTimeout(ctx) {
    return common.TimeoutError(common.FooTimeout)
}
```

Fire-and-forget commands (Restart, Quit, ByeBye, Reboot, Shutdown) apply handler-level timeout in `Execute()` for the synchronous dispatch. Their async work runs via pool with its own context from `ctxManager.NewContext()`.

#### Safety net minimum guarantee

`PoolDefaultTimeout` is user-configurable. If set below `ShellTimeout` (30min), the safety net would kill goroutines before handler timeouts fire. Added a floor of `ShellTimeout + 5min`.

#### Flaky test fix (closes #246)

`handleUpgrade()` called `utils.GetLatestVersion()` directly — an unauthenticated GitHub API call. Introduced `VersionResolver` interface following existing DI patterns (`CommandExecutor`, `WSClient`) and mock it in tests for deterministic behavior.

#### Dockerfile updates (follow-up to #249)

- Remove `systemd` package from Debian/Ubuntu Dockerfiles
- Fix default `ALPACON_URL` from `:8081` (backhaul) to `:8000` (HTTP API)
- Require `PLUGIN_ID` as environment variable (remove hardcoded UUIDs)
- Unify required directory creation across all entrypoints
- Fix quoting bug in `debian/10/entrypoint.sh`

### Test plan

- [ ] `go build -v ./cmd/alpamon`
- [ ] `go test -v ./pkg/executor/handlers/system/ -run TestSystemHandler_Upgrade_UpToDate` — previously flaky, now deterministic
- [ ] `go test ./... -p 1` — full test suite passes
- [ ] CI passes across all distro matrix (rocky-8, rhel-8, ubuntu-24.04-arm64 등 이전 실패 환경 포함)
- [ ] `docker build -t alpamon:ubuntu-22.04 -f Dockerfiles/ubuntu/22.04/Dockerfile .` — builds without systemd
