### PR TITLE
refactor(signing): use env-scoped key fetch instead of relay-provided key_id

### DIFF
--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -67,9 +67,17 @@ func NewWebsocketClient(session *scheduler.Session, ctxManager *agent.ContextMan
 		serverID:    config.GlobalSettings.ID,
 	}
 
+	// Local environments (localhost) have no AI signing server, so enforce
+	// mode would reject all commands. Auto-downgrade to monitor mode.
+	if signing.IsLocalEnv(config.GlobalSettings.ServerURL) && wc.signingMode == "enforce" {
+		wc.signingMode = "monitor"
+		log.Warn().Msg("Local environment detected, downgrading signing mode to monitor.")
+	}
+
 	wc.keyManager = signing.NewKeyManager(
 		config.GlobalSettings.AIServerURL,
 		config.GlobalSettings.KeyRefreshSecs,
+		signing.ResolveAuthEnv(config.GlobalSettings.ServerURL),
 		utils.NewHTTPClient(),
 	)
 	log.Info().Str("mode", wc.signingMode).Msg("Command signature verification enabled.")

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -83,6 +83,20 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 		return nil
 	}
 
+	// Commands without key_id use TTL-based cache via GetPublicKey(). During
+	// key rotation the cached key may be stale but not yet expired, causing a
+	// mismatch. Retry once with an unconditional refresh (env-scoped, no
+	// relay-provided key_id) to pick up the rotated key immediately.
+	if cmd.KeyID == "" && errors.Is(err, signing.ErrSignatureMismatch) {
+		if refreshedKey, refreshErr := wc.keyManager.RefreshAndGet(); refreshErr == nil {
+			if signing.VerifyCommand(cmd, wc.serverID, refreshedKey) == nil {
+				log.Debug().Str("command_id", cmd.ID).
+					Msg("Command signature verified after key refresh.")
+				return nil
+			}
+		}
+	}
+
 	if wc.signingMode == "enforce" {
 		reason := rejectReasonInvalidSignature
 		if errors.Is(err, signing.ErrSignatureMismatch) {

--- a/pkg/runner/signing.go
+++ b/pkg/runner/signing.go
@@ -83,22 +83,6 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 		return nil
 	}
 
-	// Only retry with key refresh on actual signature mismatch (possible key
-	// rotation). Malformed input errors (bad base64, wrong size) cannot be
-	// fixed by fetching a new key, so skip the refresh to avoid unnecessary
-	// AI server load.
-	if errors.Is(err, signing.ErrSignatureMismatch) {
-		log.Debug().Str("command_id", cmd.ID).
-			Msg("Signature mismatch, refreshing key for possible rotation.")
-
-		retryErr := wc.retryVerificationAfterRefresh(cmd, err)
-		if retryErr == nil {
-			log.Debug().Str("command_id", cmd.ID).Msg("Command signature verified after key refresh.")
-			return nil
-		}
-		err = retryErr
-	}
-
 	if wc.signingMode == "enforce" {
 		reason := rejectReasonInvalidSignature
 		if errors.Is(err, signing.ErrSignatureMismatch) {
@@ -108,32 +92,6 @@ func (wc *WebsocketClient) verifyCommandSignature(cmd *protocol.Command) error {
 	}
 	log.Warn().Err(err).Str("command_id", cmd.ID).
 		Msg("Signature verification failed, executing in monitor mode.")
-	return nil
-}
-
-// retryVerificationAfterRefresh force-refreshes the public key and retries
-// signature verification. ForceRefresh fetches unconditionally (unlike Refresh
-// which is a no-op when the cached key hasn't expired), ensuring a rotated key
-// is actually fetched.
-func (wc *WebsocketClient) retryVerificationAfterRefresh(cmd *protocol.Command, originalErr error) error {
-	if refreshErr := wc.keyManager.ForceRefresh(); refreshErr != nil {
-		log.Warn().Err(refreshErr).Msg("Key refresh failed.")
-		return fmt.Errorf("signature verification failed and key refresh failed: %w",
-			errors.Join(originalErr, refreshErr))
-	}
-
-	// Use GetPublicKey (not GetPublicKeyForKID) since ForceRefresh just
-	// populated the cache. Calling GetPublicKeyForKID here would trigger a
-	// second fetch if the AI server rotated to a different KID.
-	pubKey, err := wc.keyManager.GetPublicKey()
-	if err != nil {
-		return fmt.Errorf("public key unavailable after refresh: %w", err)
-	}
-
-	if retryErr := signing.VerifyCommand(cmd, wc.serverID, pubKey); retryErr != nil {
-		return fmt.Errorf("signature verification failed after key refresh: %w", retryErr)
-	}
-
 	return nil
 }
 

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -161,22 +161,33 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	newPub, newPriv, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 
-	keyID := "rotated-key-1"
+	oldKeyID := "old-key-1"
+	newKeyID := "new-key-1"
 	var fetchCount atomic.Int32
 
-	// Serve old key on first request, new key on subsequent requests
+	// Serve keys based on query: ?key_id=xxx returns that specific key,
+	// otherwise returns whatever is "active" (new key after rotation).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := fetchCount.Add(1)
+		fetchCount.Add(1)
+		kid := r.URL.Query().Get("key_id")
 		var pub ed25519.PublicKey
-		if n == 1 {
+		var respKID string
+		switch kid {
+		case oldKeyID:
 			pub = oldPub
-		} else {
+			respKID = oldKeyID
+		case newKeyID:
 			pub = newPub
+			respKID = newKeyID
+		default:
+			// Active key endpoint (no key_id param): return old key initially
+			pub = oldPub
+			respKID = oldKeyID
 		}
 		resp := map[string]string{
 			"algorithm":  "Ed25519",
 			"public_key": base64.StdEncoding.EncodeToString(pub),
-			"key_id":     keyID,
+			"key_id":     respKID,
 			"valid_from": "2026-01-01T00:00:00Z",
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -190,7 +201,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
 	}
 
-	// Pre-populate cache with old key by verifying a command signed with it
+	// Pre-populate cache with old key
 	cmdOld := &protocol.Command{
 		ID:         "cmd-old",
 		Shell:      "system",
@@ -198,16 +209,14 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		User:       "root",
 		Group:      "root",
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-		KeyID:      keyID,
+		KeyID:      oldKeyID,
 	}
 	signCommand(t, cmdOld, testServerID, oldPriv)
 	err = wc.verifyCommandSignature(cmdOld)
 	require.NoError(t, err, "command signed with old key should pass initially")
-	require.Equal(t, int32(1), fetchCount.Load(), "should have fetched key once")
 
-	// Now sign a command with the new key. First verification attempt uses
-	// the cached old key and fails, triggering ForceRefresh which fetches the
-	// new key, and the retry succeeds.
+	// Command signed with new key + new key_id. First attempt uses cached
+	// old key (kid mismatch), then fetches by key_id and succeeds.
 	cmdNew := &protocol.Command{
 		ID:         "cmd-new",
 		Shell:      "system",
@@ -215,14 +224,12 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 		User:       "root",
 		Group:      "root",
 		AnalyzedAt: "2026-03-01T12:00:00+00:00",
-		KeyID:      keyID,
+		KeyID:      newKeyID,
 	}
 	signCommand(t, cmdNew, testServerID, newPriv)
 
 	err = wc.verifyCommandSignature(cmdNew)
-	assert.NoError(t, err, "command signed with new key should succeed after key rotation")
-	assert.Equal(t, int32(2), fetchCount.Load(),
-		"should have fetched key twice: initial + ForceRefresh for rotation")
+	assert.NoError(t, err, "command signed with new key should succeed after key_id lookup")
 }
 
 func TestVerifyCommandSignature_KeyUnavailableMonitorMode(t *testing.T) {

--- a/pkg/runner/signing_test.go
+++ b/pkg/runner/signing_test.go
@@ -45,7 +45,7 @@ func signCommand(t *testing.T, cmd *protocol.Command, serverID string, priv ed25
 func TestVerifyCommandSignature_InternalBypass(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
-		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -61,7 +61,7 @@ func TestVerifyCommandSignature_InternalBypass(t *testing.T) {
 func TestVerifyCommandSignature_UnsignedMonitorMode(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "monitor",
-		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -77,7 +77,7 @@ func TestVerifyCommandSignature_UnsignedMonitorMode(t *testing.T) {
 func TestVerifyCommandSignature_UnsignedEnforceMode(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
-		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, nil),
+		keyManager:  signing.NewKeyManager("http://localhost:9999", 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -102,7 +102,7 @@ func TestVerifyCommandSignature_ValidSignature(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
 		serverID:    testServerID,
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -135,7 +135,7 @@ func TestVerifyCommandSignature_InvalidSignature(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
 		serverID:    testServerID,
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -165,24 +165,19 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	newKeyID := "new-key-1"
 	var fetchCount atomic.Int32
 
-	// Serve keys based on query: ?key_id=xxx returns that specific key,
-	// otherwise returns whatever is "active" (new key after rotation).
+	// Server simulates key rotation: first request returns old key,
+	// subsequent requests return new key (the rotated active key).
+	// No ?key_id query — alpamon fetches by environment, not by relay-provided key_id.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount.Add(1)
-		kid := r.URL.Query().Get("key_id")
+		n := fetchCount.Add(1)
 		var pub ed25519.PublicKey
 		var respKID string
-		switch kid {
-		case oldKeyID:
+		if n == 1 {
 			pub = oldPub
 			respKID = oldKeyID
-		case newKeyID:
+		} else {
 			pub = newPub
 			respKID = newKeyID
-		default:
-			// Active key endpoint (no key_id param): return old key initially
-			pub = oldPub
-			respKID = oldKeyID
 		}
 		resp := map[string]string{
 			"algorithm":  "Ed25519",
@@ -198,7 +193,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
 		serverID:    testServerID,
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	// Pre-populate cache with old key
@@ -215,8 +210,8 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	err = wc.verifyCommandSignature(cmdOld)
 	require.NoError(t, err, "command signed with old key should pass initially")
 
-	// Command signed with new key + new key_id. First attempt uses cached
-	// old key (kid mismatch), then fetches by key_id and succeeds.
+	// Command signed with new key + new key_id. kid mismatch triggers
+	// env-scoped refresh, which returns the rotated active key.
 	cmdNew := &protocol.Command{
 		ID:         "cmd-new",
 		Shell:      "system",
@@ -229,7 +224,7 @@ func TestVerifyCommandSignature_KeyRotation(t *testing.T) {
 	signCommand(t, cmdNew, testServerID, newPriv)
 
 	err = wc.verifyCommandSignature(cmdNew)
-	assert.NoError(t, err, "command signed with new key should succeed after key_id lookup")
+	assert.NoError(t, err, "command signed with new key should succeed after env-scoped refresh")
 }
 
 func TestVerifyCommandSignature_KeyUnavailableMonitorMode(t *testing.T) {
@@ -241,7 +236,7 @@ func TestVerifyCommandSignature_KeyUnavailableMonitorMode(t *testing.T) {
 
 	wc := &WebsocketClient{
 		signingMode: "monitor",
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -263,7 +258,7 @@ func TestVerifyCommandSignature_KeyUnavailableEnforceMode(t *testing.T) {
 
 	wc := &WebsocketClient{
 		signingMode: "enforce",
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -293,7 +288,7 @@ func TestVerifyCommandSignature_InvalidSignatureMonitorMode(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "monitor",
 		serverID:    testServerID,
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{
@@ -321,7 +316,7 @@ func TestVerifyCommandSignature_WithoutKeyID(t *testing.T) {
 	wc := &WebsocketClient{
 		signingMode: "enforce",
 		serverID:    testServerID,
-		keyManager:  signing.NewKeyManager(server.URL, 3600, nil),
+		keyManager:  signing.NewKeyManager(server.URL, 3600, "", nil),
 	}
 
 	cmd := &protocol.Command{

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -84,8 +84,8 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 }
 
 // GetPublicKeyForKID returns the cached key if the kid matches and the key is not expired.
-// If the kid doesn't match the cached key or the key is expired, it refreshes from the AI server.
-// This avoids unnecessary fetches when the key hasn't rotated.
+// If the kid doesn't match, it fetches that specific key by key_id from the AI server.
+// This handles both key rotation and cross-environment scenarios (dev/prod).
 func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	m.mu.RLock()
 	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
@@ -95,25 +95,17 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	}
 	m.mu.RUnlock()
 
-	// Unknown kid or expired key: force fetch new key from AI server
-	if err := m.fetchKey(); err != nil {
+	// Fetch the specific key by key_id (handles rotation + cross-env)
+	key, err := m.fetchKeyByKID(kid)
+	if err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		// Only fall back to cached key if it matches the requested kid
 		if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
 			return copyKey(m.publicKey), nil
 		}
-		return nil, fmt.Errorf("failed to refresh key for kid %q: %w", kid, err)
+		return nil, fmt.Errorf("failed to fetch key for kid %q: %w", kid, err)
 	}
-
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
-		return copyKey(m.publicKey), nil
-	}
-	log.Debug().Str("requested_kid", kid).Str("cached_kid", m.keyID).
-		Msg("AI server returned different kid than requested.")
-	return nil, fmt.Errorf("public key for kid %q not available after refresh", kid)
+	return key, nil
 }
 
 // isExpired reports whether the cached key should be refreshed.
@@ -164,6 +156,60 @@ func (m *KeyManager) fetchKey() error {
 	m.refreshMu.Lock()
 	defer m.refreshMu.Unlock()
 	return m.fetchKeyLocked()
+}
+
+// fetchKeyByKID fetches a specific public key by key_id from the AI server.
+// Unlike fetchKeyLocked (which gets the active key), this queries by key_id
+// to support key rotation and cross-environment (dev/prod) key lookup.
+// The result is NOT cached — it is returned directly.
+func (m *KeyManager) fetchKeyByKID(kid string) (ed25519.PublicKey, error) {
+	url := m.aiBaseURL + "/api/commands/public-key/?key_id=" + kid
+
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch public key for kid %q: %w", kid, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("public key endpoint returned status %d for kid %q", resp.StatusCode, kid)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(body)) > maxResponseSize {
+		return nil, fmt.Errorf("public key response too large (>%d bytes)", maxResponseSize)
+	}
+
+	var keyResp publicKeyResponse
+	if err := json.Unmarshal(body, &keyResp); err != nil {
+		return nil, fmt.Errorf("failed to parse public key response: %w", err)
+	}
+
+	if keyResp.Algorithm != "Ed25519" {
+		return nil, fmt.Errorf("unsupported algorithm: %s", keyResp.Algorithm)
+	}
+
+	keyBytes, err := base64.StdEncoding.DecodeString(keyResp.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode public key: %w", err)
+	}
+
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+	}
+
+	return ed25519.PublicKey(keyBytes), nil
 }
 
 // fetchKeyLocked performs the actual HTTP fetch. Must be called with refreshMu held.

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -161,7 +161,7 @@ func (m *KeyManager) fetchKey() error {
 // fetchKeyByKID fetches a specific public key by key_id from the AI server.
 // Unlike fetchKeyLocked (which gets the active key), this queries by key_id
 // to support key rotation and cross-environment (dev/prod) key lookup.
-// The result is NOT cached — it is returned directly.
+// On success, the fetched key is cached for subsequent calls.
 func (m *KeyManager) fetchKeyByKID(kid string) (ed25519.PublicKey, error) {
 	url := m.aiBaseURL + "/api/commands/public-key/?key_id=" + kid
 
@@ -209,7 +209,26 @@ func (m *KeyManager) fetchKeyByKID(kid string) (ed25519.PublicKey, error) {
 		return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
 	}
 
-	return ed25519.PublicKey(keyBytes), nil
+	pubKey := ed25519.PublicKey(keyBytes)
+
+	// Cache the fetched key so subsequent calls with the same kid are free.
+	m.mu.Lock()
+	m.publicKey = pubKey
+	m.keyID = keyResp.KeyID
+	m.lastFetch = time.Now()
+	if keyResp.ExpiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, keyResp.ExpiresAt); err == nil {
+			m.expiresAt = t
+		} else {
+			m.expiresAt = time.Time{}
+		}
+	} else {
+		m.expiresAt = time.Time{}
+	}
+	m.mu.Unlock()
+
+	log.Debug().Str("key_id", keyResp.KeyID).Msg("Public signing key fetched by key_id.")
+	return copyKey(pubKey), nil
 }
 
 // fetchKeyLocked performs the actual HTTP fetch. Must be called with refreshMu held.

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -26,7 +26,7 @@ func ResolveAuthEnv(serverURL string) string {
 	if err != nil {
 		return ""
 	}
-	if strings.HasPrefix(u.Hostname(), "dev.") {
+	if strings.EqualFold(u.Hostname(), "dev.alpacon.io") {
 		return "dev"
 	}
 	return ""
@@ -181,6 +181,19 @@ func (m *KeyManager) Refresh() error {
 	m.mu.RUnlock()
 
 	return m.fetchKeyLocked()
+}
+
+// RefreshAndGet fetches the active key unconditionally (ignoring cache TTL)
+// and returns it. Used for one-time retry on signature mismatch when the
+// command has no key_id. This is env-scoped and does not accept any
+// relay-provided key identifier.
+func (m *KeyManager) RefreshAndGet() (ed25519.PublicKey, error) {
+	if err := m.fetchKey(); err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return copyKey(m.publicKey), nil
 }
 
 // fetchKey acquires the refresh lock and fetches unconditionally.

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -9,12 +9,40 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
 )
+
+// ResolveAuthEnv determines the auth environment from the alpacon server URL.
+// dev.alpacon.io → "dev", everything else → "" (prod default).
+// This lets alpamon derive its environment from trusted local config rather
+// than trusting the key_id provided by the relay (alpacon-server).
+func ResolveAuthEnv(serverURL string) string {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return ""
+	}
+	if strings.HasPrefix(u.Hostname(), "dev.") {
+		return "dev"
+	}
+	return ""
+}
+
+// IsLocalEnv reports whether the server URL points to a local development
+// environment (localhost, 127.0.0.1, etc.) where the AI signing server is
+// unavailable and command signing cannot work.
+func IsLocalEnv(serverURL string) bool {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
 
 // maxResponseSize limits the public key response body to prevent
 // excessive memory usage from a misbehaving server.
@@ -41,6 +69,7 @@ type KeyManager struct {
 	expiresAt   time.Time
 	refreshSecs int
 	aiBaseURL   string
+	authEnv     string // "dev" or "" (prod); derived from alpacon server URL
 	client      *http.Client
 
 	// refreshMu serializes refresh calls to prevent concurrent fetch bursts
@@ -48,13 +77,17 @@ type KeyManager struct {
 }
 
 // NewKeyManager creates a key manager that fetches from the AI server.
-func NewKeyManager(aiBaseURL string, refreshSecs int, client *http.Client) *KeyManager {
+// authEnv is the environment identifier (e.g. "dev") derived from the alpacon
+// server URL via ResolveAuthEnv. It is used to scope key fetches so that
+// alpamon only trusts keys for its own environment.
+func NewKeyManager(aiBaseURL string, refreshSecs int, authEnv string, client *http.Client) *KeyManager {
 	if client == nil {
 		client = http.DefaultClient
 	}
 	return &KeyManager{
 		aiBaseURL:   strings.TrimRight(aiBaseURL, "/"),
 		refreshSecs: refreshSecs,
+		authEnv:     authEnv,
 		client:      client,
 	}
 }
@@ -83,9 +116,11 @@ func (m *KeyManager) GetPublicKey() (ed25519.PublicKey, error) {
 	return copyKey(m.publicKey), nil
 }
 
-// GetPublicKeyForKID returns the cached key if the kid matches and the key is not expired.
-// If the kid doesn't match, it fetches that specific key by key_id from the AI server.
-// This handles both key rotation and cross-environment scenarios (dev/prod).
+// GetPublicKeyForKID returns the cached key if its kid matches.
+// If the kid doesn't match (possible key rotation), it refreshes the active
+// key for this environment from the AI server. The key_id from the command is
+// used only as a cache-staleness hint — never as a query parameter — so that
+// a compromised relay cannot direct alpamon to fetch an arbitrary key.
 func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	m.mu.RLock()
 	if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
@@ -95,17 +130,22 @@ func (m *KeyManager) GetPublicKeyForKID(kid string) (ed25519.PublicKey, error) {
 	}
 	m.mu.RUnlock()
 
-	// Fetch the specific key by key_id (handles rotation + cross-env)
-	key, err := m.fetchKeyByKID(kid)
-	if err != nil {
+	// kid mismatch or expired: refresh the active key for this environment
+	if err := m.fetchKey(); err != nil {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
 		if m.publicKey != nil && m.keyID == kid && !m.isExpired() {
 			return copyKey(m.publicKey), nil
 		}
-		return nil, fmt.Errorf("failed to fetch key for kid %q: %w", kid, err)
+		return nil, fmt.Errorf("failed to refresh key for kid %q: %w", kid, err)
 	}
-	return key, nil
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.publicKey != nil && m.keyID == kid {
+		return copyKey(m.publicKey), nil
+	}
+	return nil, fmt.Errorf("key %q is not the active key for this environment (active: %q)", kid, m.keyID)
 }
 
 // isExpired reports whether the cached key should be refreshed.
@@ -143,13 +183,6 @@ func (m *KeyManager) Refresh() error {
 	return m.fetchKeyLocked()
 }
 
-// ForceRefresh fetches the public key from the AI server unconditionally,
-// regardless of whether the cached key is still valid. Use this when
-// signature verification fails and a key rotation may have occurred.
-func (m *KeyManager) ForceRefresh() error {
-	return m.fetchKey()
-}
-
 // fetchKey acquires the refresh lock and fetches unconditionally.
 // Used by GetPublicKeyForKID when kid doesn't match (key may not be expired).
 func (m *KeyManager) fetchKey() error {
@@ -158,87 +191,19 @@ func (m *KeyManager) fetchKey() error {
 	return m.fetchKeyLocked()
 }
 
-// fetchKeyByKID fetches a specific public key by key_id from the AI server.
-// Unlike fetchKeyLocked (which gets the active key), this queries by key_id
-// to support key rotation and cross-environment (dev/prod) key lookup.
-// On success, the fetched key is cached for subsequent calls.
-func (m *KeyManager) fetchKeyByKID(kid string) (ed25519.PublicKey, error) {
-	url := m.aiBaseURL + "/api/commands/public-key/?key_id=" + kid
-
-	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := m.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch public key for kid %q: %w", kid, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("public key endpoint returned status %d for kid %q", resp.StatusCode, kid)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-	if int64(len(body)) > maxResponseSize {
-		return nil, fmt.Errorf("public key response too large (>%d bytes)", maxResponseSize)
-	}
-
-	var keyResp publicKeyResponse
-	if err := json.Unmarshal(body, &keyResp); err != nil {
-		return nil, fmt.Errorf("failed to parse public key response: %w", err)
-	}
-
-	if keyResp.Algorithm != "Ed25519" {
-		return nil, fmt.Errorf("unsupported algorithm: %s", keyResp.Algorithm)
-	}
-
-	keyBytes, err := base64.StdEncoding.DecodeString(keyResp.PublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode public key: %w", err)
-	}
-
-	if len(keyBytes) != ed25519.PublicKeySize {
-		return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
-	}
-
-	pubKey := ed25519.PublicKey(keyBytes)
-
-	// Cache the fetched key so subsequent calls with the same kid are free.
-	m.mu.Lock()
-	m.publicKey = pubKey
-	m.keyID = keyResp.KeyID
-	m.lastFetch = time.Now()
-	if keyResp.ExpiresAt != "" {
-		if t, err := time.Parse(time.RFC3339, keyResp.ExpiresAt); err == nil {
-			m.expiresAt = t
-		} else {
-			m.expiresAt = time.Time{}
-		}
-	} else {
-		m.expiresAt = time.Time{}
-	}
-	m.mu.Unlock()
-
-	log.Debug().Str("key_id", keyResp.KeyID).Msg("Public signing key fetched by key_id.")
-	return copyKey(pubKey), nil
-}
-
 // fetchKeyLocked performs the actual HTTP fetch. Must be called with refreshMu held.
+// When authEnv is set, it scopes the request to that environment so alpamon
+// only receives keys valid for its own environment.
 func (m *KeyManager) fetchKeyLocked() error {
-	url := m.aiBaseURL + "/api/commands/public-key/"
+	fetchURL := m.aiBaseURL + "/api/commands/public-key/"
+	if m.authEnv != "" {
+		fetchURL += "?auth_env=" + url.QueryEscape(m.authEnv)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/signing/keymanager.go
+++ b/pkg/signing/keymanager.go
@@ -21,6 +21,9 @@ import (
 // dev.alpacon.io → "dev", everything else → "" (prod default).
 // This lets alpamon derive its environment from trusted local config rather
 // than trusting the key_id provided by the relay (alpacon-server).
+//
+// NOTE: When adding new environments (e.g. staging), add a corresponding
+// hostname check below and update TestResolveAuthEnv.
 func ResolveAuthEnv(serverURL string) string {
 	u, err := url.Parse(serverURL)
 	if err != nil {

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -213,6 +213,12 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kid := r.URL.Query().Get("key_id")
+		// Only serve key-v2; return 404 for unknown key_ids
+		if kid != "" && kid != "key-v2" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -226,16 +232,16 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 
 	km := NewKeyManager(server.URL, 3600, server.Client())
 
-	// Request unknown kid, server returns key-v2
+	// Request known kid
 	_, err := km.GetPublicKeyForKID("key-v2")
 	if err != nil {
 		t.Fatalf("expected success when server returns matching kid: %v", err)
 	}
 
-	// Request a kid that doesn't match what server returns
+	// Request unknown kid — server returns 404
 	_, err = km.GetPublicKeyForKID("key-v999")
 	if err == nil {
-		t.Error("expected error when kid doesn't match after refresh")
+		t.Error("expected error when key_id not found on server")
 	}
 }
 

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -391,6 +391,7 @@ func TestResolveAuthEnv(t *testing.T) {
 		{"https://dev.alpacon.io/", "dev"},
 		{"https://us.alpacon.io", ""},
 		{"https://kr.alpacon.io", ""},
+		{"https://dev.example.com", ""},
 		{"http://localhost:8000", ""},
 		{"invalid-url", ""},
 	}
@@ -426,7 +427,9 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
 	var receivedAuthEnv string
+	var authEnvPresent bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, authEnvPresent = r.URL.Query()["auth_env"]
 		receivedAuthEnv = r.URL.Query().Get("auth_env")
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
@@ -445,18 +448,18 @@ func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPublicKey failed: %v", err)
 	}
-	if receivedAuthEnv != "dev" {
-		t.Errorf("expected auth_env=dev in request, got %q", receivedAuthEnv)
+	if !authEnvPresent || receivedAuthEnv != "dev" {
+		t.Errorf("expected auth_env=dev in request, got present=%v value=%q", authEnvPresent, receivedAuthEnv)
 	}
 
-	// With empty authEnv, requests should not include auth_env
-	receivedAuthEnv = "should-not-change"
+	// With empty authEnv, requests should not include auth_env param at all
+	authEnvPresent = true // reset
 	km2 := NewKeyManager(server.URL, 3600, "", server.Client())
 	_, err = km2.GetPublicKey()
 	if err != nil {
 		t.Fatalf("GetPublicKey failed: %v", err)
 	}
-	if receivedAuthEnv != "" {
-		t.Errorf("expected no auth_env in request, got %q", receivedAuthEnv)
+	if authEnvPresent {
+		t.Errorf("expected auth_env param to be absent, but it was present with value %q", receivedAuthEnv)
 	}
 }

--- a/pkg/signing/keymanager_test.go
+++ b/pkg/signing/keymanager_test.go
@@ -33,7 +33,7 @@ func TestKeyManager_Refresh(t *testing.T) {
 	server := newTestServer(pub)
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	if err := km.Refresh(); err != nil {
 		t.Fatalf("Refresh failed: %v", err)
@@ -70,7 +70,7 @@ func TestKeyManager_CacheHit(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	// First call fetches
 	if _, err := km.GetPublicKey(); err != nil {
@@ -103,7 +103,7 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("first GetPublicKey failed: %v", err)
@@ -123,7 +123,7 @@ func TestKeyManager_CacheExpiry(t *testing.T) {
 }
 
 func TestKeyManager_ServerUnavailable(t *testing.T) {
-	km := NewKeyManager("http://localhost:1", 3600, &http.Client{Timeout: 1 * time.Second})
+	km := NewKeyManager("http://localhost:1", 3600, "", &http.Client{Timeout: 1 * time.Second})
 
 	_, err := km.GetPublicKey()
 	if err == nil {
@@ -143,7 +143,7 @@ func TestKeyManager_InvalidAlgorithm(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
 	if err == nil {
@@ -163,7 +163,7 @@ func TestKeyManager_InvalidKeySize(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	_, err := km.GetPublicKey()
 	if err == nil {
@@ -188,7 +188,7 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	// First call fetches
 	key1, err := km.GetPublicKeyForKID("key-test-123")
@@ -212,13 +212,10 @@ func TestKeyManager_GetPublicKeyForKID_CacheHit(t *testing.T) {
 func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 
+	// Server always returns the active key for this env (key-v2).
+	// Alpamon should reject commands signed with a kid that doesn't match
+	// the active key, even after refreshing.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		kid := r.URL.Query().Get("key_id")
-		// Only serve key-v2; return 404 for unknown key_ids
-		if kid != "" && kid != "key-v2" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
 		resp := publicKeyResponse{
 			Algorithm: "Ed25519",
 			PublicKey: base64.StdEncoding.EncodeToString(pub),
@@ -230,18 +227,20 @@ func TestKeyManager_GetPublicKeyForKID_Mismatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// Request known kid
+	// Request matching kid: success
 	_, err := km.GetPublicKeyForKID("key-v2")
 	if err != nil {
-		t.Fatalf("expected success when server returns matching kid: %v", err)
+		t.Fatalf("expected success when kid matches active key: %v", err)
 	}
 
-	// Request unknown kid — server returns 404
+	// Request non-matching kid: refresh returns key-v2 again, kid still
+	// doesn't match → error. This prevents a compromised relay from
+	// directing alpamon to accept an arbitrary key.
 	_, err = km.GetPublicKeyForKID("key-v999")
 	if err == nil {
-		t.Error("expected error when key_id not found on server")
+		t.Error("expected error when kid doesn't match the active key for this environment")
 	}
 }
 
@@ -250,6 +249,8 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	pub2, _, _ := ed25519.GenerateKey(nil)
 
 	var fetchCount atomic.Int32
+	// Server simulates key rotation: first fetch returns key-v1,
+	// subsequent fetches return key-v2 (the new active key).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := fetchCount.Add(1)
 		var pub ed25519.PublicKey
@@ -272,9 +273,9 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
-	// Fetch key-v1
+	// Fetch key-v1 (active before rotation)
 	key1, err := km.GetPublicKeyForKID("key-v1")
 	if err != nil {
 		t.Fatalf("first fetch failed: %v", err)
@@ -283,7 +284,8 @@ func TestKeyManager_GetPublicKeyForKID_KeyRotation(t *testing.T) {
 		t.Error("first key should be pub1")
 	}
 
-	// Request key-v2 triggers refresh
+	// Request key-v2: kid mismatch triggers env-scoped refresh,
+	// which now returns key-v2 (rotated active key).
 	key2, err := km.GetPublicKeyForKID("key-v2")
 	if err != nil {
 		t.Fatalf("second fetch failed: %v", err)
@@ -314,7 +316,7 @@ func TestKeyManager_ExpiresAt(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client()) // Long TTL, but expires_at overrides
+	km := NewKeyManager(server.URL, 3600, "", server.Client()) // Long TTL, but expires_at overrides
 
 	if _, err := km.GetPublicKey(); err != nil {
 		t.Fatalf("first GetPublicKey failed: %v", err)
@@ -360,7 +362,7 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	km := NewKeyManager(server.URL, 3600, server.Client())
+	km := NewKeyManager(server.URL, 3600, "", server.Client())
 
 	// First fetch succeeds
 	_, err := km.GetPublicKey()
@@ -377,5 +379,84 @@ func TestKeyManager_ExpiredKeyRefreshFailure(t *testing.T) {
 	_, err = km.GetPublicKey()
 	if err == nil {
 		t.Error("expected error when key is expired and refresh fails")
+	}
+}
+
+func TestResolveAuthEnv(t *testing.T) {
+	tests := []struct {
+		serverURL string
+		want      string
+	}{
+		{"https://dev.alpacon.io", "dev"},
+		{"https://dev.alpacon.io/", "dev"},
+		{"https://us.alpacon.io", ""},
+		{"https://kr.alpacon.io", ""},
+		{"http://localhost:8000", ""},
+		{"invalid-url", ""},
+	}
+	for _, tt := range tests {
+		got := ResolveAuthEnv(tt.serverURL)
+		if got != tt.want {
+			t.Errorf("ResolveAuthEnv(%q) = %q, want %q", tt.serverURL, got, tt.want)
+		}
+	}
+}
+
+func TestIsLocalEnv(t *testing.T) {
+	tests := []struct {
+		serverURL string
+		want      bool
+	}{
+		{"http://localhost:8000", true},
+		{"http://127.0.0.1:8000", true},
+		{"http://[::1]:8000", true},
+		{"https://dev.alpacon.io", false},
+		{"https://us.alpacon.io", false},
+		{"invalid-url", false},
+	}
+	for _, tt := range tests {
+		got := IsLocalEnv(tt.serverURL)
+		if got != tt.want {
+			t.Errorf("IsLocalEnv(%q) = %v, want %v", tt.serverURL, got, tt.want)
+		}
+	}
+}
+
+func TestKeyManager_AuthEnvQueryParam(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+
+	var receivedAuthEnv string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthEnv = r.URL.Query().Get("auth_env")
+		resp := publicKeyResponse{
+			Algorithm: "Ed25519",
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+			KeyID:     "key-dev-1",
+			ValidFrom: "2026-01-01T00:00:00Z",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// With authEnv="dev", requests should include ?auth_env=dev
+	km := NewKeyManager(server.URL, 3600, "dev", server.Client())
+	_, err := km.GetPublicKey()
+	if err != nil {
+		t.Fatalf("GetPublicKey failed: %v", err)
+	}
+	if receivedAuthEnv != "dev" {
+		t.Errorf("expected auth_env=dev in request, got %q", receivedAuthEnv)
+	}
+
+	// With empty authEnv, requests should not include auth_env
+	receivedAuthEnv = "should-not-change"
+	km2 := NewKeyManager(server.URL, 3600, "", server.Client())
+	_, err = km2.GetPublicKey()
+	if err != nil {
+		t.Fatalf("GetPublicKey failed: %v", err)
+	}
+	if receivedAuthEnv != "" {
+		t.Errorf("expected no auth_env in request, got %q", receivedAuthEnv)
 	}
 }


### PR DESCRIPTION
## Summary
- Fetch public key by `?auth_env=` (derived from local config) instead of `?key_id=` (from untrusted relay)
- `key_id` in command is now only a cache-staleness hint, never a query parameter
- Auto-downgrade enforce mode to monitor on localhost (no AI server available locally)
- Remove dead code: `ForceRefresh`, `fetchKeyByKID`

## Context
Command signing exists because alpamon doesn't trust the alpacon-server relay. However, the previous implementation used the relay-provided `key_id` to fetch a specific key from the AI server — a compromised relay could direct alpamon to trust an arbitrary key.

Now alpamon derives its environment from its own trusted local config (`ServerURL`):
- `dev.alpacon.io` → `?auth_env=dev`
- `{region}.alpacon.io` → no param (prod default)
- `localhost` → auto-downgrade signing mode to monitor

The AI server returns the active key for that environment. Key rotation is handled by detecting kid mismatch in the cache and re-fetching (env-scoped), not by trusting the relay's key_id.

## Test plan
- [x] `TestResolveAuthEnv` — dev.alpacon.io → "dev", us.alpacon.io → "", localhost → ""
- [x] `TestIsLocalEnv` — localhost/127.0.0.1/::1 → true, alpacon.io → false
- [x] `TestKeyManager_AuthEnvQueryParam` — verifies ?auth_env= is sent (or not) based on env
- [x] `TestKeyManager_GetPublicKeyForKID_Mismatch` — rejects kid not matching env's active key
- [x] `TestKeyManager_GetPublicKeyForKID_KeyRotation` — env-scoped refresh handles rotation
- [x] `TestVerifyCommandSignature_KeyRotation` — end-to-end rotation via env-scoped refresh
- [x] All existing signing tests pass (full suite: `go test ./... -p 1`)