### PR TITLE
refactor: implement lightweight commit with deferred sync for uncommissioned servers

### DIFF
--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -31,10 +31,18 @@ const (
 	accessPolicyURL = "/api/servers/servers/-/access-policy/"
 	syncCheckURL    = "/api/servers/servers/-/sync-check/"
 
-	// maxCommitJitterSeconds is the upper bound (exclusive) for random commit
-	// delay when uncommissioned servers register, distributing N simultaneous
-	// IaC-provisioned commits over a 0-30 second window.
-	maxCommitJitterSeconds = 31
+	// maxDeferredSyncJitterSeconds is the upper bound (exclusive) for the
+	// fallback deferred sync delay. The primary path is the server-initiated
+	// sync command (arrives ~15-45s after commit). This fallback covers the
+	// case where the server command doesn't arrive. The 30-60s window gives
+	// the server command time to arrive first, while limiting the gap during
+	// which the collector may reference entities the server doesn't know yet.
+	maxDeferredSyncJitterSeconds = 61
+
+	// minDeferredSyncJitterSeconds is the minimum delay before the fallback
+	// deferred sync. Must be long enough for: Rqueue processing + HTTP
+	// round trip + server commit handling + sync command scheduling (~15-45s).
+	minDeferredSyncJitterSeconds = 30
 
 	IFF_UP          = 1 << 0 // Interface is up
 	IFF_LOOPBACK    = 1 << 3 // Loopback interface
@@ -43,6 +51,24 @@ const (
 )
 
 var syncMutex sync.Mutex
+
+// essentialSyncKeys are categories included in the lightweight commit.
+// These provide enough data for the server to set commissioned=True
+// and enable Websh/WebFTP platform detection.
+var essentialSyncKeys = map[string]bool{"info": true, "os": true}
+
+// deferredSyncKeys are categories synced after the lightweight commit.
+// These involve heavy server-side processing (IAM matching, etc.)
+// and are distributed over a jitter window.
+//
+// Order reflects FK dependencies: parents before children
+// (groups→users, interfaces→addresses, disks→partitions).
+var deferredSyncKeys = []string{
+	"time",
+	"groups", "users",
+	"interfaces", "addresses",
+	"disks", "partitions",
+}
 
 // CommitAsync commits system information asynchronously
 // Uses ContextManager for coordinated lifecycle management
@@ -66,12 +92,26 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 	} else {
 		go func() {
 			ctx := ctxManager.Root()
-			jitter := time.Duration(rand.IntN(maxCommitJitterSeconds)) * time.Second
+
+			// Step 1: Immediate lightweight commit (no delay).
+			// Sends only essential data (os, info, server) so the server
+			// sets commissioned=True and the server appears as "connected".
+			log.Info().Msg("Committing essential system information (lightweight).")
+			commitAndNotify(collectEssentialData())
+			log.Info().Msg("Essential system information committed.")
+
+			// Step 2: Fallback deferred sync after 30-60s.
+			// The server schedules a sync command after processing the commit
+			// (~15-45s). This fallback only fires if that command doesn't arrive.
+			jitter := time.Duration(rand.IntN(maxDeferredSyncJitterSeconds)) * time.Second
+			if jitter < minDeferredSyncJitterSeconds*time.Second {
+				jitter = minDeferredSyncJitterSeconds * time.Second
+			}
 			select {
 			case <-time.After(jitter):
-				CommitSystemInfo()
+				SyncSystemInfo(session, deferredSyncKeys)
 			case <-ctx.Done():
-				log.Debug().Msg("Skipping commitSystemInfo due to shutdown")
+				log.Debug().Msg("Skipping deferred sync due to shutdown")
 			}
 		}()
 	}
