### PR TITLE
feat: add Ed25519 signature verification package

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -20,6 +20,7 @@ type Command struct {
 	// Signature verification fields (populated by alpacon-server from AI server signing)
 	Signature  string `json:"signature,omitempty"`
 	AnalyzedAt string `json:"analyzed_at,omitempty"`
+	KeyID      string `json:"key_id,omitempty"`
 }
 
 // File represents a file in command data

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -80,19 +80,19 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	return copyKey(m.publicKey), nil
 }
 
-// GetPublicKeyForKID returns the cached key if the kid matches.
-// If the kid doesn't match the cached key, it refreshes from the AI server.
+// GetPublicKeyForKID returns the cached key if the kid matches and the key is not expired.
+// If the kid doesn't match the cached key or the key is expired, it refreshes from the AI server.
 // This avoids unnecessary fetches when the key hasn't rotated.
 func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	m.mu.RLock()
-	if m.publicKey != nil && m.keyID == kid {
+	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
 		key := copyKey(m.publicKey)
 		m.mu.RUnlock()
 		return key, nil
 	}
 	m.mu.RUnlock()
 
-	// Unknown kid: force fetch new key from AI server
+	// Unknown kid or expired key: force fetch new key from AI server
 	if err := m.fetchKey(); err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
@@ -179,9 +179,12 @@ func (m *KeyManager) fetchKeyLocked() error {
 		return fmt.Errorf("public key endpoint returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(body)) > maxResponseSize {
+		return fmt.Errorf("public key response too large (>%d bytes)", maxResponseSize)
 	}
 
 	var keyResp publicKeyResponse

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -96,10 +97,11 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	if err := m.fetchKey(); err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		if m.publicKey != nil {
+		// Only fall back to cached key if it matches the requested kid
+		if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
 			return copyKey(m.publicKey), nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to refresh key for kid %q: %w", kid, err)
 	}
 
 	m.mu.RLock()
@@ -194,6 +196,10 @@ func (m *KeyManager) fetchKeyLocked() error {
 
 	if keyResp.Algorithm != "Ed25519" {
 		return fmt.Errorf("unsupported algorithm: %s", keyResp.Algorithm)
+	}
+
+	if keyResp.KeyID == "" {
+		return errors.New("AI server returned empty key_id")
 	}
 
 	keyBytes, err := base64.StdEncoding.DecodeString(keyResp.PublicKey)

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -1,0 +1,126 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// publicKeyResponse represents the response from GET /api/commands/public-key/
+type publicKeyResponse struct {
+	Algorithm string `json:"algorithm"`
+	PublicKey string `json:"public_key"`
+	KeyID     string `json:"key_id"`
+	ValidFrom string `json:"valid_from"`
+}
+
+// KeyManager fetches and caches the Ed25519 public key from the AI server.
+type KeyManager struct {
+	mu             sync.RWMutex
+	publicKey      ed25519.PublicKey
+	keyID          string
+	lastFetch      time.Time
+	refreshSecs    int
+	aiBaseURL      string
+	client         *http.Client
+	fetchTimeout   time.Duration
+}
+
+// NewKeyManager creates a key manager that fetches from the AI server.
+func NewKeyManager(aiBaseURL string, refreshSecs int, client *http.Client) *KeyManager {
+	return &KeyManager{
+		aiBaseURL:    aiBaseURL,
+		refreshSecs:  refreshSecs,
+		client:       client,
+		fetchTimeout: 10 * time.Second,
+	}
+}
+
+// GetPublicKey returns the cached public key, refreshing if stale.
+func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
+	m.mu.RLock()
+	if m.publicKey != nil && time.Since(m.lastFetch) < time.Duration(m.refreshSecs)*time.Second {
+		key := m.publicKey
+		m.mu.RUnlock()
+		return key, nil
+	}
+	m.mu.RUnlock()
+
+	if err := m.Refresh(); err != nil {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		if m.publicKey != nil {
+			return m.publicKey, nil
+		}
+		return nil, err
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.publicKey, nil
+}
+
+// Refresh fetches the latest public key from the AI server.
+func (m *KeyManager) Refresh() error {
+	url := m.aiBaseURL + "/api/commands/public-key/"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{
+		Transport: m.client.Transport,
+		Timeout:   m.fetchTimeout,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch public key: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("public key endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var keyResp publicKeyResponse
+	if err := json.Unmarshal(body, &keyResp); err != nil {
+		return fmt.Errorf("failed to parse public key response: %w", err)
+	}
+
+	if keyResp.Algorithm != "Ed25519" {
+		return fmt.Errorf("unsupported algorithm: %s", keyResp.Algorithm)
+	}
+
+	keyBytes, err := base64.StdEncoding.DecodeString(keyResp.PublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to decode public key: %w", err)
+	}
+
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.publicKey = ed25519.PublicKey(keyBytes)
+	m.keyID = keyResp.KeyID
+	m.lastFetch = time.Now()
+
+	log.Debug().Str("key_id", keyResp.KeyID).Msg("Public signing key refreshed.")
+
+	return nil
+}

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,19 +36,22 @@ type KeyManager struct {
 
 // NewKeyManager creates a key manager that fetches from the AI server.
 func NewKeyManager(aiBaseURL string, refreshSecs int, client *http.Client) *KeyManager {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	return &KeyManager{
-		aiBaseURL:    aiBaseURL,
+		aiBaseURL:    strings.TrimRight(aiBaseURL, "/"),
 		refreshSecs:  refreshSecs,
 		client:       client,
 		fetchTimeout: 10 * time.Second,
 	}
 }
 
-// GetPublicKey returns the cached public key, refreshing if stale.
+// GetPublicKey returns a copy of the cached public key, refreshing if stale.
 func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	m.mu.RLock()
 	if m.publicKey != nil && time.Since(m.lastFetch) < time.Duration(m.refreshSecs)*time.Second {
-		key := m.publicKey
+		key := copyKey(m.publicKey)
 		m.mu.RUnlock()
 		return key, nil
 	}
@@ -57,14 +61,20 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
 		if m.publicKey != nil {
-			return m.publicKey, nil
+			return copyKey(m.publicKey), nil
 		}
 		return nil, err
 	}
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.publicKey, nil
+	return copyKey(m.publicKey), nil
+}
+
+func copyKey(key ed25519.PublicKey) ed25519.PublicKey {
+	cp := make(ed25519.PublicKey, len(key))
+	copy(cp, key)
+	return cp
 }
 
 // Refresh fetches the latest public key from the AI server.
@@ -77,8 +87,10 @@ func (m *KeyManager) Refresh() error {
 	}
 
 	client := &http.Client{
-		Transport: m.client.Transport,
-		Timeout:   m.fetchTimeout,
+		Transport:     m.client.Transport,
+		CheckRedirect: m.client.CheckRedirect,
+		Jar:           m.client.Jar,
+		Timeout:       m.fetchTimeout,
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -14,6 +14,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// maxResponseSize limits the public key response body to prevent
+// excessive memory usage from a misbehaving server.
+const maxResponseSize = 16 * 1024 // 16 KB
+
 // publicKeyResponse represents the response from GET /api/commands/public-key/
 type publicKeyResponse struct {
 	Algorithm string `json:"algorithm"`
@@ -34,6 +38,9 @@ type KeyManager struct {
 	aiBaseURL    string
 	client       *http.Client
 	fetchTimeout time.Duration
+
+	// refreshMu serializes refresh calls to prevent concurrent fetch bursts
+	refreshMu sync.Mutex
 }
 
 // NewKeyManager creates a key manager that fetches from the AI server.
@@ -85,8 +92,8 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	}
 	m.mu.RUnlock()
 
-	// Unknown kid: fetch new key from AI server
-	if err := m.Refresh(); err != nil {
+	// Unknown kid: force fetch new key from AI server
+	if err := m.fetchKey(); err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
 		if m.publicKey != nil {
@@ -121,7 +128,33 @@ func copyKey(key ed25519.PublicKey) ed25519.PublicKey {
 }
 
 // Refresh fetches the latest public key from the AI server.
+// Only one refresh runs at a time; concurrent callers wait for the in-flight result.
+// If the cache is still valid (another goroutine refreshed), this is a no-op.
 func (m *KeyManager) Refresh() error {
+	m.refreshMu.Lock()
+	defer m.refreshMu.Unlock()
+
+	// Double-check: another goroutine may have refreshed while we waited
+	m.mu.RLock()
+	if m.publicKey != nil && !m.isExpired() {
+		m.mu.RUnlock()
+		return nil
+	}
+	m.mu.RUnlock()
+
+	return m.fetchKeyLocked()
+}
+
+// fetchKey acquires the refresh lock and fetches unconditionally.
+// Used by GetPublicKeyForKID when kid doesn't match (key may not be expired).
+func (m *KeyManager) fetchKey() error {
+	m.refreshMu.Lock()
+	defer m.refreshMu.Unlock()
+	return m.fetchKeyLocked()
+}
+
+// fetchKeyLocked performs the actual HTTP fetch. Must be called with refreshMu held.
+func (m *KeyManager) fetchKeyLocked() error {
 	url := m.aiBaseURL + "/api/commands/public-key/"
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -146,7 +179,7 @@ func (m *KeyManager) Refresh() error {
 		return fmt.Errorf("public key endpoint returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -1,6 +1,7 @@
 package signing
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
@@ -28,17 +29,19 @@ type publicKeyResponse struct {
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
+// fetchTimeout is the timeout for public key HTTP requests.
+const fetchTimeout = 10 * time.Second
+
 // KeyManager fetches and caches the Ed25519 public key from the AI server.
 type KeyManager struct {
-	mu           sync.RWMutex
-	publicKey    ed25519.PublicKey
-	keyID        string
-	lastFetch    time.Time
-	expiresAt    time.Time
-	refreshSecs  int
-	aiBaseURL    string
-	client       *http.Client
-	fetchTimeout time.Duration
+	mu          sync.RWMutex
+	publicKey   ed25519.PublicKey
+	keyID       string
+	lastFetch   time.Time
+	expiresAt   time.Time
+	refreshSecs int
+	aiBaseURL   string
+	client      *http.Client
 
 	// refreshMu serializes refresh calls to prevent concurrent fetch bursts
 	refreshMu sync.Mutex
@@ -50,10 +53,9 @@ func NewKeyManager(aiBaseURL string, refreshSecs int, client *http.Client) *KeyM
 		client = http.DefaultClient
 	}
 	return &KeyManager{
-		aiBaseURL:    strings.TrimRight(aiBaseURL, "/"),
-		refreshSecs:  refreshSecs,
-		client:       client,
-		fetchTimeout: 10 * time.Second,
+		aiBaseURL:   strings.TrimRight(aiBaseURL, "/"),
+		refreshSecs: refreshSecs,
+		client:      client,
 	}
 }
 
@@ -109,6 +111,8 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
 		return copyKey(m.publicKey), nil
 	}
+	log.Debug().Str("requested_kid", kid).Str("cached_kid", m.keyID).
+		Msg("AI server returned different kid than requested.")
 	return nil, fmt.Errorf("public key for kid %q not available after refresh", kid)
 }
 
@@ -159,19 +163,15 @@ func (m *KeyManager) fetchKey() error {
 func (m *KeyManager) fetchKeyLocked() error {
 	url := m.aiBaseURL + "/api/commands/public-key/"
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	client := &http.Client{
-		Transport:     m.client.Transport,
-		CheckRedirect: m.client.CheckRedirect,
-		Jar:           m.client.Jar,
-		Timeout:       m.fetchTimeout,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := m.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to fetch public key: %w", err)
 	}

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -70,10 +70,10 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	if err := m.Refresh(); err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		if m.publicKey != nil {
+		if m.publicKey != nil && !m.isExpired() {
 			return copyKey(m.publicKey), nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("public key expired and refresh failed: %w", err)
 	}
 
 	m.mu.RLock()
@@ -106,10 +106,10 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if m.keyID != kid {
-		return nil, fmt.Errorf("key_id mismatch after refresh: cached %q, requested %q", m.keyID, kid)
+	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
+		return copyKey(m.publicKey), nil
 	}
-	return copyKey(m.publicKey), nil
+	return nil, fmt.Errorf("public key for kid %q not available after refresh", kid)
 }
 
 // isExpired reports whether the cached key should be refreshed.

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -20,18 +20,20 @@ type publicKeyResponse struct {
 	PublicKey string `json:"public_key"`
 	KeyID     string `json:"key_id"`
 	ValidFrom string `json:"valid_from"`
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 // KeyManager fetches and caches the Ed25519 public key from the AI server.
 type KeyManager struct {
-	mu             sync.RWMutex
-	publicKey      ed25519.PublicKey
-	keyID          string
-	lastFetch      time.Time
-	refreshSecs    int
-	aiBaseURL      string
-	client         *http.Client
-	fetchTimeout   time.Duration
+	mu           sync.RWMutex
+	publicKey    ed25519.PublicKey
+	keyID        string
+	lastFetch    time.Time
+	expiresAt    time.Time
+	refreshSecs  int
+	aiBaseURL    string
+	client       *http.Client
+	fetchTimeout time.Duration
 }
 
 // NewKeyManager creates a key manager that fetches from the AI server.
@@ -50,7 +52,7 @@ func NewKeyManager(aiBaseURL string, refreshSecs int, client *http.Client) *KeyM
 // GetPublicKey returns a copy of the cached public key, refreshing if stale.
 func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	m.mu.RLock()
-	if m.publicKey != nil && time.Since(m.lastFetch) < time.Duration(m.refreshSecs)*time.Second {
+	if m.publicKey != nil && !m.isExpired() {
 		key := copyKey(m.publicKey)
 		m.mu.RUnlock()
 		return key, nil
@@ -69,6 +71,47 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return copyKey(m.publicKey), nil
+}
+
+// GetPublicKeyForKID returns the cached key if the kid matches.
+// If the kid doesn't match the cached key, it refreshes from the AI server.
+// This avoids unnecessary fetches when the key hasn't rotated.
+func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
+	m.mu.RLock()
+	if m.publicKey != nil && m.keyID == kid {
+		key := copyKey(m.publicKey)
+		m.mu.RUnlock()
+		return key, nil
+	}
+	m.mu.RUnlock()
+
+	// Unknown kid: fetch new key from AI server
+	if err := m.Refresh(); err != nil {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		if m.publicKey != nil {
+			return copyKey(m.publicKey), nil
+		}
+		return nil, err
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.keyID != kid {
+		return nil, fmt.Errorf("key_id mismatch after refresh: cached %q, requested %q", m.keyID, kid)
+	}
+	return copyKey(m.publicKey), nil
+}
+
+// isExpired reports whether the cached key should be refreshed.
+// Must be called with m.mu held (read or write).
+func (m *KeyManager) isExpired() bool {
+	// If AI server provided expires_at, use it
+	if !m.expiresAt.IsZero() {
+		return time.Now().After(m.expiresAt)
+	}
+	// Fall back to TTL-based refresh
+	return time.Since(m.lastFetch) >= time.Duration(m.refreshSecs)*time.Second
 }
 
 func copyKey(key ed25519.PublicKey) ed25519.PublicKey {
@@ -132,7 +175,18 @@ func (m *KeyManager) Refresh() error {
 	m.keyID = keyResp.KeyID
 	m.lastFetch = time.Now()
 
-	log.Debug().Str("key_id", keyResp.KeyID).Msg("Public signing key refreshed.")
+	if keyResp.ExpiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, keyResp.ExpiresAt); err == nil {
+			m.expiresAt = t
+			log.Debug().Str("key_id", keyResp.KeyID).Time("expires_at", t).Msg("Public signing key refreshed.")
+		} else {
+			log.Warn().Str("expires_at", keyResp.ExpiresAt).Msg("Failed to parse expires_at, falling back to TTL-based refresh.")
+			m.expiresAt = time.Time{}
+		}
+	} else {
+		m.expiresAt = time.Time{}
+		log.Debug().Str("key_id", keyResp.KeyID).Msg("Public signing key refreshed.")
+	}
 
 	return nil
 }

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -55,9 +56,9 @@ func TestKeyManager_Refresh(t *testing.T) {
 func TestKeyManager_CacheHit(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
+		fetchCount.Add(1)
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -80,17 +81,17 @@ func TestKeyManager_CacheHit(t *testing.T) {
 		t.Fatalf("second GetPublicKey failed: %v", err)
 	}
 
-	if fetchCount != 1 {
-		t.Errorf("expected 1 fetch, got %d", fetchCount)
+	if fetchCount.Load() != 1 {
+		t.Errorf("expected 1 fetch, got %d", fetchCount.Load())
 	}
 }
 
 func TestKeyManager_CacheExpiry(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
+		fetchCount.Add(1)
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -116,8 +117,8 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 		t.Fatalf("second GetPublicKey failed: %v", err)
 	}
 
-	if fetchCount != 2 {
-		t.Errorf("expected 2 fetches after cache expiry, got %d", fetchCount)
+	if fetchCount.Load() != 2 {
+		t.Errorf("expected 2 fetches after cache expiry, got %d", fetchCount.Load())
 	}
 }
 
@@ -173,9 +174,9 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
+		fetchCount.Add(1)
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -203,8 +204,8 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 	if !key1.Equal(key2) {
 		t.Error("keys should match")
 	}
-	if fetchCount != 1 {
-		t.Errorf("expected 1 fetch for matching kid, got %d", fetchCount)
+	if fetchCount.Load() != 1 {
+		t.Errorf("expected 1 fetch for matching kid, got %d", fetchCount.Load())
 	}
 }
 
@@ -242,12 +243,12 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	pub1, _, _ := ed25519.GenerateKey(nil)
 	pub2, _, _ := ed25519.GenerateKey(nil)
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
+		n := fetchCount.Add(1)
 		var pub ed25519.PublicKey
 		var kid string
-		if fetchCount == 1 {
+		if n == 1 {
 			pub = pub1
 			kid = "key-v1"
 		} else {
@@ -284,17 +285,17 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	if !key2.Equal(pub2) {
 		t.Error("second key should be pub2")
 	}
-	if fetchCount != 2 {
-		t.Errorf("expected 2 fetches for key rotation, got %d", fetchCount)
+	if fetchCount.Load() != 2 {
+		t.Errorf("expected 2 fetches for key rotation, got %d", fetchCount.Load())
 	}
 }
 
 func TestKeyManager_ExpiresAt(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
+		fetchCount.Add(1)
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -316,8 +317,8 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("second GetPublicKey failed: %v", err)
 	}
-	if fetchCount != 1 {
-		t.Errorf("expected 1 fetch before expiry, got %d", fetchCount)
+	if fetchCount.Load() != 1 {
+		t.Errorf("expected 1 fetch before expiry, got %d", fetchCount.Load())
 	}
 
 	// Simulate expires_at having passed by moving it into the past
@@ -328,18 +329,17 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("third GetPublicKey failed: %v", err)
 	}
-	if fetchCount != 2 {
-		t.Errorf("expected 2 fetches after expires_at, got %d", fetchCount)
+	if fetchCount.Load() != 2 {
+		t.Errorf("expected 2 fetches after expires_at, got %d", fetchCount.Load())
 	}
 }
 
 func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
-	callCount := 0
+	var callCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount > 1 {
+		if callCount.Add(1) > 1 {
 			http.Error(w, "server error", http.StatusInternalServerError)
 			return
 		}

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -333,7 +333,7 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 	}
 }
 
-func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
+func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
 	callCount := 0
@@ -357,23 +357,19 @@ func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, server.Client())
 
 	// First fetch succeeds
-	key1, err := km.GetPublicKey()
+	_, err := km.GetPublicKey()
 	if err != nil {
 		t.Fatalf("first fetch should succeed: %v", err)
 	}
 
-	// Simulate cache expiry by moving lastFetch into the past
+	// Simulate cache expiry
 	km.mu.Lock()
 	km.lastFetch = time.Now().Add(-2 * time.Hour)
 	km.mu.Unlock()
 
-	// Next fetch fails on refresh but should return stale key
-	key2, err := km.GetPublicKey()
-	if err != nil {
-		t.Fatalf("should return stale key on refresh failure: %v", err)
-	}
-
-	if !key1.Equal(key2) {
-		t.Error("stale key should match original key")
+	// Expired key + refresh failure should return error, not stale key
+	_, err = km.GetPublicKey()
+	if err == nil {
+		t.Error("expected error when key is expired and refresh fails")
 	}
 }

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -102,12 +102,16 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 1, server.Client()) // 1 second TTL
+	km := NewKeyManager(server.URL, 3600, server.Client())
 
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("first GetPublicKey failed: %v", err)
 	}
-	time.Sleep(1100 * time.Millisecond)
+	// Simulate cache expiry by moving lastFetch into the past
+	km.mu.Lock()
+	km.lastFetch = time.Now().Add(-2 * time.Hour)
+	km.mu.Unlock()
+
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("second GetPublicKey failed: %v", err)
 	}
@@ -316,8 +320,11 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 		t.Errorf("expected 1 fetch before expiry, got %d", fetchCount)
 	}
 
-	// Wait for expires_at to pass
-	time.Sleep(1100 * time.Millisecond)
+	// Simulate expires_at having passed by moving it into the past
+	km.mu.Lock()
+	km.expiresAt = time.Now().Add(-1 * time.Second)
+	km.mu.Unlock()
+
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("third GetPublicKey failed: %v", err)
 	}
@@ -347,7 +354,7 @@ func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 1, server.Client()) // 1 second TTL
+	km := NewKeyManager(server.URL, 3600, server.Client())
 
 	// First fetch succeeds
 	key1, err := km.GetPublicKey()
@@ -355,8 +362,12 @@ func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
 		t.Fatalf("first fetch should succeed: %v", err)
 	}
 
-	// Wait for cache expiry, next fetch fails but returns stale key
-	time.Sleep(1100 * time.Millisecond)
+	// Simulate cache expiry by moving lastFetch into the past
+	km.mu.Lock()
+	km.lastFetch = time.Now().Add(-2 * time.Hour)
+	km.mu.Unlock()
+
+	// Next fetch fails on refresh but should return stale key
 	key2, err := km.GetPublicKey()
 	if err != nil {
 		t.Fatalf("should return stale key on refresh failure: %v", err)

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -1,0 +1,200 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestServer(pub ed25519.PublicKey) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/commands/public-key/" {
+			http.NotFound(w, r)
+			return
+		}
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test-123",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestKeyManager_Refresh(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	server := newTestServer(pub)
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	if err := km.Refresh(); err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+
+	key, err := km.GetPublicKey()
+	if err != nil {
+		t.Fatalf("GetPublicKey failed: %v", err)
+	}
+
+	if !pub.Equal(key) {
+		t.Error("fetched key does not match expected public key")
+	}
+
+	if km.keyID != "key-test-123" {
+		t.Errorf("expected key ID 'key-test-123', got '%s'", km.keyID)
+	}
+}
+
+func TestKeyManager_CacheHit(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	// First call fetches
+	km.GetPublicKey()
+	// Second call should use cache
+	km.GetPublicKey()
+
+	if fetchCount != 1 {
+		t.Errorf("expected 1 fetch, got %d", fetchCount)
+	}
+}
+
+func TestKeyManager_CacheExpiry(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 1, server.Client()) // 1 second TTL
+
+	km.GetPublicKey()
+	time.Sleep(1100 * time.Millisecond)
+	km.GetPublicKey()
+
+	if fetchCount != 2 {
+		t.Errorf("expected 2 fetches after cache expiry, got %d", fetchCount)
+	}
+}
+
+func TestKeyManager_ServerUnavailable(t *testing.T) {
+	km := NewKeyManager("http://localhost:1", 3600, &http.Client{Timeout: 1 * time.Second})
+
+	_, err := km.GetPublicKey()
+	if err == nil {
+		t.Error("expected error when server is unavailable")
+	}
+}
+
+func TestKeyManager_InvalidAlgorithm(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := publicKeyResponse{
+			Algorithm: "RSA",
+			PublicKey: base64.StdEncoding.EncodeToString(make([]byte, 32)),
+			KeyID:     "key-test",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	_, err := km.GetPublicKey()
+	if err == nil {
+		t.Error("expected error for unsupported algorithm")
+	}
+}
+
+func TestKeyManager_InvalidKeySize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString([]byte("tooshort")),
+			KeyID:     "key-test",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	_, err := km.GetPublicKey()
+	if err == nil {
+		t.Error("expected error for invalid key size")
+	}
+}
+
+func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount > 1 {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 1, server.Client()) // 1 second TTL
+
+	// First fetch succeeds
+	key1, err := km.GetPublicKey()
+	if err != nil {
+		t.Fatalf("first fetch should succeed: %v", err)
+	}
+
+	// Wait for cache expiry, next fetch fails but returns stale key
+	time.Sleep(1100 * time.Millisecond)
+	key2, err := km.GetPublicKey()
+	if err != nil {
+		t.Fatalf("should return stale key on refresh failure: %v", err)
+	}
+
+	if !key1.Equal(key2) {
+		t.Error("stale key should match original key")
+	}
+}

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -300,7 +300,7 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
 			KeyID:     "key-test",
 			ValidFrom: "2026-01-01T00:00:00Z",
-			ExpiresAt: time.Now().Add(1 * time.Second).UTC().Format(time.RFC3339),
+			ExpiresAt: "2099-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -72,9 +72,13 @@ func TestKeyManager_CacheHit(t *testing.T) {
 	km := NewKeyManager(server.URL, 3600, server.Client())
 
 	// First call fetches
-	km.GetPublicKey()
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("first GetPublicKey failed: %v", err)
+	}
 	// Second call should use cache
-	km.GetPublicKey()
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("second GetPublicKey failed: %v", err)
+	}
 
 	if fetchCount != 1 {
 		t.Errorf("expected 1 fetch, got %d", fetchCount)
@@ -100,9 +104,13 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 1, server.Client()) // 1 second TTL
 
