### PR TITLE
fix: resolve CodeQL security alerts (path-injection, request-forgery)

### DIFF
--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -135,9 +135,8 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	// codeql[go/path-injection]: Intentional - Admin-specified file path for download
 	if bulk || recursive {
-		defer func() { _ = os.Remove(name) }() // lgtm[go/path-injection]
+		defer func() { _ = os.Remove(name) }() // codeql[go/path-injection]: Intentional: admin-specified temp archive cleanup
 	}
 
 	catCmd := exec.CommandContext(ctx, "cat", name)

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -129,14 +129,14 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	name, displayName, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
+	name, cleanupPath, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create archive")
 		return 1, err.Error()
 	}
 
-	if bulk || recursive {
-		defer func() { _ = os.Remove(name) }()
+	if cleanupPath != "" {
+		defer func() { _ = os.Remove(cleanupPath) }()
 	}
 
 	catCmd := exec.CommandContext(ctx, "cat", name)
@@ -148,7 +148,7 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	requestBody, contentType, err := h.createMultipartBody(output, displayName, args.UseBlob, recursive)
+	requestBody, contentType, err := h.createMultipartBody(output, filepath.Base(name), args.UseBlob, recursive)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to make request body")
 		return 1, err.Error()
@@ -308,17 +308,18 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 }
 
 // makeArchive creates a zip archive from the specified paths.
-// It returns the archive file path, a display name for the upload, and any error.
+// It returns the archive file path, a cleanup path (non-empty only for temp archives), and any error.
+// cleanupPath is always derived from os.TempDir() and never from user input,
+// ensuring os.Remove(cleanupPath) is safe from path-injection.
 func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, recursive bool, sysProcAttr *syscall.SysProcAttr) (string, string, error) {
 	var archiveName string
-	var displayName string
+	var cleanupPath string
 	var cmd *exec.Cmd
 	path := paths[0]
 
 	if bulk {
-		zipName := uuid.New().String() + ".zip"
-		archiveName = filepath.Join(os.TempDir(), zipName)
-		displayName = zipName
+		archiveName = filepath.Join(os.TempDir(), uuid.New().String()+".zip")
+		cleanupPath = archiveName
 		dirPath := filepath.Dir(path)
 		basePaths := make([]string, len(paths))
 		for i, p := range paths {
@@ -332,13 +333,13 @@ func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, rec
 	} else {
 		if recursive {
 			archiveName = filepath.Join(os.TempDir(), uuid.New().String()+".zip")
-			displayName = filepath.Base(path) + ".zip"
+			cleanupPath = archiveName
 			cmd = exec.CommandContext(ctx, "zip", "-r", archiveName, filepath.Base(path))
 			cmd.SysProcAttr = sysProcAttr
 			cmd.Dir = filepath.Dir(path)
 		} else {
 			archiveName = path
-			displayName = filepath.Base(path)
+			// cleanupPath stays "" — single file, no temp archive to clean up
 		}
 	}
 
@@ -349,7 +350,7 @@ func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, rec
 		}
 	}
 
-	return archiveName, displayName, nil
+	return archiveName, cleanupPath, nil
 }
 
 // createMultipartBody creates a multipart form body for file upload

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -129,14 +129,14 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	name, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
+	name, displayName, err := h.makeArchive(ctx, paths, bulk, recursive, sysProcAttr)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create archive")
 		return 1, err.Error()
 	}
 
 	if bulk || recursive {
-		defer func() { _ = os.Remove(name) }() // codeql[go/path-injection]: Intentional: admin-specified temp archive cleanup
+		defer func() { _ = os.Remove(name) }()
 	}
 
 	catCmd := exec.CommandContext(ctx, "cat", name)
@@ -148,7 +148,7 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	requestBody, contentType, err := h.createMultipartBody(output, filepath.Base(name), args.UseBlob, recursive)
+	requestBody, contentType, err := h.createMultipartBody(output, displayName, args.UseBlob, recursive)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to make request body")
 		return 1, err.Error()
@@ -307,14 +307,18 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 	return paths, isBulk, isRecursive, nil
 }
 
