### PR TITLE
feat: add command signature verification protocol fields and config

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -16,6 +16,10 @@ type Command struct {
 	Env     map[string]string `json:"env"`
 	AllowSh bool              `json:"allow_sh,omitempty"`
 	Data    string            `json:"data,omitempty"`
+
+	// Signature verification fields (populated by alpacon-server from AI server signing)
+	Signature  string `json:"signature,omitempty"`
+	AnalyzedAt string `json:"analyzed_at,omitempty"`
 }
 
 // File represents a file in command data

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,11 @@ const (
 	DefaultPoolQueueSize      = 200
 	DefaultPoolDefaultTimeout = 3600 // 1 hour; safety net for handler-level timeouts
 
+	// Signing configuration defaults
+	// mode: "monitor" (log warnings, always execute) or "enforce" (reject unsigned/invalid)
+	DefaultSigningMode    = "monitor"
+	DefaultKeyRefreshSecs = 3600 // 1 hour
+
 	// Pool configuration limits for warnings
 	MaxReasonableWorkers        = 1000
 	MaxReasonableQueueSize      = 10000
@@ -214,6 +219,30 @@ func validateConfig(config Config, wsPath string, controlWsPath string) (bool, S
 		}
 	} else {
 		log.Debug().Msgf("Using default editor idle timeout: %d minutes.", settings.EditorIdleTimeout)
+	}
+
+	// Validate and set signing configuration
+	settings.SigningMode = DefaultSigningMode
+	settings.KeyRefreshSecs = DefaultKeyRefreshSecs
+
+	if config.Signing.AIServerURL != "" {
+		settings.AIServerURL = strings.TrimSuffix(config.Signing.AIServerURL, "/")
+		log.Debug().Msgf("Command signature verification enabled with AI server: %s", settings.AIServerURL)
+	}
+
+	if config.Signing.Mode != "" {
+		mode := strings.ToLower(config.Signing.Mode)
+		if mode != "monitor" && mode != "enforce" {
+			log.Error().Msgf("Invalid signing mode '%s', must be 'monitor' or 'enforce'.", config.Signing.Mode)
+			valid = false
+		} else {
+			settings.SigningMode = mode
+		}
+	}
+
+	if config.Signing.KeyRefresh != nil {
+		settings.KeyRefreshSecs = *config.Signing.KeyRefresh
+		log.Debug().Msgf("Using configured key refresh interval: %d seconds.", settings.KeyRefreshSecs)
 	}
 
 	// Validate pool settings are reasonable

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,7 +255,8 @@ func validateConfig(config Config, wsPath string, controlWsPath string) (bool, S
 			}
 		}
 	} else if config.Signing.Mode != "" || config.Signing.KeyRefresh != nil {
-		log.Warn().Msg("Signing mode or key_refresh set without ai_server_url, signing configuration will be ignored.")
+		log.Warn().Msgf("Signing mode=%q or key_refresh=%v set without ai_server_url, signing configuration will be ignored.",
+			config.Signing.Mode, config.Signing.KeyRefresh)
 	}
 
 	// Validate pool settings are reasonable

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -226,23 +226,36 @@ func validateConfig(config Config, wsPath string, controlWsPath string) (bool, S
 	settings.KeyRefreshSecs = DefaultKeyRefreshSecs
 
 	if config.Signing.AIServerURL != "" {
-		settings.AIServerURL = strings.TrimSuffix(config.Signing.AIServerURL, "/")
-		log.Debug().Msgf("Command signature verification enabled with AI server: %s", settings.AIServerURL)
-	}
-
-	if config.Signing.Mode != "" {
-		mode := strings.ToLower(config.Signing.Mode)
-		if mode != "monitor" && mode != "enforce" {
-			log.Error().Msgf("Invalid signing mode '%s', must be 'monitor' or 'enforce'.", config.Signing.Mode)
+		aiURL := strings.TrimSuffix(config.Signing.AIServerURL, "/")
+		if !strings.HasPrefix(aiURL, "http://") && !strings.HasPrefix(aiURL, "https://") {
+			log.Error().Msgf("Invalid signing ai_server_url '%s', must start with http:// or https://.", aiURL)
 			valid = false
 		} else {
-			settings.SigningMode = mode
+			settings.AIServerURL = aiURL
+			log.Debug().Msgf("Command signature verification enabled with AI server: %s", aiURL)
 		}
-	}
 
-	if config.Signing.KeyRefresh != nil {
-		settings.KeyRefreshSecs = *config.Signing.KeyRefresh
-		log.Debug().Msgf("Using configured key refresh interval: %d seconds.", settings.KeyRefreshSecs)
+		if config.Signing.Mode != "" {
+			mode := strings.ToLower(config.Signing.Mode)
+			if mode != "monitor" && mode != "enforce" {
+				log.Error().Msgf("Invalid signing mode '%s', must be 'monitor' or 'enforce'.", config.Signing.Mode)
+				valid = false
+			} else {
+				settings.SigningMode = mode
+			}
+		}
+
+		if config.Signing.KeyRefresh != nil {
+			if *config.Signing.KeyRefresh <= 0 {
+				log.Error().Msgf("Invalid signing key_refresh '%d', must be a positive number of seconds.", *config.Signing.KeyRefresh)
+				valid = false
+			} else {
+				settings.KeyRefreshSecs = *config.Signing.KeyRefresh
+				log.Debug().Msgf("Using configured key refresh interval: %d seconds.", settings.KeyRefreshSecs)
+			}
+		}
+	} else if config.Signing.Mode != "" || config.Signing.KeyRefresh != nil {
+		log.Warn().Msg("Signing mode or key_refresh set without ai_server_url, signing configuration will be ignored.")
 	}
 
 	// Validate pool settings are reasonable

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -192,17 +192,18 @@ func TestSigningConfigWithoutURL(t *testing.T) {
 	config := Config{}
 	config.Signing.Mode = "enforce"
 
-	valid, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
 
-	// Should not fail validation (just warn)
+	// Signing config should be ignored (defaults kept) when ai_server_url is empty
 	if settings.AIServerURL != "" {
 		t.Errorf("Expected empty AIServerURL, got %s", settings.AIServerURL)
 	}
-	// Mode should remain default since URL is empty
 	if settings.SigningMode != DefaultSigningMode {
 		t.Errorf("Expected default SigningMode when URL is empty, got %s", settings.SigningMode)
 	}
-	_ = valid
+	if settings.KeyRefreshSecs != DefaultKeyRefreshSecs {
+		t.Errorf("Expected default KeyRefreshSecs when URL is empty, got %d", settings.KeyRefreshSecs)
+	}
 }
 
 func TestSigningConfigFromINI(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -109,3 +109,135 @@ func TestEditorIdleTimeoutCustom(t *testing.T) {
 		t.Errorf("Expected EditorIdleTimeout to be 15, got %d", settings.EditorIdleTimeout)
 	}
 }
+
+func TestSigningConfigDefaults(t *testing.T) {
+	config := Config{}
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+
+	if settings.AIServerURL != "" {
+		t.Errorf("Expected default AIServerURL to be empty, got %s", settings.AIServerURL)
+	}
+	if settings.SigningMode != DefaultSigningMode {
+		t.Errorf("Expected default SigningMode to be %s, got %s", DefaultSigningMode, settings.SigningMode)
+	}
+	if settings.KeyRefreshSecs != DefaultKeyRefreshSecs {
+		t.Errorf("Expected default KeyRefreshSecs to be %d, got %d", DefaultKeyRefreshSecs, settings.KeyRefreshSecs)
+	}
+}
+
+func TestSigningConfigValid(t *testing.T) {
+	config := Config{}
+	config.Signing.AIServerURL = "https://ai.example.com/"
+	config.Signing.Mode = "enforce"
+	config.Signing.KeyRefresh = intPtr(1800)
+
+	_, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+
+	if settings.AIServerURL != "https://ai.example.com" {
+		t.Errorf("Expected AIServerURL trailing slash trimmed, got %s", settings.AIServerURL)
+	}
+	if settings.SigningMode != "enforce" {
+		t.Errorf("Expected SigningMode 'enforce', got %s", settings.SigningMode)
+	}
+	if settings.KeyRefreshSecs != 1800 {
+		t.Errorf("Expected KeyRefreshSecs 1800, got %d", settings.KeyRefreshSecs)
+	}
+}
+
+func TestSigningConfigInvalidMode(t *testing.T) {
+	config := Config{}
+	config.Signing.AIServerURL = "https://ai.example.com"
+	config.Signing.Mode = "invalid"
+
+	valid, _ := validateConfig(config, "/ws/test/", "/ws/control/")
+	if valid {
+		t.Error("Expected validation to fail for invalid signing mode")
+	}
+}
+
+func TestSigningConfigInvalidURL(t *testing.T) {
+	config := Config{}
+	config.Signing.AIServerURL = "not-a-url"
+
+	valid, _ := validateConfig(config, "/ws/test/", "/ws/control/")
+	if valid {
+		t.Error("Expected validation to fail for invalid ai_server_url")
+	}
+}
+
+func TestSigningConfigNegativeKeyRefresh(t *testing.T) {
+	config := Config{}
+	config.Signing.AIServerURL = "https://ai.example.com"
+	config.Signing.KeyRefresh = intPtr(-1)
+
+	valid, _ := validateConfig(config, "/ws/test/", "/ws/control/")
+	if valid {
+		t.Error("Expected validation to fail for negative key_refresh")
+	}
+}
+
+func TestSigningConfigZeroKeyRefresh(t *testing.T) {
+	config := Config{}
+	config.Signing.AIServerURL = "https://ai.example.com"
+	config.Signing.KeyRefresh = intPtr(0)
+
+	valid, _ := validateConfig(config, "/ws/test/", "/ws/control/")
+	if valid {
+		t.Error("Expected validation to fail for zero key_refresh")
+	}
+}
+
+func TestSigningConfigWithoutURL(t *testing.T) {
+	// Setting mode/key_refresh without ai_server_url should warn but not fail
+	config := Config{}
+	config.Signing.Mode = "enforce"
+
+	valid, settings := validateConfig(config, "/ws/test/", "/ws/control/")
+
+	// Should not fail validation (just warn)
+	if settings.AIServerURL != "" {
+		t.Errorf("Expected empty AIServerURL, got %s", settings.AIServerURL)
+	}
+	// Mode should remain default since URL is empty
+	if settings.SigningMode != DefaultSigningMode {
+		t.Errorf("Expected default SigningMode when URL is empty, got %s", settings.SigningMode)
+	}
+	_ = valid
+}
+
+func TestSigningConfigFromINI(t *testing.T) {
+	content := `[server]
+url = http://test.com
+id = testid
+key = testkey
+
+[signing]
+ai_server_url = https://ai.example.com
+mode = enforce
+key_refresh = 7200
+`
+	tmpfile, err := os.CreateTemp("", "alpamon-test-*.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := LoadConfig([]string{tmpfile.Name()}, "/ws/test/", "/ws/control/")
+
+	if settings.AIServerURL != "https://ai.example.com" {
+		t.Errorf("Expected AIServerURL 'https://ai.example.com', got %s", settings.AIServerURL)
+	}
+	if settings.SigningMode != "enforce" {
+		t.Errorf("Expected SigningMode 'enforce', got %s", settings.SigningMode)
+	}
+	if settings.KeyRefreshSecs != 7200 {
+		t.Errorf("Expected KeyRefreshSecs 7200, got %d", settings.KeyRefreshSecs)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -15,6 +15,11 @@ type Settings struct {
 	PoolQueueSize      int // Size of the job queue for the global worker pool
 	PoolDefaultTimeout int // Default timeout in seconds for pool tasks (0 = no timeout)
 	EditorIdleTimeout  int // Editor idle timeout in minutes (0 = no timeout)
+
+	// Command signature verification
+	AIServerURL    string // AI server URL for public key fetch (empty = verification disabled)
+	SigningMode    string // "monitor" (warn only) or "enforce" (reject unsigned)
+	KeyRefreshSecs int    // Public key cache TTL in seconds
 }
 
 type Config struct {
@@ -38,4 +43,9 @@ type Config struct {
 	Editor struct {
 		IdleTimeout *int `ini:"idle_timeout"`
 	} `ini:"editor"`
+	Signing struct {
+		AIServerURL string `ini:"ai_server_url"`
+		Mode        string `ini:"mode"`
+		KeyRefresh  *int   `ini:"key_refresh"`
+	} `ini:"signing"`
 }


### PR DESCRIPTION
## Summary
- Add `Signature` and `AnalyzedAt` fields to the `Command` struct for Ed25519 signature verification
- Add `[signing]` config section with `ai_server_url`, `mode` (monitor/enforce), and `key_refresh` options
- No behavior change — fields are `omitempty` and config defaults to disabled

## Test plan
- [x] Build passes
- [x] Existing tests pass (protocol + config)
- [ ] Verify config parsing with `[signing]` section in alpamon.conf

Refs #262