-	km.GetPublicKey()
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("first GetPublicKey failed: %v", err)
+	}
 	time.Sleep(1100 * time.Millisecond)
-	km.GetPublicKey()
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("second GetPublicKey failed: %v", err)
+	}
 
 	if fetchCount != 2 {
 		t.Errorf("expected 2 fetches after cache expiry, got %d", fetchCount)

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -23,7 +23,7 @@ func newTestServer(pub ed25519.PublicKey) *httptest.Server {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 }
 
@@ -65,7 +65,7 @@ func TestKeyManager_CacheHit(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -98,7 +98,7 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -134,7 +134,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 			KeyID:     "key-test",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -154,7 +154,7 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 			KeyID:     "key-test",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -179,7 +179,7 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -215,7 +215,7 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -257,7 +257,7 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -299,7 +299,7 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 			ExpiresAt: time.Now().Add(1 * time.Second).UTC().Format(time.RFC3339),
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -343,7 +343,7 @@ func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
 			ValidFrom: "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -166,6 +166,166 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 	}
 }
 
+func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test-123",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	// First call fetches
+	key1, err := km.GetPublicKeyForKID("key-test-123")
+	if err != nil {
+		t.Fatalf("first GetPublicKeyForKID failed: %v", err)
+	}
+	// Second call with same kid should use cache
+	key2, err := km.GetPublicKeyForKID("key-test-123")
+	if err != nil {
+		t.Fatalf("second GetPublicKeyForKID failed: %v", err)
+	}
+
+	if !key1.Equal(key2) {
+		t.Error("keys should match")
+	}
+	if fetchCount != 1 {
+		t.Errorf("expected 1 fetch for matching kid, got %d", fetchCount)
+	}
+}
+
+func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-v2",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	// Request unknown kid, server returns key-v2
+	_, err := km.GetPublicKeyForKID("key-v2")
+	if err != nil {
+		t.Fatalf("expected success when server returns matching kid: %v", err)
+	}
+
+	// Request a kid that doesn't match what server returns
+	_, err = km.GetPublicKeyForKID("key-v999")
+	if err == nil {
+		t.Error("expected error when kid doesn't match after refresh")
+	}
+}
+
+func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(nil)
+	pub2, _, _ := ed25519.GenerateKey(nil)
+
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		var pub ed25519.PublicKey
+		var kid string
+		if fetchCount == 1 {
+			pub = pub1
+			kid = "key-v1"
+		} else {
+			pub = pub2
+			kid = "key-v2"
+		}
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     kid,
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client())
+
+	// Fetch key-v1
+	key1, err := km.GetPublicKeyForKID("key-v1")
+	if err != nil {
+		t.Fatalf("first fetch failed: %v", err)
+	}
+	if !key1.Equal(pub1) {
+		t.Error("first key should be pub1")
+	}
+
+	// Request key-v2 triggers refresh
+	key2, err := km.GetPublicKeyForKID("key-v2")
+	if err != nil {
+		t.Fatalf("second fetch failed: %v", err)
+	}
+	if !key2.Equal(pub2) {
+		t.Error("second key should be pub2")
+	}
+	if fetchCount != 2 {
+		t.Errorf("expected 2 fetches for key rotation, got %d", fetchCount)
+	}
+}
+
+func TestKeyManager_ExpiresAt(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-test",
+			ValidFrom: "2026-01-01T00:00:00Z",
+			ExpiresAt: time.Now().Add(1 * time.Second).UTC().Format(time.RFC3339),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	km := NewKeyManager(server.URL, 3600, server.Client()) // Long TTL, but expires_at overrides
+
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("first GetPublicKey failed: %v", err)
+	}
+	// Should use cache (not expired yet)
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("second GetPublicKey failed: %v", err)
+	}
+	if fetchCount != 1 {
+		t.Errorf("expected 1 fetch before expiry, got %d", fetchCount)
+	}
+
+	// Wait for expires_at to pass
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := km.GetPublicKey(); err != nil {
+		t.Fatalf("third GetPublicKey failed: %v", err)
+	}
+	if fetchCount != 2 {
+		t.Errorf("expected 2 fetches after expires_at, got %d", fetchCount)
+	}
+}
+
 func TestKeyManager_StaleKeyOnRefreshFailure(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/alpacax/alpamon/internal/protocol"
 )
 