-// makeArchive creates a zip archive from the specified paths
-func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, recursive bool, sysProcAttr *syscall.SysProcAttr) (string, error) {
+// makeArchive creates a zip archive from the specified paths.
+// It returns the archive file path, a display name for the upload, and any error.
+func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, recursive bool, sysProcAttr *syscall.SysProcAttr) (string, string, error) {
 	var archiveName string
+	var displayName string
 	var cmd *exec.Cmd
 	path := paths[0]
 
 	if bulk {
-		archiveName = filepath.Dir(path) + "/" + uuid.New().String() + ".zip"
+		zipName := uuid.New().String() + ".zip"
+		archiveName = filepath.Join(os.TempDir(), zipName)
+		displayName = zipName
 		dirPath := filepath.Dir(path)
 		basePaths := make([]string, len(paths))
 		for i, p := range paths {
@@ -327,23 +331,25 @@ func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, rec
 		cmd.Dir = dirPath
 	} else {
 		if recursive {
-			archiveName = path + ".zip"
+			archiveName = filepath.Join(os.TempDir(), uuid.New().String()+".zip")
+			displayName = filepath.Base(path) + ".zip"
 			cmd = exec.CommandContext(ctx, "zip", "-r", archiveName, filepath.Base(path))
 			cmd.SysProcAttr = sysProcAttr
 			cmd.Dir = filepath.Dir(path)
 		} else {
 			archiveName = path
+			displayName = filepath.Base(path)
 		}
 	}
 
 	if bulk || recursive {
 		err := cmd.Run()
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 	}
 
-	return archiveName, nil
+	return archiveName, displayName, nil
 }
 
 // createMultipartBody creates a multipart form body for file upload

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -339,13 +339,16 @@ func (h *FileHandler) makeArchive(ctx context.Context, paths []string, bulk, rec
 			cmd.Dir = filepath.Dir(path)
 		} else {
 			archiveName = path
-			// cleanupPath stays "" — single file, no temp archive to clean up
+			// cleanupPath stays ""—single file, no temp archive to clean up
 		}
 	}
 
 	if bulk || recursive {
 		err := cmd.Run()
 		if err != nil {
+			if cleanupPath != "" {
+				_ = os.Remove(cleanupPath)
+			}
 			return "", "", err
 		}
 	}

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -208,7 +208,7 @@ func TestValidateWebSocketURL(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateWebSocketURL(tc.url)
+			_, err := validateWebSocketURL(tc.url)
 			if tc.wantErr && err == nil {
 				t.Fatalf("validateWebSocketURL(%q) expected error", tc.url)
 			}
@@ -224,7 +224,7 @@ func TestValidateWebSocketURL_InvalidServerURL(t *testing.T) {
 	t.Cleanup(func() { config.GlobalSettings.ServerURL = prevServerURL })
 	config.GlobalSettings.ServerURL = "://invalid"
 
-	err := validateWebSocketURL("wss://whatever.com/ws")
+	_, err := validateWebSocketURL("wss://whatever.com/ws")
 	if err == nil {
 		t.Fatal("expected error for invalid server URL")
 	}
@@ -261,7 +261,7 @@ func TestValidateWebSocketURL_ServerWithExplicitPort(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateWebSocketURL(tc.url)
+			_, err := validateWebSocketURL(tc.url)
 			if tc.wantErr && err == nil {
 				t.Fatalf("validateWebSocketURL(%q) expected error", tc.url)
 			}

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -271,4 +271,3 @@ func TestValidateWebSocketURL_ServerWithExplicitPort(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -438,7 +438,7 @@ func validateWebSocketURL(rawURL string) (string, error) {
 		return "", fmt.Errorf("unsupported server URL scheme: %s", serverURL.Scheme)
 	}
 
-	if parsed.Scheme != expectedScheme {
+	if !strings.EqualFold(parsed.Scheme, expectedScheme) {
 		return "", fmt.Errorf("WebSocket URL scheme %q does not match expected scheme %q", parsed.Scheme, expectedScheme)
 	}
 
@@ -446,7 +446,15 @@ func validateWebSocketURL(rawURL string) (string, error) {
 		return "", fmt.Errorf("WebSocket URL host %q does not match server host %q", parsed.Hostname(), serverURL.Hostname())
 	}
 
-	return parsed.String(), nil
+	// Reconstruct URL using trusted sources for scheme and host to prevent SSRF.
+	// scheme and host come from config (trusted), not user input.
+	sanitized := &url.URL{
+		Scheme:   expectedScheme,
+		Host:     serverURL.Host,
+		Path:     parsed.Path,
+		RawQuery: parsed.RawQuery,
+	}
+	return sanitized.String(), nil
 }
 
 // getPtyUserAndEnv retrieves user information and sets environment variables.

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -76,16 +76,16 @@ func NewPtyClient(data protocol.CommandData, apiSession *scheduler.Session, mana
 }
 
 func (pc *PtyClient) initializePtySession() error {
-	if err := validateWebSocketURL(pc.url); err != nil {
+	sanitizedURL, err := validateWebSocketURL(pc.url)
+	if err != nil {
 		return err
 	}
-	var err error
 	dialer := websocket.Dialer{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: !config.GlobalSettings.SSLVerify,
 		},
 	}
-	pc.conn, _, err = dialer.Dial(pc.url, pc.requestHeader)
+	pc.conn, _, err = dialer.Dial(sanitizedURL, pc.requestHeader)
 	if err != nil {
 		return fmt.Errorf("failed to connect Websh server: %w", err)
 	}
@@ -384,7 +384,8 @@ func (pc *PtyClient) recovery() error {
 			}
 			pc.url = strings.Replace(config.GlobalSettings.ServerURL, "http", "ws", 1) + resp.WebsocketURL
 
-			if err := validateWebSocketURL(pc.url); err != nil {
+			sanitizedURL, err := validateWebSocketURL(pc.url)
+			if err != nil {
 				return backoff.Permanent(err)
 			}
 
@@ -393,7 +394,7 @@ func (pc *PtyClient) recovery() error {
 					InsecureSkipVerify: !config.GlobalSettings.SSLVerify,
 				},
 			}
-			conn, _, err := dialer.Dial(pc.url, pc.requestHeader)
+			conn, _, err := dialer.Dial(sanitizedURL, pc.requestHeader)
 			if err != nil {
 				log.Warn().Err(err).Msg("Websh reconnect failed.")
 				return err
@@ -415,15 +416,16 @@ func (pc *PtyClient) recovery() error {
 
 // validateWebSocketURL checks that the given URL uses the correct ws/wss scheme
 // derived from the configured server URL and that its host matches the server.
-func validateWebSocketURL(rawURL string) error {
+// It returns a sanitized URL string reconstructed from the parsed components.
+func validateWebSocketURL(rawURL string) (string, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("invalid WebSocket URL: %w", err)
+		return "", fmt.Errorf("invalid WebSocket URL: %w", err)
 	}
 
 	serverURL, err := url.Parse(config.GlobalSettings.ServerURL)
 	if err != nil {
-		return fmt.Errorf("invalid server URL: %w", err)
+		return "", fmt.Errorf("invalid server URL: %w", err)
 	}
 
 	var expectedScheme string
@@ -433,18 +435,18 @@ func validateWebSocketURL(rawURL string) error {
 	case "https":
 		expectedScheme = "wss"
 	default:
-		return fmt.Errorf("unsupported server URL scheme: %s", serverURL.Scheme)
+		return "", fmt.Errorf("unsupported server URL scheme: %s", serverURL.Scheme)
 	}
 
 	if parsed.Scheme != expectedScheme {
-		return fmt.Errorf("WebSocket URL scheme %q does not match expected scheme %q", parsed.Scheme, expectedScheme)
+		return "", fmt.Errorf("WebSocket URL scheme %q does not match expected scheme %q", parsed.Scheme, expectedScheme)
 	}
 
 	if !strings.EqualFold(parsed.Hostname(), serverURL.Hostname()) {
-		return fmt.Errorf("WebSocket URL host %q does not match server host %q", parsed.Hostname(), serverURL.Hostname())
+		return "", fmt.Errorf("WebSocket URL host %q does not match server host %q", parsed.Hostname(), serverURL.Hostname())
 	}
 
-	return nil
+	return parsed.String(), nil
 }
 
 // getPtyUserAndEnv retrieves user information and sets environment variables.

--- a/pkg/runner/pty.go
+++ b/pkg/runner/pty.go
@@ -80,6 +80,7 @@ func (pc *PtyClient) initializePtySession() error {
 	if err != nil {
 		return err
 	}
+	pc.url = sanitizedURL
 	dialer := websocket.Dialer{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: !config.GlobalSettings.SSLVerify,


### PR DESCRIPTION
## Summary

Fixes two CodeQL security alerts in alpamon.

- Resolves `go/request-forgery` by having `validateWebSocketURL` return a sanitized URL reconstructed from trusted config sources, so `dialer.Dial()` never receives raw user input.
- Resolves `go/path-injection` by splitting `makeArchive` return values into `(archivePath, cleanupPath, error)`, where `cleanupPath` is always derived from `os.TempDir()`, breaking the taint chain to `os.Remove`.

## Changes

- `pkg/runner/pty.go`: `validateWebSocketURL` now returns a sanitized URL with scheme and host taken from `config.GlobalSettings.ServerURL` (trusted). `dialer.Dial()` uses the sanitized URL instead of the raw input.
- `pkg/runner/ftp_test.go`: Updated test call sites to handle the new `(string, error)` return signature.
- `pkg/executor/handlers/file/file.go`: Split `makeArchive` return into `(archivePath, cleanupPath, error)`. `cleanupPath` is always `os.TempDir()`-based or empty, ensuring `os.Remove` is never called with a user-controlled path.

## Stack: golang

## Checklist

### Universal
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] No hardcoded secrets or credentials

### Go
- [ ] Error handling is complete
- [ ] Tests include edge cases
- [ ] `go mod tidy` executed

## Testing

Manually verified on a dev environment (`alpacax.dev.alpacon.io`) using an Ubuntu VM (UTM):
- Websh: Terminal sessions work correctly over WebSocket connections
- WebFTP: File upload and download operations function as expected