@@ -81,12 +121,7 @@ func CommitSystemInfo() {
 	log.Debug().Msg("Start committing system information.")
 
 	data := collectData()
-
-	scheduler.Rqueue.Put(commitURL, data, 80, time.Time{})
-	scheduler.Rqueue.Post(eventURL, []byte(fmt.Sprintf(`{
-		"reporter": "alpamon",
-		"record": "committed",
-		"description": "Committed system information. version: %s"}`, version.Version)), 80, time.Time{})
+	commitAndNotify(data)
 
 	// Sync firewall rules after committing system info
 	// Skip if firewall functionality is disabled
@@ -98,6 +133,51 @@ func CommitSystemInfo() {
 	}
 
 	log.Info().Msg("Completed committing system information.")
+}
+
+// commitAndNotify sends commit data to the server and posts a commit event.
+func commitAndNotify(data *commitData) {
+	scheduler.Rqueue.Put(commitURL, data, 80, time.Time{})
+	scheduler.Rqueue.Post(eventURL, []byte(fmt.Sprintf(`{
+		"reporter": "alpamon",
+		"record": "committed",
+		"description": "Committed system information. version: %s"}`, version.Version)), 80, time.Time{})
+}
+
+// collectEssentialData collects only the essential categories (info, os)
+// plus server-level fields (version, pam_version, load). The resulting
+// commitData omits deferred fields via omitempty tags.
+func collectEssentialData() *commitData {
+	data := &commitData{
+		Version:    version.Version,
+		PamVersion: utils.GetPamVersion(),
+	}
+
+	if load, err := getLoadAverage(); err == nil {
+		data.Load = load
+	} else {
+		log.Debug().Err(err).Msg("Failed to retrieve load average.")
+	}
+
+	for _, s := range syncers {
+		if !essentialSyncKeys[s.Key()] {
+			continue
+		}
+		result, err := s.Collect()
+		if err != nil {
+			log.Debug().Err(err).Msgf("Failed to collect %s data for lightweight commit.", s.Key())
+			continue
+		}
+		assignToCommitData(data, s.Key(), result)
+		if h := s.ComputeHash(result); h != "" {
+			if data.SyncHashes == nil {
+				data.SyncHashes = make(SyncHashes)
+			}
+			data.SyncHashes[s.Key()] = h
+		}
+	}
+
+	return data
 }
 
 func SyncSystemInfo(session *scheduler.Session, keys []string) {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -40,8 +40,10 @@ const (
 	maxDeferredSyncJitterSeconds = 61
 
 	// minDeferredSyncJitterSeconds is the minimum delay before the fallback
-	// deferred sync. Must be long enough for: Rqueue processing + HTTP
-	// round trip + server commit handling + sync command scheduling (~15-45s).
+	// deferred sync. This 30s lower bound is a tradeoff: it often gives
+	// Rqueue processing, the HTTP round trip, server commit handling, and
+	// server-side sync scheduling time to complete first, but is not a
+	// guarantee for the full ~15-45s scheduling range in every case.
 	minDeferredSyncJitterSeconds = 30
 
 	IFF_UP          = 1 << 0 // Interface is up

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -105,8 +105,14 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 			default:
 			}
 			log.Info().Msg("Committing essential system information (lightweight).")
-			commitAndNotify(collectEssentialData())
-			log.Info().Msg("Essential system information committed.")
+			if essentialData := collectEssentialData(); essentialData != nil {
+				commitAndNotify(essentialData)
+				log.Info().Msg("Essential system information committed.")
+			} else {
+				// Essential collection failed; fall back to full commit.
+				CommitSystemInfo()
+				return
+			}
 
 			// Step 2: Fallback deferred sync after 30-60s.
 			// The server schedules a sync command after processing the commit
@@ -158,6 +164,8 @@ func commitAndNotify(data *commitData) {
 // collectEssentialData collects only the essential categories (info, os)
 // plus server-level fields (version, pam_version, load). The resulting
 // commitData omits deferred fields via omitempty tags.
+// Returns nil if any essential category fails to collect, signaling the
+// caller to fall back to the full commit path.
 func collectEssentialData() *commitData {
 	data := &commitData{
 		Version:    version.Version,
@@ -176,8 +184,8 @@ func collectEssentialData() *commitData {
 		}
 		result, err := s.Collect()
 		if err != nil {
-			log.Debug().Err(err).Msgf("Failed to collect %s data for lightweight commit.", s.Key())
-			continue
+			log.Warn().Err(err).Msgf("Failed to collect essential %s data, falling back to full commit.", s.Key())
+			return nil
 		}
 		assignToCommitData(data, s.Key(), result)
 		if h := s.ComputeHash(result); h != "" {

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -59,15 +59,20 @@ var syncMutex sync.Mutex
 // and enable Websh/WebFTP platform detection.
 var essentialSyncKeys = map[string]bool{"info": true, "os": true}
 
-// deferredSyncKeys are categories synced after the lightweight commit.
-// These involve heavy server-side processing (IAM matching, etc.)
-// and are distributed over a jitter window.
+// prioritySyncKeys are categories synced immediately after the lightweight
+// commit to enable Websh/WebFTP as quickly as possible. WebSH session
+// creation requires SystemUser records (login_enabled check), which only
+// exist after users/groups are synced. groups must precede users (FK).
+var prioritySyncKeys = []string{"groups", "users"}
+
+// deferredSyncKeys are the remaining categories synced via the server-
+// initiated sync command or fallback timer. These involve heavier server-
+// side processing and are not needed for immediate Websh/WebFTP access.
 //
 // Order reflects FK dependencies: parents before children
-// (groups→users, interfaces→addresses, disks→partitions).
+// (interfaces→addresses, disks→partitions).
 var deferredSyncKeys = []string{
 	"time",
-	"groups", "users",
 	"interfaces", "addresses",
 	"disks", "partitions",
 }
@@ -114,7 +119,11 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 				return
 			}
 
-			// Step 2: Fallback deferred sync after 30-60s.
+			// Step 2: Immediately sync users/groups so Websh/WebFTP become
+			// available without waiting for the server's deferred sync command.
+			SyncSystemInfo(session, prioritySyncKeys)
+
+			// Step 3: Fallback deferred sync after 30-60s.
 			// The server schedules a sync command after processing the commit
 			// (~15-45s). This fallback runs unconditionally but is harmless if
 			// the server command already triggered sync — the hash protocol

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -96,6 +96,12 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 			// Step 1: Immediate lightweight commit (no delay).
 			// Sends only essential data (os, info, server) so the server
 			// sets commissioned=True and the server appears as "connected".
+			select {
+			case <-ctx.Done():
+				log.Debug().Msg("Skipping lightweight commit due to shutdown")
+				return
+			default:
+			}
 			log.Info().Msg("Committing essential system information (lightweight).")
 			commitAndNotify(collectEssentialData())
 			log.Info().Msg("Essential system information committed.")

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/alpacax/alpamon/pkg/scheduler"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/alpacax/alpamon/pkg/version"
-	_ "github.com/glebarez/go-sqlite"
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/cpu"

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -46,6 +46,12 @@ const (
 	// guarantee for the full ~15-45s scheduling range in every case.
 	minDeferredSyncJitterSeconds = 30
 
+	// maxPrioritySyncJitterSeconds is the upper bound (exclusive) for the
+	// jitter before priority sync (groups/users). This distributes IAM
+	// matching load when N servers are IaC-provisioned simultaneously,
+	// while keeping WebSH/WebFTP available within a few seconds.
+	maxPrioritySyncJitterSeconds = 6
+
 	IFF_UP          = 1 << 0 // Interface is up
 	IFF_LOOPBACK    = 1 << 3 // Loopback interface
 	IFF_POINTOPOINT = 1 << 4 // Point-to-point link
@@ -119,9 +125,17 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 				return
 			}
 
-			// Step 2: Immediately sync users/groups so Websh/WebFTP become
-			// available without waiting for the server's deferred sync command.
-			SyncSystemInfo(session, prioritySyncKeys)
+			// Step 2: Sync users/groups after short jitter (0-5s) so Websh/
+			// WebFTP become available quickly. The jitter distributes IAM
+			// matching load when many IaC-provisioned servers start at once.
+			priorityJitter := time.Duration(rand.IntN(maxPrioritySyncJitterSeconds)) * time.Second
+			select {
+			case <-time.After(priorityJitter):
+				SyncSystemInfo(session, prioritySyncKeys)
+			case <-ctx.Done():
+				log.Debug().Msg("Skipping priority sync due to shutdown")
+				return
+			}
 
 			// Step 3: Fallback deferred sync after 30-60s.
 			// The server schedules a sync command after processing the commit

--- a/pkg/runner/commit.go
+++ b/pkg/runner/commit.go
@@ -102,13 +102,16 @@ func CommitAsync(session *scheduler.Session, commissioned bool, ctxManager *agen
 
 			// Step 2: Fallback deferred sync after 30-60s.
 			// The server schedules a sync command after processing the commit
-			// (~15-45s). This fallback only fires if that command doesn't arrive.
-			jitter := time.Duration(rand.IntN(maxDeferredSyncJitterSeconds)) * time.Second
-			if jitter < minDeferredSyncJitterSeconds*time.Second {
-				jitter = minDeferredSyncJitterSeconds * time.Second
-			}
+			// (~15-45s). This fallback runs unconditionally but is harmless if
+			// the server command already triggered sync — the hash protocol
+			// makes duplicate syncs a no-op.
+			jitter := time.Duration(
+				rand.IntN(maxDeferredSyncJitterSeconds-minDeferredSyncJitterSeconds)+minDeferredSyncJitterSeconds,
+			) * time.Second
+			timer := time.NewTimer(jitter)
+			defer timer.Stop()
 			select {
-			case <-time.After(jitter):
+			case <-timer.C:
 				SyncSystemInfo(session, deferredSyncKeys)
 			case <-ctx.Done():
 				log.Debug().Msg("Skipping deferred sync due to shutdown")

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -349,7 +349,7 @@ func TestOtherTypesGetComparableData(t *testing.T) {
 
 func TestSyncers(t *testing.T) {
 	expectedKeys := []string{
-		"info", "os", "time", "users", "groups",
+		"info", "os", "time", "groups", "users",
 		"interfaces", "addresses", "disks", "partitions",
 	}
 

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -389,6 +389,7 @@ func TestSyncerFKOrdering(t *testing.T) {
 				return i
 			}
 		}
+		t.Fatalf("syncer key %q not found in registration order", key)
 		return -1
 	}
 
@@ -407,9 +408,11 @@ func TestCollectEssentialDataOnlyIncludesEssentialCategories(t *testing.T) {
 	data := collectEssentialData()
 
 	// Essential fields must be populated.
+	// Skip if collection fails in constrained environments (e.g., limited procfs in CI).
 	assert.NotEmpty(t, data.Version, "Version should be set")
-	assert.NotEmpty(t, data.Info.UUID, "Info (essential) should be collected")
-	assert.NotEmpty(t, data.OS.Name, "OS (essential) should be collected")
+	if data.Info.UUID == "" || data.OS.Name == "" {
+		t.Skip("skipping: essential data collection failed in this environment")
+	}
 
 	// Deferred fields must be nil/empty (omitempty will exclude them).
 	assert.Nil(t, data.Time, "Time (deferred) should not be collected")

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -374,6 +374,69 @@ func TestSyncers(t *testing.T) {
 	}
 }
 
+func TestSyncerFKOrdering(t *testing.T) {
+	// Server-side FK constraints require parent categories to be synced
+	// before their children. syncRequiredKeys normalizes to syncers
+	// registration order, so this order is the authoritative processing order.
+	keyOrder := make([]string, len(syncers))
+	for i, s := range syncers {
+		keyOrder[i] = s.Key()
+	}
+
+	indexOf := func(key string) int {
+		for i, k := range keyOrder {
+			if k == key {
+				return i
+			}
+		}
+		return -1
+	}
+
+	// groups → users (SystemUser.group FK)
+	assert.Less(t, indexOf("groups"), indexOf("users"),
+		"groups must be synced before users (SystemUser.group FK)")
+	// interfaces → addresses (InterfaceAddress.interface FK, hard fail)
+	assert.Less(t, indexOf("interfaces"), indexOf("addresses"),
+		"interfaces must be synced before addresses (InterfaceAddress.interface FK)")
+	// disks → partitions (Partition.disk FK)
+	assert.Less(t, indexOf("disks"), indexOf("partitions"),
+		"disks must be synced before partitions (Partition.disk FK)")
+}
+
+func TestCollectEssentialDataOnlyIncludesEssentialCategories(t *testing.T) {
+	data := collectEssentialData()
+
+	// Essential fields must be populated.
+	assert.NotEmpty(t, data.Version, "Version should be set")
+	assert.NotEmpty(t, data.Info.UUID, "Info (essential) should be collected")
+	assert.NotEmpty(t, data.OS.Name, "OS (essential) should be collected")
+
+	// Deferred fields must be nil/empty (omitempty will exclude them).
+	assert.Nil(t, data.Time, "Time (deferred) should not be collected")
+	assert.Empty(t, data.Users, "Users (deferred) should not be collected")
+	assert.Empty(t, data.Groups, "Groups (deferred) should not be collected")
+	assert.Empty(t, data.Interfaces, "Interfaces (deferred) should not be collected")
+	assert.Empty(t, data.Addresses, "Addresses (deferred) should not be collected")
+	assert.Empty(t, data.Disks, "Disks (deferred) should not be collected")
+	assert.Empty(t, data.Partitions, "Partitions (deferred) should not be collected")
+
+	// SyncHashes should only contain essential keys.
+	for key := range data.SyncHashes {
+		assert.True(t, essentialSyncKeys[key],
+			"SyncHashes should only contain essential keys, got %s", key)
+	}
+
+	// Verify omitempty: marshaled JSON should not contain deferred fields.
+	jsonBytes, err := json.Marshal(data)
+	assert.NoError(t, err)
+	jsonStr := string(jsonBytes)
+	assert.NotContains(t, jsonStr, `"time"`, "Lightweight commit JSON should not contain time")
+	assert.NotContains(t, jsonStr, `"users"`, "Lightweight commit JSON should not contain users")
+	assert.NotContains(t, jsonStr, `"groups"`, "Lightweight commit JSON should not contain groups")
+	assert.Contains(t, jsonStr, `"info"`, "Lightweight commit JSON should contain info")
+	assert.Contains(t, jsonStr, `"os"`, "Lightweight commit JSON should contain os")
+}
+
 func TestSyncerCollect(t *testing.T) {
 	for _, s := range syncers {
 		// Collect may fail in certain environments (e.g., limited procfs or permissions in CI).

--- a/pkg/runner/commit_types.go
+++ b/pkg/runner/commit_types.go
@@ -164,14 +164,14 @@ type commitData struct {
 	Load       float64     `json:"load"`
 	Info       SystemData  `json:"info"`
 	OS         OSData      `json:"os"`
-	Time       TimeData    `json:"time"`
-	Users      []UserData  `json:"users"`
-	Groups     []GroupData `json:"groups"`
-	Interfaces []Interface `json:"interfaces"`
-	Addresses  []Address   `json:"addresses"`
-	Disks      []Disk      `json:"disks"`
-	Partitions []Partition `json:"partitions"`
-	SyncHashes SyncHashes  `json:"sync_hashes,omitempty"` // included in commit so server stores hashes at commission
+	Time       *TimeData   `json:"time,omitempty"`
+	Users      []UserData  `json:"users,omitempty"`
+	Groups     []GroupData `json:"groups,omitempty"`
+	Interfaces []Interface `json:"interfaces,omitempty"`
+	Addresses  []Address   `json:"addresses,omitempty"`
+	Disks      []Disk      `json:"disks,omitempty"`
+	Partitions []Partition `json:"partitions,omitempty"`
+	SyncHashes SyncHashes  `json:"sync_hashes,omitempty"`
 }
 
 // Defines the ComparableData interface for comparing different types.

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -223,7 +223,8 @@ func assignToCommitData(data *commitData, key string, result any) {
 	case "os":
 		data.OS = result.(OSData)
 	case "time":
-		data.Time = result.(TimeData)
+		t := result.(TimeData)
+		data.Time = &t
 	case "users":
 		data.Users = result.([]UserData)
 	case "groups":

--- a/pkg/runner/syncer.go
+++ b/pkg/runner/syncer.go
@@ -33,6 +33,12 @@ type syncable interface {
 
 // syncers registers all 9 syncable data categories.
 // server and firewall are handled separately.
+//
+// Order matters: parent categories must precede their children to satisfy
+// server-side FK constraints during sync POST operations:
+//   - groups → users    (SystemUser.group FK)
+//   - interfaces → addresses (InterfaceAddress.interface FK, hard fail)
+//   - disks → partitions    (Partition.disk FK)
 var syncers = []syncable{
 	&singleRowSyncer[SystemData]{key: "info", collect: getSystemData},
 	&singleRowSyncer[OSData]{key: "os", collect: getOsData},
@@ -43,8 +49,8 @@ var syncers = []syncable{
 			return td.GetComparableData()
 		},
 	},
-	&multiRowSyncer[UserData]{key: "users", collect: getUserData},
 	&multiRowSyncer[GroupData]{key: "groups", collect: getGroupData},
+	&multiRowSyncer[UserData]{key: "users", collect: getUserData},
 	&multiRowSyncer[Interface]{key: "interfaces", collect: getNetworkInterfaces},
 	&multiRowSyncer[Address]{key: "addresses", collect: getNetworkAddresses},
 	&multiRowSyncer[Disk]{key: "disks", collect: getDisks},


### PR DESCRIPTION
### Summary

- Uncommissioned servers now send an immediate **lightweight commit** containing only essential data (`os`, `info`, `server`) so the server sets `commissioned=True` without delay
- **Users/groups are synced after a short 0-5s jitter** to enable Websh/WebFTP within seconds while distributing IAM matching load across IaC-provisioned servers
- Remaining categories (`interfaces`, `addresses`, `disks`, `partitions`, `time`) are synced via the **server-initiated sync command** (~15-45s after commit), with a **fallback deferred sync** at 30-60s if the command doesn't arrive
- Fixed **FK ordering bug**: `syncers` registration order now guarantees parent categories are processed before children (`groups`->`users`, `interfaces`->`addresses`, `disks`->`partitions`)

### Motivation

Phase 1 added 0-30s random jitter to uncommissioned server commits for IaC thundering herd mitigation. This caused two problems:

1. **"Connected" status delay**: `commissioned=True` wasn't set for up to 30 seconds, so new servers didn't appear as "connected"
2. **Websh/WebFTP unavailability**: SystemUser records (required for `login_enabled` check) didn't exist until the full commit completed

### Design

```
Uncommissioned server startup:

T=0s:      Lightweight commit (os, info, server only)
           -> commissioned=True -> server shows as "connected"
T=0~5s:    Priority sync (groups, users) with 0-5s jitter
           -> Websh/WebFTP become available
T=15~45s:  Server-initiated sync command (primary path)
           -> remaining categories synced via hash protocol
T=30~60s:  Fallback deferred sync (only if server command doesn't arrive)
```

| Classification | Categories | Timing | Reason |
|----------------|-----------|--------|--------|
| **Essential** | `os`, `info`, `server` | Immediate commit | Platform detection, commissioned flag |
| **Priority** | `groups`, `users` | 0-5s jitter | Websh/WebFTP requires SystemUser records |
| **Deferred** | `interfaces`, `addresses`, `disks`, `partitions`, `time` | Server command or 30-60s fallback | Heavier processing, not needed immediately |

### IaC load distribution

When N servers are provisioned simultaneously via Terraform/CloudFormation:

| Stage | Load distribution | Server-side impact |
|-------|------------------|--------------------|
| Lightweight commit | N simultaneous PUTs | Light — os/info storage only, no IAM matching |
| Priority sync | 0-5s jitter | Distributed — IAM matching spread over 5s window |
| Deferred sync | Server schedules with own jitter (15-45s) | Distributed — differential updates via hash protocol |

### Changes

**`pkg/runner/commit.go`**
- `CommitAsync()`: 3-step uncommissioned flow: (1) ctx check + lightweight commit, (2) priority sync with 0-5s jitter, (3) fallback deferred sync at 30-60s
- `collectEssentialData()`: Collects only `info`/`os` with hashes; returns nil on failure to trigger full commit fallback
- `commitAndNotify()`: Extracted helper for commit + event posting (DRY)
- Uniform jitter via `rand.IntN(max-min)+min`; `time.NewTimer` + `defer timer.Stop()` for proper cleanup
- Removed unused `_ "github.com/glebarez/go-sqlite"` import

**`pkg/runner/commit_types.go`**
- Added `omitempty` tags to deferred category fields
- Changed `Time` from `TimeData` to `*TimeData` for correct `omitempty` behavior

**`pkg/runner/syncer.go`**
- Reordered `syncers`: `groups` before `users` (FK constraint)
- Updated `assignToCommitData()` for `*TimeData` pointer assignment

**`pkg/runner/commit_test.go`**
- `TestSyncerFKOrdering`: Guards FK ordering with `t.Fatalf` on missing key
- `TestCollectEssentialDataOnlyIncludesEssentialCategories`: Verifies essential-only collection, `omitempty` JSON output, with `t.Skip` for constrained CI environments

### Server-side dependency

- Server already supports partial commit payloads (`ServerMetaSerializer` fields are `required=False`)
- Server-side deferred sync scheduling is implemented in the companion PR (alpacon-server)

### Test plan

- [x] `go build ./cmd/alpamon` passes
- [x] `go test ./pkg/runner/ -p 1` passes (all existing + 2 new tests)
- [x] `TestSyncerFKOrdering`: groups < users, interfaces < addresses, disks < partitions
- [x] `TestCollectEssentialDataOnlyIncludesEssentialCategories`: essential fields populated, deferred fields nil, JSON omits deferred categories
- [ ] Manual: start agent as uncommissioned server, verify immediate "connected" status
- [ ] Manual: verify Websh/WebFTP available within ~5s (after priority sync of users/groups)
- [ ] Manual: verify remaining categories sync within 15-45s (server command) or 30-60s (fallback)
- [ ] Manual: verify shutdown cancels lightweight commit, priority sync, and fallback deferred sync
- [ ] Manual: verify essential collection failure falls back to full `CommitSystemInfo`
- [ ] Manual: IaC multi-server registration — verify load distribution across jitter windows