@@ -50,12 +48,37 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 	_ = enc.Encode(p)
 	// Encoder.Encode appends a newline; trim it for canonical form
 	result := bytes.TrimRight(buf.Bytes(), "\n")
-	// Unescape U+2028/U+2029 that Go escapes but Python does not
-	result = []byte(strings.NewReplacer(
-		`\u2028`, "\u2028",
-		`\u2029`, "\u2029",
-	).Replace(string(result)))
+	// Unescape U+2028/U+2029 that Go escapes but Python does not.
+	// Only replace \u2028/\u2029 when not preceded by a backslash
+	// (i.e., skip \\u2028 which represents a literal backslash in JSON).
+	result = unescapeLineSeparators(result)
 	return result
+}
+
+// unescapeLineSeparators replaces JSON-escaped \u2028 and \u2029 with raw
+// UTF-8 bytes, but only when the backslash is not itself escaped (\\u2028).
+func unescapeLineSeparators(data []byte) []byte {
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\\' && i+5 < len(data) && data[i+1] == 'u' &&
+			(string(data[i+2:i+6]) == "2028" || string(data[i+2:i+6]) == "2029") {
+			// Check if the backslash is escaped (preceded by another backslash)
+			if i > 0 && data[i-1] == '\\' {
+				buf.WriteByte(data[i])
+				continue
+			}
+			if string(data[i+2:i+6]) == "2028" {
+				buf.WriteString("\u2028")
+			} else {
+				buf.WriteString("\u2029")
+			}
+			i += 5 // skip past uXXXX
+		} else {
+			buf.WriteByte(data[i])
+		}
+	}
+	return buf.Bytes()
 }
 
 // VerifyCommand verifies the Ed25519 signature on a command.

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -91,6 +91,8 @@ func unescapeLineSeparators(data []byte) []byte {
 }
 
 // VerifyCommand verifies the Ed25519 signature on a command.
+// The caller is responsible for resolving the public key, typically
+// by calling KeyManager.GetPublicKeyForKID(cmd.KeyID).
 func VerifyCommand(cmd *protocol.Command, serverID string, publicKey ed25519.PublicKey) error {
 	if cmd == nil {
 		return errors.New("nil command")

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/alpacax/alpamon/internal/protocol"
 )
@@ -26,9 +27,10 @@ type signingPayload struct {
 
 // BuildCanonicalPayload constructs the signing payload that must match
 // what the AI server signed. The output is deterministic canonical JSON.
-// Uses json.Encoder with SetEscapeHTML(false) to match Python's json.dumps
-// behavior (called with ensure_ascii=False), which does not escape <, >, &
-// or non-ASCII characters. Both sides emit raw UTF-8.
+// Uses json.Encoder with SetEscapeHTML(false) and unescapes U+2028/U+2029
+// to match Python's json.dumps(ensure_ascii=False) behavior exactly.
+// Go's encoding/json escapes U+2028/U+2029 even with SetEscapeHTML(false),
+// but Python emits them as raw UTF-8.
 func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 	if cmd == nil {
 		return nil
@@ -47,7 +49,13 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 	enc.SetEscapeHTML(false)
 	_ = enc.Encode(p)
 	// Encoder.Encode appends a newline; trim it for canonical form
-	return bytes.TrimRight(buf.Bytes(), "\n")
+	result := bytes.TrimRight(buf.Bytes(), "\n")
+	// Unescape U+2028/U+2029 that Go escapes but Python does not
+	result = []byte(strings.NewReplacer(
+		`\u2028`, "\u2028",
+		`\u2029`, "\u2029",
+	).Replace(string(result)))
+	return result
 }
 
 // VerifyCommand verifies the Ed25519 signature on a command.

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -1,6 +1,7 @@
 package signing
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
@@ -25,6 +26,8 @@ type signingPayload struct {
 
 // BuildCanonicalPayload constructs the signing payload that must match
 // what the AI server signed. The output is deterministic canonical JSON.
+// Uses json.Encoder with SetEscapeHTML(false) to match Python's json.dumps
+// behavior, which does not escape <, >, or & characters.
 func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 	p := signingPayload{
 		CommandID: cmd.ID,
@@ -35,12 +38,20 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 		Timestamp: cmd.AnalyzedAt,
 		Username:  cmd.User,
 	}
-	data, _ := json.Marshal(p)
-	return data
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(p)
+	// Encoder.Encode appends a newline; trim it for canonical form
+	return bytes.TrimRight(buf.Bytes(), "\n")
 }
 
 // VerifyCommand verifies the Ed25519 signature on a command.
 func VerifyCommand(cmd *protocol.Command, serverID string, publicKey ed25519.PublicKey) error {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public key size: got %d, want %d", len(publicKey), ed25519.PublicKeySize)
+	}
+
 	if cmd.Signature == "" {
 		return errors.New("empty signature")
 	}

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/alpacax/alpamon/internal/protocol"
 )
 
@@ -56,15 +57,23 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 }
 
 // unescapeLineSeparators replaces JSON-escaped \u2028 and \u2029 with raw
-// UTF-8 bytes, but only when the backslash is not itself escaped (\\u2028).
+// UTF-8 bytes, but only when the leading backslash is not itself escaped.
+// Escaping is determined by counting consecutive preceding backslashes:
+// odd count means the backslash is escaped (part of \\), even means it
+// introduces a real JSON escape sequence.
 func unescapeLineSeparators(data []byte) []byte {
 	var buf bytes.Buffer
 	buf.Grow(len(data))
 	for i := 0; i < len(data); i++ {
 		if data[i] == '\\' && i+5 < len(data) && data[i+1] == 'u' &&
 			(string(data[i+2:i+6]) == "2028" || string(data[i+2:i+6]) == "2029") {
-			// Check if the backslash is escaped (preceded by another backslash)
-			if i > 0 && data[i-1] == '\\' {
+			// Count consecutive preceding backslashes
+			backslashCount := 0
+			for j := i - 1; j >= 0 && data[j] == '\\'; j-- {
+				backslashCount++
+			}
+			if backslashCount%2 == 1 {
+				// Odd preceding backslashes: this backslash is escaped, not a JSON escape
 				buf.WriteByte(data[i])
 				continue
 			}

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -1,0 +1,64 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/alpacax/alpamon/internal/protocol"
+)
+
+// signingPayload defines the canonical payload that the AI server signs.
+// Struct fields are ordered alphabetically by JSON tag to match Python's
+// json.dumps(sort_keys=True, separators=(',', ':')).
+type signingPayload struct {
+	CommandID string `json:"command_id"`
+	GroupName string `json:"groupname"`
+	Line      string `json:"line"`
+	ServerID  string `json:"server_id"`
+	Shell     string `json:"shell"`
+	Timestamp string `json:"timestamp"`
+	Username  string `json:"username"`
+}
+
+// BuildCanonicalPayload constructs the signing payload that must match
+// what the AI server signed. The output is deterministic canonical JSON.
+func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
+	p := signingPayload{
+		CommandID: cmd.ID,
+		GroupName: cmd.Group,
+		Line:      cmd.Line,
+		ServerID:  serverID,
+		Shell:     cmd.Shell,
+		Timestamp: cmd.AnalyzedAt,
+		Username:  cmd.User,
+	}
+	data, _ := json.Marshal(p)
+	return data
+}
+
+// VerifyCommand verifies the Ed25519 signature on a command.
+func VerifyCommand(cmd *protocol.Command, serverID string, publicKey ed25519.PublicKey) error {
+	if cmd.Signature == "" {
+		return errors.New("empty signature")
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(cmd.Signature)
+	if err != nil {
+		return fmt.Errorf("invalid signature encoding: %w", err)
+	}
+
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("invalid signature size: got %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+
+	payload := BuildCanonicalPayload(cmd, serverID)
+
+	if !ed25519.Verify(publicKey, payload, sig) {
+		return errors.New("signature verification failed")
+	}
+
+	return nil
+}

--- a/pkg/signing/verifier.go
+++ b/pkg/signing/verifier.go
@@ -27,8 +27,12 @@ type signingPayload struct {
 // BuildCanonicalPayload constructs the signing payload that must match
 // what the AI server signed. The output is deterministic canonical JSON.
 // Uses json.Encoder with SetEscapeHTML(false) to match Python's json.dumps
-// behavior, which does not escape <, >, or & characters.
+// behavior (called with ensure_ascii=False), which does not escape <, >, &
+// or non-ASCII characters. Both sides emit raw UTF-8.
 func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
+	if cmd == nil {
+		return nil
+	}
 	p := signingPayload{
 		CommandID: cmd.ID,
 		GroupName: cmd.Group,
@@ -48,6 +52,10 @@ func BuildCanonicalPayload(cmd *protocol.Command, serverID string) []byte {
 
 // VerifyCommand verifies the Ed25519 signature on a command.
 func VerifyCommand(cmd *protocol.Command, serverID string, publicKey ed25519.PublicKey) error {
+	if cmd == nil {
+		return errors.New("nil command")
+	}
+
 	if len(publicKey) != ed25519.PublicKeySize {
 		return fmt.Errorf("invalid public key size: got %d, want %d", len(publicKey), ed25519.PublicKeySize)
 	}

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -170,3 +170,38 @@ func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
 		t.Error("expected error for wrong signature size")
 	}
 }
+
+func TestVerifyCommand_NilPublicKey(t *testing.T) {
+	cmd := &protocol.Command{
+		ID:        "cmd-123",
+		Shell:     "system",
+		Line:      "whoami",
+		User:      "root",
+		Group:     "root",
+		Signature: base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize)),
+	}
+
+	err := VerifyCommand(cmd, "server-456", nil)
+	if err == nil {
+		t.Error("expected error for nil public key")
+	}
+}
+
+func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
+	// Verify that <, >, & are NOT escaped (matching Python's json.dumps behavior)
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "system",
+		Line:       "echo '<h1>test</h1>' & cat /etc/passwd",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-01-01T00:00:00+00:00",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "srv-1")
+	expected := `{"command_id":"cmd-1","groupname":"root","line":"echo '<h1>test</h1>' & cat /etc/passwd","server_id":"srv-1","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
+
+	if string(payload) != expected {
+		t.Errorf("HTML chars should not be escaped\ngot:  %s\nwant: %s", string(payload), expected)
+	}
+}

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -229,6 +229,30 @@ func TestBuildCanonicalPayload_LineSeparators(t *testing.T) {
 	}
 }
 
+func TestBuildCanonicalPayload_LiteralBackslashU2028(t *testing.T) {
+	// Verify that literal "\u2028"/"\u2029" text in user input is NOT
+	// corrupted by the U+2028/U+2029 unescaping post-processing.
+	cmd := &protocol.Command{
+		ID:         "cmd-2",
+		Shell:      "system",
+		Line:       `echo hello\u2028and\u2029end`,
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-01-01T00:00:00+00:00",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "srv-1")
+
+	// Must NOT contain raw U+2028/U+2029 bytes (those would mean corruption)
+	if bytes.Contains(payload, []byte("\u2028")) || bytes.Contains(payload, []byte("\u2029")) {
+		t.Errorf("literal \\u2028/\\u2029 text should not become raw bytes\ngot: %s", string(payload))
+	}
+	// JSON should contain the escaped form \\u2028/\\u2029
+	if !bytes.Contains(payload, []byte(`\\u2028`)) || !bytes.Contains(payload, []byte(`\\u2029`)) {
+		t.Errorf("literal \\u2028/\\u2029 should remain as \\\\u2028/\\\\u2029 in JSON\ngot: %s", string(payload))
+	}
+}
+
 func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
 	// Verify that <, >, & are NOT escaped (matching Python's json.dumps behavior)
 	cmd := &protocol.Command{

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -1,0 +1,172 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+
+	"github.com/alpacax/alpamon/internal/protocol"
+)
+
+func TestBuildCanonicalPayload(t *testing.T) {
+	cmd := &protocol.Command{
+		ID:         "test-uuid",
+		Shell:      "system",
+		Line:       "echo hello",
+		User:       "root",
+		Group:      "alpacon",
+		AnalyzedAt: "2026-01-01T00:00:00+00:00",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "server-uuid")
+
+	// Must match Python's json.dumps(sort_keys=True, separators=(',', ':'))
+	expected := `{"command_id":"test-uuid","groupname":"alpacon","line":"echo hello","server_id":"server-uuid","shell":"system","timestamp":"2026-01-01T00:00:00+00:00","username":"root"}`
+
+	if string(payload) != expected {
+		t.Errorf("canonical payload mismatch\ngot:  %s\nwant: %s", string(payload), expected)
+	}
+}
+
+func TestBuildCanonicalPayload_EmptyAnalyzedAt(t *testing.T) {
+	cmd := &protocol.Command{
+		ID:    "cmd-1",
+		Shell: "system",
+		Line:  "ls",
+		User:  "deploy",
+		Group: "deploy",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "srv-1")
+	expected := `{"command_id":"cmd-1","groupname":"deploy","line":"ls","server_id":"srv-1","shell":"system","timestamp":"","username":"deploy"}`
+
+	if string(payload) != expected {
+		t.Errorf("canonical payload mismatch\ngot:  %s\nwant: %s", string(payload), expected)
+	}
+}
+
+func TestVerifyCommand_Valid(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+	}
+	serverID := "server-456"
+
+	payload := BuildCanonicalPayload(cmd, serverID)
+	sig := ed25519.Sign(priv, payload)
+	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	if err := VerifyCommand(cmd, serverID, pub); err != nil {
+		t.Errorf("expected valid signature, got error: %v", err)
+	}
+}
+
+func TestVerifyCommand_TamperedPayload(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+	}
+	serverID := "server-456"
+
+	payload := BuildCanonicalPayload(cmd, serverID)
+	sig := ed25519.Sign(priv, payload)
+	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	// Tamper with the command
+	cmd.Line = "rm -rf /"
+
+	err := VerifyCommand(cmd, serverID, pub)
+	if err == nil {
+		t.Error("expected verification failure for tampered command")
+	}
+}
+
+func TestVerifyCommand_WrongServerID(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+
+	cmd := &protocol.Command{
+		ID:         "cmd-123",
+		Shell:      "system",
+		Line:       "whoami",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-03-01T12:00:00+00:00",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "server-456")
+	sig := ed25519.Sign(priv, payload)
+	cmd.Signature = base64.StdEncoding.EncodeToString(sig)
+
+	err := VerifyCommand(cmd, "different-server", pub)
+	if err == nil {
+		t.Error("expected verification failure for wrong server ID")
+	}
+}
+
+func TestVerifyCommand_EmptySignature(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	cmd := &protocol.Command{
+		ID:    "cmd-123",
+		Shell: "system",
+		Line:  "whoami",
+		User:  "root",
+		Group: "root",
+	}
+
+	err := VerifyCommand(cmd, "server-456", pub)
+	if err == nil {
+		t.Error("expected error for empty signature")
+	}
+}
+
+func TestVerifyCommand_InvalidBase64(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	cmd := &protocol.Command{
+		ID:        "cmd-123",
+		Shell:     "system",
+		Line:      "whoami",
+		User:      "root",
+		Group:     "root",
+		Signature: "not-valid-base64!!!",
+	}
+
+	err := VerifyCommand(cmd, "server-456", pub)
+	if err == nil {
+		t.Error("expected error for invalid base64 signature")
+	}
+}
+
+func TestVerifyCommand_WrongSignatureSize(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	cmd := &protocol.Command{
+		ID:        "cmd-123",
+		Shell:     "system",
+		Line:      "whoami",
+		User:      "root",
+		Group:     "root",
+		Signature: base64.StdEncoding.EncodeToString([]byte("tooshort")),
+	}
+
+	err := VerifyCommand(cmd, "server-456", pub)
+	if err == nil {
+		t.Error("expected error for wrong signature size")
+	}
+}

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -187,6 +187,22 @@ func TestVerifyCommand_NilPublicKey(t *testing.T) {
 	}
 }
 
+func TestVerifyCommand_NilCommand(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	err := VerifyCommand(nil, "server-456", pub)
+	if err == nil {
+		t.Error("expected error for nil command")
+	}
+}
+
+func TestBuildCanonicalPayload_NilCommand(t *testing.T) {
+	payload := BuildCanonicalPayload(nil, "srv-1")
+	if payload != nil {
+		t.Errorf("expected nil payload for nil command, got %s", string(payload))
+	}
+}
+
 func TestBuildCanonicalPayload_HTMLChars(t *testing.T) {
 	// Verify that <, >, & are NOT escaped (matching Python's json.dumps behavior)
 	cmd := &protocol.Command{

--- a/pkg/signing/verifier_test.go
+++ b/pkg/signing/verifier_test.go
@@ -1,6 +1,7 @@
 package signing
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/base64"
 	"testing"
@@ -200,6 +201,31 @@ func TestBuildCanonicalPayload_NilCommand(t *testing.T) {
 	payload := BuildCanonicalPayload(nil, "srv-1")
 	if payload != nil {
 		t.Errorf("expected nil payload for nil command, got %s", string(payload))
+	}
+}
+
+func TestBuildCanonicalPayload_LineSeparators(t *testing.T) {
+	// U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) must NOT be
+	// escaped, matching Python's json.dumps(ensure_ascii=False) behavior.
+	// Go's encoding/json escapes these even with SetEscapeHTML(false).
+	cmd := &protocol.Command{
+		ID:         "cmd-1",
+		Shell:      "system",
+		Line:       "echo hello\u2028world\u2029end",
+		User:       "root",
+		Group:      "root",
+		AnalyzedAt: "2026-01-01T00:00:00+00:00",
+	}
+
+	payload := BuildCanonicalPayload(cmd, "srv-1")
+
+	// Payload must contain raw UTF-8 bytes, not \u2028/\u2029 escapes
+	if bytes.Contains(payload, []byte(`\u2028`)) || bytes.Contains(payload, []byte(`\u2029`)) {
+		t.Errorf("U+2028/U+2029 should not be escaped in canonical payload\ngot: %s", string(payload))
+	}
+	// Verify the raw bytes are present
+	if !bytes.Contains(payload, []byte("\u2028")) || !bytes.Contains(payload, []byte("\u2029")) {
+		t.Error("payload should contain raw U+2028/U+2029 bytes")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `pkg/signing/keymanager.go`: fetches and caches Ed25519 public key from AI server (`GET /api/commands/public-key/`)
- Add `pkg/signing/verifier.go`: builds canonical payload and verifies Ed25519 signatures
- Add `KeyID` field to `Command` struct for kid-based key cache lookup
- Canonical payload uses struct with alphabetically ordered JSON tags to guarantee byte-identical output with Python's `json.dumps(sort_keys=True, separators=(',', ':'))`

## Key design decisions

### Key management
- **kid-based lookup**: `GetPublicKeyForKID(kid)` returns cached key if kid matches and not expired, otherwise fetches from AI server
- **expires_at support**: AI server can include `expires_at` in public key response for proactive refresh before expiry, with TTL-based fallback
- **Concurrent refresh guard**: `refreshMu` serializes refresh calls to prevent fetch bursts under load
- **Expired key rejection**: expired keys are never returned on refresh failure

### Canonical payload
- `SetEscapeHTML(false)` to match Python's `json.dumps`
- U+2028/U+2029 unescaping with backslash counting to handle edge cases (Go escapes these, Python does not)
- Nil command checks on public API boundaries

### Defense in depth
- Response body limited to 16KB via `io.LimitReader` with explicit oversized detection
- Empty `key_id` from AI server rejected before cache update

## Test coverage (25 tests)
- Key fetch, caching, TTL expiry, expires_at expiry
- kid-based cache hit, kid mismatch, key rotation
- Expired key + refresh failure → error
- Canonical payload: basic, empty fields, HTML chars, U+2028/U+2029, literal backslash-u
- Signature: valid, tampered, wrong server ID, empty, invalid base64, wrong size, nil key, nil command
- Server errors: unavailable, invalid algorithm, invalid key size

## Cross-repo compatibility
- **alpacon-protos** (PR #23): `CommandExecute` proto adds `signature`, `key_id`, `analyzed_at` fields
- **alpacon-server** (PR #1816): stores `key_id` from AI server, includes signing fields in command dispatch
- **alpacon-ai-server**: verify response includes `key_id`, public-key response includes `expires_at`

## Test plan
- [x] All 25 signing package tests pass
- [x] All CI checks pass (golangci-lint, build, 19 distros)
- [ ] Cross-language test: sign payload in Python, verify in Go (to be validated during integration)

Stacked on #263

Refs #262