### PR TITLE
fix(windows): WebFTP path handling, containment, and PowerShell env

### DIFF
--- a/cmd/alpamon/command/ftp/ftp.go
+++ b/cmd/alpamon/command/ftp/ftp.go
@@ -1,8 +1,11 @@
 package ftp
 
 import (
+	"os"
+
 	"github.com/alpacax/alpamon/pkg/logger"
 	"github.com/alpacax/alpamon/pkg/runner"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +28,12 @@ var FtpCmd = &cobra.Command{
 func RunFtpWorker(data runner.FtpConfigData) {
 	ftpClient := runner.NewFtpClient(data)
 	if ftpClient == nil {
-		return
+		// NewFtpClient refuses to start on Windows when the home
+		// directory is empty, since containment requires a valid
+		// root. Surface it as an error so the parent/operator can
+		// spot the misconfiguration instead of a silent success.
+		log.Error().Msg("FTP worker aborting: client could not be initialized")
+		os.Exit(1)
 	}
 	ftpClient.RunFtpBackground()
 }

--- a/cmd/alpamon/command/ftp/ftp.go
+++ b/cmd/alpamon/command/ftp/ftp.go
@@ -7,7 +7,7 @@ import (
 )
 
 var FtpCmd = &cobra.Command{
-	Use:   "ftp <url> <homeDirectory>",
+	Use:   "ftp <url> <serverURL> <homeDirectory>",
 	Short: "Start worker for Web FTP",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -24,5 +24,8 @@ var FtpCmd = &cobra.Command{
 
 func RunFtpWorker(data runner.FtpConfigData) {
 	ftpClient := runner.NewFtpClient(data)
+	if ftpClient == nil {
+		return
+	}
 	ftpClient.RunFtpBackground()
 }

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -214,7 +214,8 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 
-	downloadPath, err := utils.SanitizePath(args.Path)
+	// Paths arrive in wire format from the web client.
+	downloadPath, err := utils.SanitizePath(utils.FromWirePath(args.Path))
 	if err != nil {
 		return 1, err.Error()
 	}
@@ -270,6 +271,13 @@ func (h *FileHandler) demoteWithHomeDir(username, groupname string) (*syscall.Sy
 func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]string, bool, bool, error) {
 	paths := make([]string, len(pathList))
 	for i, path := range pathList {
+		// Paths from the web client arrive in wire format (POSIX-like
+		// with a leading "/"). Convert to a native OS path before any
+		// filepath.IsAbs / Join work, otherwise Windows drive-letter
+		// paths like "/C:/Users/foo" get joined to homeDirectory and
+		// produce "C:\C:\Users\foo".
+		path = utils.FromWirePath(path)
+
 		if strings.HasPrefix(path, "~") {
 			path = strings.Replace(path, "~", homeDirectory, 1)
 		}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -174,14 +176,14 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 	var code int
 	var message string
 
-	sysProcAttr, err := h.demote(args.Username, args.Groupname)
+	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to demote user.")
 		return 1, err.Error(), nil
 	}
 
 	if len(args.Files) == 0 {
-		code, message = h.fileDownload(ctx, args, sysProcAttr)
+		code, message = h.fileDownload(ctx, args, sysProcAttr, homeDirectory)
 		h.statFileTransfer(code, upload, message, args)
 	} else {
 		for _, file := range args.Files {
@@ -195,7 +197,7 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 				AllowUnzip:     file.AllowUnzip,
 				URL:            file.URL,
 			}
-			code, message = h.fileDownload(ctx, cmdArgs, sysProcAttr)
+			code, message = h.fileDownload(ctx, cmdArgs, sysProcAttr, homeDirectory)
 			h.statFileTransfer(code, upload, message, cmdArgs)
 		}
 	}
@@ -208,7 +210,7 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 }
 
 // fileDownload handles single file download
-func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs, sysProcAttr *syscall.SysProcAttr) (int, string) {
+func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs, sysProcAttr *syscall.SysProcAttr, homeDirectory string) (int, string) {
 	content, err := h.getFileData(args)
 	if err != nil {
 		return 1, err.Error()
@@ -218,6 +220,11 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	downloadPath, err := utils.SanitizePath(utils.FromWirePath(args.Path))
 	if err != nil {
 		return 1, err.Error()
+	}
+	if runtime.GOOS == "windows" {
+		if err := utils.EnsureUnderHome(homeDirectory, downloadPath); err != nil {
+			return 1, err.Error()
+		}
 	}
 	args.Path = downloadPath
 
@@ -243,28 +250,23 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	return 0, fmt.Sprintf("Successfully downloaded %s.", args.Path)
 }
 
-// demote demotes privilege to the specified user/group
-func (h *FileHandler) demote(username, groupname string) (*syscall.SysProcAttr, error) {
-	result, err := utils.Demote(username, groupname, utils.DemoteOptions{ValidateGroup: true})
-	if err != nil {
-		return nil, err
-	}
-	if result == nil {
-		return nil, nil
-	}
-	return result.SysProcAttr, nil
-}
-
-// demoteWithHomeDir demotes privilege and returns home directory
+// demoteWithHomeDir demotes privilege and returns home directory.
+// On Windows utils.Demote is a no-op but the home directory is still
+// needed for path containment, so fall back to os/user.Lookup.
 func (h *FileHandler) demoteWithHomeDir(username, groupname string) (*syscall.SysProcAttr, string, error) {
 	result, err := utils.Demote(username, groupname, utils.DemoteOptions{ValidateGroup: false})
 	if err != nil {
 		return nil, "", err
 	}
-	if result == nil {
-		return nil, "", nil
+	if result != nil {
+		return result.SysProcAttr, result.User.HomeDir, nil
 	}
-	return result.SysProcAttr, result.User.HomeDir, nil
+	if runtime.GOOS == "windows" && username != "" {
+		if u, err := user.Lookup(username); err == nil {
+			return nil, u.HomeDir, nil
+		}
+	}
+	return nil, "", nil
 }
 
 // parsePaths parses and validates the path list
@@ -289,6 +291,11 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 		sanitized, err := utils.SanitizePath(path)
 		if err != nil {
 			return nil, false, false, err
+		}
+		if runtime.GOOS == "windows" {
+			if err := utils.EnsureUnderHome(homeDirectory, sanitized); err != nil {
+				return nil, false, false, err
+			}
 		}
 		paths[i] = sanitized
 	}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -222,9 +222,11 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 	if runtime.GOOS == "windows" {
-		if err := utils.EnsureUnderHome(homeDirectory, downloadPath); err != nil {
+		resolved, err := resolveAndEnsureUnderHome(homeDirectory, downloadPath)
+		if err != nil {
 			return 1, err.Error()
 		}
+		downloadPath = resolved
 	}
 	args.Path = downloadPath
 
@@ -248,6 +250,25 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	}
 
 	return 0, fmt.Sprintf("Successfully downloaded %s.", args.Path)
+}
+
+// resolveAndEnsureUnderHome resolves symlinks/junctions on both the
+// home directory and the target path, then verifies the target stays
+// within home. Used on Windows where OS-level privilege demotion does
+// not scope file access to the user's home.
+func resolveAndEnsureUnderHome(home, target string) (string, error) {
+	resolvedHome, err := utils.ResolveSymlinksBestEffort(home)
+	if err != nil {
+		return "", err
+	}
+	resolvedTarget, err := utils.ResolveSymlinksBestEffort(target)
+	if err != nil {
+		return "", err
+	}
+	if err := utils.EnsureUnderHome(resolvedHome, resolvedTarget); err != nil {
+		return "", err
+	}
+	return resolvedTarget, nil
 }
 
 // demoteWithHomeDir demotes privilege and returns home directory.
@@ -293,9 +314,11 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 			return nil, false, false, err
 		}
 		if runtime.GOOS == "windows" {
-			if err := utils.EnsureUnderHome(homeDirectory, sanitized); err != nil {
+			resolved, err := resolveAndEnsureUnderHome(homeDirectory, sanitized)
+			if err != nil {
 				return nil, false, false, err
 			}
+			sanitized = resolved
 		}
 		paths[i] = sanitized
 	}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -222,7 +222,7 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 		return 1, err.Error()
 	}
 	if runtime.GOOS == "windows" {
-		resolved, err := resolveAndEnsureUnderHome(homeDirectory, downloadPath)
+		resolved, err := utils.ResolveAndEnsureUnderHome(homeDirectory, downloadPath)
 		if err != nil {
 			return 1, err.Error()
 		}
@@ -250,25 +250,6 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	}
 
 	return 0, fmt.Sprintf("Successfully downloaded %s.", args.Path)
-}
-
-// resolveAndEnsureUnderHome resolves symlinks/junctions on both the
-// home directory and the target path, then verifies the target stays
-// within home. Used on Windows where OS-level privilege demotion does
-// not scope file access to the user's home.
-func resolveAndEnsureUnderHome(home, target string) (string, error) {
-	resolvedHome, err := utils.ResolveSymlinksBestEffort(home)
-	if err != nil {
-		return "", err
-	}
-	resolvedTarget, err := utils.ResolveSymlinksBestEffort(target)
-	if err != nil {
-		return "", err
-	}
-	if err := utils.EnsureUnderHome(resolvedHome, resolvedTarget); err != nil {
-		return "", err
-	}
-	return resolvedTarget, nil
 }
 
 // demoteWithHomeDir demotes privilege and returns home directory.
@@ -314,7 +295,7 @@ func (h *FileHandler) parsePaths(homeDirectory string, pathList []string) ([]str
 			return nil, false, false, err
 		}
 		if runtime.GOOS == "windows" {
-			resolved, err := resolveAndEnsureUnderHome(homeDirectory, sanitized)
+			resolved, err := utils.ResolveAndEnsureUnderHome(homeDirectory, sanitized)
 			if err != nil {
 				return nil, false, false, err
 			}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -178,18 +178,21 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 	var code int
 	var message string
 
-	// Download enforces supplementary-group membership so a requested
-	// GID cannot widen filesystem access beyond what the user has.
-	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, true, args.HomeDirectory)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to demote user.")
-		return 1, err.Error(), nil
-	}
-
 	if len(args.Files) == 0 {
+		// Download enforces supplementary-group membership so a requested
+		// GID cannot widen filesystem access beyond what the user has.
+		sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, true, args.HomeDirectory)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to demote user.")
+			return 1, err.Error(), nil
+		}
 		code, message = h.fileDownload(ctx, args, sysProcAttr, homeDirectory)
 		h.statFileTransfer(code, upload, message, args)
 	} else {
+		// Each file entry may target a different user/group, so demote
+		// per file to get the correct sysProcAttr and home directory
+		// for that entry. Reusing the outer args.Username's demotion
+		// would mix up ownership and containment roots on Unix.
 		for _, file := range args.Files {
 			cmdArgs := &common.CommandArgs{
 				Username:       file.Username,
@@ -200,6 +203,15 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 				AllowOverwrite: file.AllowOverwrite,
 				AllowUnzip:     file.AllowUnzip,
 				URL:            file.URL,
+				HomeDirectory:  args.HomeDirectory,
+			}
+			sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(cmdArgs.Username, cmdArgs.Groupname, true, cmdArgs.HomeDirectory)
+			if err != nil {
+				log.Error().Err(err).Str("username", cmdArgs.Username).Msg("Failed to demote user.")
+				code = 1
+				message = err.Error()
+				h.statFileTransfer(code, upload, message, cmdArgs)
+				continue
 			}
 			code, message = h.fileDownload(ctx, cmdArgs, sysProcAttr, homeDirectory)
 			h.statFileTransfer(code, upload, message, cmdArgs)

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -118,7 +118,9 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 		return 1, "No paths provided"
 	}
 
-	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname)
+	// Upload accepts looser group matching; supplementary-group
+	// enforcement applies to downloads via ValidateGroup=true.
+	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, false)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to demote user.")
 		return 1, err.Error()
@@ -176,7 +178,9 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 	var code int
 	var message string
 
-	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname)
+	// Download enforces supplementary-group membership so a requested
+	// GID cannot widen filesystem access beyond what the user has.
+	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, true)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to demote user.")
 		return 1, err.Error(), nil
@@ -253,17 +257,22 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 }
 
 // demoteWithHomeDir demotes privilege and returns home directory.
-// On Windows utils.Demote is a no-op but the home directory is still
-// needed for path containment, so fall back to os/user.Lookup.
-func (h *FileHandler) demoteWithHomeDir(username, groupname string) (*syscall.SysProcAttr, string, error) {
-	result, err := utils.Demote(username, groupname, utils.DemoteOptions{ValidateGroup: false})
+// validateGroup enforces that the requested group is a supplementary
+// group of the user — required on Unix download paths to prevent
+// using an arbitrary GID for filesystem access, and off on upload
+// paths which accept looser group matching.
+// When utils.Demote is a no-op (e.g., Windows, or Unix running as a
+// non-root user), falls back to os/user.Lookup so the home directory
+// is still populated for path containment / relative-path resolution.
+func (h *FileHandler) demoteWithHomeDir(username, groupname string, validateGroup bool) (*syscall.SysProcAttr, string, error) {
+	result, err := utils.Demote(username, groupname, utils.DemoteOptions{ValidateGroup: validateGroup})
 	if err != nil {
 		return nil, "", err
 	}
 	if result != nil {
 		return result.SysProcAttr, result.User.HomeDir, nil
 	}
-	if runtime.GOOS == "windows" && username != "" {
+	if username != "" {
 		if u, err := user.Lookup(username); err == nil {
 			return nil, u.HomeDir, nil
 		}

--- a/pkg/executor/handlers/file/file.go
+++ b/pkg/executor/handlers/file/file.go
@@ -120,7 +120,7 @@ func (h *FileHandler) handleUpload(ctx context.Context, args *common.CommandArgs
 
 	// Upload accepts looser group matching; supplementary-group
 	// enforcement applies to downloads via ValidateGroup=true.
-	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, false)
+	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, false, args.HomeDirectory)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to demote user.")
 		return 1, err.Error()
@@ -180,7 +180,7 @@ func (h *FileHandler) handleDownload(ctx context.Context, args *common.CommandAr
 
 	// Download enforces supplementary-group membership so a requested
 	// GID cannot widen filesystem access beyond what the user has.
-	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, true)
+	sysProcAttr, homeDirectory, err := h.demoteWithHomeDir(args.Username, args.Groupname, true, args.HomeDirectory)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to demote user.")
 		return 1, err.Error(), nil
@@ -256,15 +256,23 @@ func (h *FileHandler) fileDownload(ctx context.Context, args *common.CommandArgs
 	return 0, fmt.Sprintf("Successfully downloaded %s.", args.Path)
 }
 
-// demoteWithHomeDir demotes privilege and returns home directory.
+// demoteWithHomeDir demotes privilege and returns the home directory.
 // validateGroup enforces that the requested group is a supplementary
-// group of the user — required on Unix download paths to prevent
-// using an arbitrary GID for filesystem access, and off on upload
-// paths which accept looser group matching.
-// When utils.Demote is a no-op (e.g., Windows, or Unix running as a
-// non-root user), falls back to os/user.Lookup so the home directory
-// is still populated for path containment / relative-path resolution.
-func (h *FileHandler) demoteWithHomeDir(username, groupname string, validateGroup bool) (*syscall.SysProcAttr, string, error) {
+// group of the user. Required on Unix download paths to prevent
+// using an arbitrary GID for filesystem access; off on upload paths
+// which accept looser group matching.
+//
+// Home directory is resolved in descending priority:
+//  1. utils.Demote result (Unix, running as root)
+//  2. os/user.Lookup on the given username
+//  3. fallbackHome (typically args.HomeDirectory carried in the
+//     protocol message from alpacon-server)
+//
+// The fallback exists so Windows and non-root Unix paths do not end
+// up with an empty home, which would cause relative paths to resolve
+// against the process CWD and Windows containment to fail with a
+// misleading configuration error.
+func (h *FileHandler) demoteWithHomeDir(username, groupname string, validateGroup bool, fallbackHome string) (*syscall.SysProcAttr, string, error) {
 	result, err := utils.Demote(username, groupname, utils.DemoteOptions{ValidateGroup: validateGroup})
 	if err != nil {
 		return nil, "", err
@@ -273,11 +281,11 @@ func (h *FileHandler) demoteWithHomeDir(username, groupname string, validateGrou
 		return result.SysProcAttr, result.User.HomeDir, nil
 	}
 	if username != "" {
-		if u, err := user.Lookup(username); err == nil {
+		if u, err := user.Lookup(username); err == nil && u.HomeDir != "" {
 			return nil, u.HomeDir, nil
 		}
 	}
-	return nil, "", nil
+	return nil, fallbackHome, nil
 }
 
 // parsePaths parses and validates the path list

--- a/pkg/executor/handlers/file/file_test.go
+++ b/pkg/executor/handlers/file/file_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/executor/handlers/common"
@@ -219,6 +220,16 @@ func TestFileExists(t *testing.T) {
 }
 
 func TestFileHandler_parsePaths(t *testing.T) {
+	// This test uses Unix-style absolute paths ("/home/user", "/tmp/...").
+	// On Windows parsePaths runs EnsureUnderHome with these paths, which
+	// fails because "/tmp/file.txt" is not inside "/home/user" under
+	// Windows path semantics and "/home/user" itself is not an absolute
+	// Windows path. Skip on Windows; the behavior there is covered by
+	// the EnsureUnderHome and ResolveAndEnsureUnderHome tests in
+	// pkg/utils/wirepath_test.go.
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix path conventions; Windows containment is covered in pkg/utils")
+	}
 	handler := NewFileHandler(common.NewMockCommandExecutor(t), nil)
 
 	tests := []struct {

--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -161,7 +161,7 @@ func (h *TerminalHandler) handleOpenFTP(args *common.CommandArgs) (int, string, 
 	}
 	// utils.Demote is a no-op on Windows, so result is nil and the
 	// homeDirectory above never gets populated. Fall back to the home
-	// directory carried in the protocol message — alpacon-server sends
+	// directory carried in the protocol message: alpacon-server sends
 	// SystemUser.directory here, which is the user's real home.
 	if homeDirectory == "" {
 		homeDirectory = args.HomeDirectory

--- a/pkg/executor/handlers/terminal/terminal.go
+++ b/pkg/executor/handlers/terminal/terminal.go
@@ -159,6 +159,13 @@ func (h *TerminalHandler) handleOpenFTP(args *common.CommandArgs) (int, string, 
 			homeDirectory = result.User.HomeDir
 		}
 	}
+	// utils.Demote is a no-op on Windows, so result is nil and the
+	// homeDirectory above never gets populated. Fall back to the home
+	// directory carried in the protocol message — alpacon-server sends
+	// SystemUser.directory here, which is the user's real home.
+	if homeDirectory == "" {
+		homeDirectory = args.HomeDirectory
+	}
 
 	executable, err := os.Executable()
 	if err != nil {

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -554,6 +554,11 @@ func (fc *FtpClient) cpFile(src, dst string, allowOverwrite bool) (CommandResult
 }
 
 func (fc *FtpClient) chmod(path, mode string, recursive bool) (CommandResult, error) {
+	if runtime.GOOS == "windows" {
+		msg := fmt.Sprintf("chmod is %s. Windows uses ACLs instead of POSIX modes.", ErrNotSupported)
+		return CommandResult{Message: msg}, fmt.Errorf("%s", msg)
+	}
+
 	path, err := fc.parsePath(path)
 	if err != nil {
 		return CommandResult{Message: err.Error()}, err
@@ -606,6 +611,11 @@ func (fc *FtpClient) chmodRecursive(path string, fileMode os.FileMode) error {
 }
 
 func (fc *FtpClient) chown(path, username, groupname string, recursive bool) (CommandResult, error) {
+	if runtime.GOOS == "windows" {
+		msg := fmt.Sprintf("chown is %s. Windows uses SID-based ownership instead of UID/GID.", ErrNotSupported)
+		return CommandResult{Message: msg}, fmt.Errorf("%s", msg)
+	}
+
 	path, err := fc.parsePath(path)
 	if err != nil {
 		return CommandResult{Message: err.Error()}, err

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -18,47 +18,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// Wire format for FTP paths is POSIX-like with a leading "/".
-// - Unix native "/home/foo"            <=> wire "/home/foo"
-// - Windows native "C:\\Users\\foo"    <=> wire "/C:/Users/foo"
-// The web client splits paths on "/", so all responses must use wire
-// format. OS calls inside alpamon use the native format.
-
-// fromWirePath converts a wire-format FTP path to a native OS path.
-// It is a no-op on Unix. On Windows, "/C:/Users/foo" → "C:\\Users\\foo".
-// A bare "/C:" is normalized to the drive root "C:\\" since "C:" alone
-// means drive-relative on Windows, which is not what a breadcrumb click
-// to the drive letter means semantically.
-func fromWirePath(p string) string {
-	if p == "" {
-		return p
-	}
-	if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && isDriveLetter(p[1], p[2]) {
-		p = p[1:]
-		if len(p) == 2 {
-			p += `\`
-		}
-	}
-	return filepath.FromSlash(p)
-}
-
-// toWirePath converts a native OS path to the wire format.
-// It is a no-op on Unix. On Windows, "C:\\Users\\foo" → "/C:/Users/foo".
-func toWirePath(p string) string {
-	if p == "" {
-		return p
-	}
-	slashed := filepath.ToSlash(p)
-	if runtime.GOOS == "windows" && len(slashed) >= 2 && isDriveLetter(slashed[0], slashed[1]) {
-		return "/" + slashed
-	}
-	return slashed
-}
-
-func isDriveLetter(c0, c1 byte) bool {
-	return ((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z')) && c1 == ':'
-}
-
 type FtpClient struct {
 	conn             *websocket.Conn
 	requestHeader    http.Header
@@ -74,7 +33,7 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 		"User-Agent": {utils.GetUserAgent("alpamon")},
 	}
 
-	homeDir := fromWirePath(data.HomeDirectory)
+	homeDir := utils.FromWirePath(data.HomeDirectory)
 	return &FtpClient{
 		requestHeader:    headers,
 		url:              data.URL,
@@ -211,14 +170,14 @@ func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (Command
 }
 
 // parsePath takes a wire-format path from the web client and returns a
-// native OS absolute path suitable for os.* calls. Use toWirePath() when
+// native OS absolute path suitable for os.* calls. Use utils.ToWirePath() when
 // placing the resulting path back into a response.
 func (fc *FtpClient) parsePath(path string) (string, error) {
 	if strings.ContainsRune(path, '\x00') {
 		return "", fmt.Errorf("invalid argument: path contains null byte")
 	}
 
-	path = fromWirePath(path)
+	path = utils.FromWirePath(path)
 
 	if strings.HasPrefix(path, "~") {
 		path = strings.Replace(path, "~", fc.workingDirectory, 1)
@@ -266,7 +225,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int, showHidden b
 	result := CommandResult{
 		Name:     filepath.Base(path),
 		Type:     "folder",
-		Path:     toWirePath(path),
+		Path:     utils.ToWirePath(path),
 		ModTime:  nil,
 		Children: []CommandResult{},
 	}
@@ -343,7 +302,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 	modTime := info.ModTime()
 	child := &CommandResult{
 		Name:             entry.Name(),
-		Path:             toWirePath(fullPath),
+		Path:             utils.ToWirePath(fullPath),
 		Code:             returnCodes[List].Success,
 		ModTime:          &modTime,
 		PermissionString: permString,
@@ -354,7 +313,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 
 	if isSymlink {
 		child.Type = "symlink"
-		child.Target = toWirePath(target)
+		child.Target = utils.ToWirePath(target)
 		if targetInfo != nil {
 			child.Size = targetInfo.Size()
 		}
@@ -379,7 +338,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 func (fc *FtpClient) handleListErrorResult(path string, err error) CommandResult {
 	result := CommandResult{
 		Name:    filepath.Base(path),
-		Path:    toWirePath(path),
+		Path:    utils.ToWirePath(path),
 		Message: err.Error(),
 	}
 	_, result.Code = GetFtpErrorCode(List, result)
@@ -432,7 +391,7 @@ func (fc *FtpClient) cwd(path string) (CommandResult, error) {
 }
 
 func (fc *FtpClient) pwd() (CommandResult, error) {
-	wire := toWirePath(fc.workingDirectory)
+	wire := utils.ToWirePath(fc.workingDirectory)
 	return CommandResult{
 		Message: fmt.Sprintf("Current working directory: %s.", wire),
 		Path:    wire,
@@ -519,8 +478,8 @@ func (fc *FtpClient) mv(src, dst string, allowOverwrite bool) (CommandResult, er
 	}
 
 	return CommandResult{
-		Dst:     toWirePath(dst),
-		Message: fmt.Sprintf("Move %s to %s.", toWirePath(src), toWirePath(dst)),
+		Dst:     utils.ToWirePath(dst),
+		Message: fmt.Sprintf("Move %s to %s.", utils.ToWirePath(src), utils.ToWirePath(dst)),
 	}, nil
 }
 
@@ -575,8 +534,8 @@ func (fc *FtpClient) cpDir(src, dst string, allowOverwrite bool) (CommandResult,
 	}
 
 	return CommandResult{
-		Dst:     toWirePath(dst),
-		Message: fmt.Sprintf("Copy %s to %s.", toWirePath(src), toWirePath(dst)),
+		Dst:     utils.ToWirePath(dst),
+		Message: fmt.Sprintf("Copy %s to %s.", utils.ToWirePath(src), utils.ToWirePath(dst)),
 	}, nil
 }
 
@@ -589,8 +548,8 @@ func (fc *FtpClient) cpFile(src, dst string, allowOverwrite bool) (CommandResult
 	}
 
 	return CommandResult{
-		Dst:     toWirePath(dst),
-		Message: fmt.Sprintf("Copy %s to %s.", toWirePath(src), toWirePath(dst)),
+		Dst:     utils.ToWirePath(dst),
+		Message: fmt.Sprintf("Copy %s to %s.", utils.ToWirePath(src), utils.ToWirePath(dst)),
 	}, nil
 }
 

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -206,25 +206,15 @@ func (fc *FtpClient) parsePath(path string) (string, error) {
 		// Windows has no privilege demotion (utils.Demote is a no-op),
 		// so alpamon runs as the service account (typically SYSTEM)
 		// and OS-level ACLs do not scope the session to the named user.
-		// Enforce an explicit home-directory containment instead, so a
-		// malicious wire path cannot read system files like
-		// C:\Windows\System32\config\SAM.
-		//
-		// Resolve symlinks/junctions on both the target and the home
-		// directory so a user who creates a junction inside home
-		// cannot redirect subsequent operations outside home.
-		resolvedHome, err := utils.ResolveSymlinksBestEffort(fc.homeDirectory)
+		// Enforce an explicit home-directory containment instead, with
+		// symlinks/junctions resolved on both sides, so a malicious
+		// wire path (or a junction planted inside home) cannot reach
+		// system files like C:\Windows\System32\config\SAM.
+		resolved, err := utils.ResolveAndEnsureUnderHome(fc.homeDirectory, cleanPath)
 		if err != nil {
 			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
 		}
-		resolvedPath, err := utils.ResolveSymlinksBestEffort(cleanPath)
-		if err != nil {
-			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
-		}
-		if err := utils.EnsureUnderHome(resolvedHome, resolvedPath); err != nil {
-			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
-		}
-		return resolvedPath, nil
+		return resolved, nil
 	}
 
 	// Unix: enforce that the resolved path stays under "/". OS-level

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -195,10 +195,20 @@ func (fc *FtpClient) parsePath(path string) (string, error) {
 	cleanPath := filepath.Clean(absPath)
 
 	if runtime.GOOS == "windows" {
+		// Windows has no privilege demotion (utils.Demote is a no-op),
+		// so alpamon runs as the service account (typically SYSTEM)
+		// and OS-level ACLs do not scope the session to the named user.
+		// Enforce an explicit home-directory containment instead, so a
+		// malicious wire path cannot read system files like
+		// C:\Windows\System32\config\SAM.
+		if err := utils.EnsureUnderHome(fc.homeDirectory, cleanPath); err != nil {
+			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
+		}
 		return cleanPath, nil
 	}
 
-	// Unix: enforce that the resolved path stays under "/".
+	// Unix: enforce that the resolved path stays under "/". OS-level
+	// ACLs from privilege demotion provide the finer-grained scoping.
 	rel, err := filepath.Rel("/", cleanPath)
 	if err != nil {
 		return "", fmt.Errorf("%s: invalid path: %w", ErrInvalidArgument, err)

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,47 @@ import (
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/gorilla/websocket"
 )
+
+// Wire format for FTP paths is POSIX-like with a leading "/".
+// - Unix native "/home/foo"            <=> wire "/home/foo"
+// - Windows native "C:\\Users\\foo"    <=> wire "/C:/Users/foo"
+// The web client splits paths on "/", so all responses must use wire
+// format. OS calls inside alpamon use the native format.
+
+// fromWirePath converts a wire-format FTP path to a native OS path.
+// It is a no-op on Unix. On Windows, "/C:/Users/foo" → "C:\\Users\\foo".
+// A bare "/C:" is normalized to the drive root "C:\\" since "C:" alone
+// means drive-relative on Windows, which is not what a breadcrumb click
+// to the drive letter means semantically.
+func fromWirePath(p string) string {
+	if p == "" {
+		return p
+	}
+	if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && isDriveLetter(p[1], p[2]) {
+		p = p[1:]
+		if len(p) == 2 {
+			p += `\`
+		}
+	}
+	return filepath.FromSlash(p)
+}
+
+// toWirePath converts a native OS path to the wire format.
+// It is a no-op on Unix. On Windows, "C:\\Users\\foo" → "/C:/Users/foo".
+func toWirePath(p string) string {
+	if p == "" {
+		return p
+	}
+	slashed := filepath.ToSlash(p)
+	if runtime.GOOS == "windows" && len(slashed) >= 2 && isDriveLetter(slashed[0], slashed[1]) {
+		return "/" + slashed
+	}
+	return slashed
+}
+
+func isDriveLetter(c0, c1 byte) bool {
+	return ((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z')) && c1 == ':'
+}
 
 type FtpClient struct {
 	conn             *websocket.Conn
@@ -32,11 +74,12 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 		"User-Agent": {utils.GetUserAgent("alpamon")},
 	}
 
+	homeDir := fromWirePath(data.HomeDirectory)
 	return &FtpClient{
 		requestHeader:    headers,
 		url:              data.URL,
-		homeDirectory:    data.HomeDirectory,
-		workingDirectory: data.HomeDirectory,
+		homeDirectory:    homeDir,
+		workingDirectory: homeDir,
 		log:              data.Logger,
 	}
 }
@@ -167,10 +210,15 @@ func (fc *FtpClient) handleFtpCommand(command FtpCommand, data FtpData) (Command
 	}
 }
 
+// parsePath takes a wire-format path from the web client and returns a
+// native OS absolute path suitable for os.* calls. Use toWirePath() when
+// placing the resulting path back into a response.
 func (fc *FtpClient) parsePath(path string) (string, error) {
 	if strings.ContainsRune(path, '\x00') {
 		return "", fmt.Errorf("invalid argument: path contains null byte")
 	}
+
+	path = fromWirePath(path)
 
 	if strings.HasPrefix(path, "~") {
 		path = strings.Replace(path, "~", fc.workingDirectory, 1)
@@ -186,6 +234,12 @@ func (fc *FtpClient) parsePath(path string) (string, error) {
 	}
 
 	cleanPath := filepath.Clean(absPath)
+
+	if runtime.GOOS == "windows" {
+		return cleanPath, nil
+	}
+
+	// Unix: enforce that the resolved path stays under "/".
 	rel, err := filepath.Rel("/", cleanPath)
 	if err != nil {
 		return "", fmt.Errorf("%s: invalid path: %w", ErrInvalidArgument, err)
@@ -212,7 +266,7 @@ func (fc *FtpClient) listRecursive(path string, depth, current int, showHidden b
 	result := CommandResult{
 		Name:     filepath.Base(path),
 		Type:     "folder",
-		Path:     path,
+		Path:     toWirePath(path),
 		ModTime:  nil,
 		Children: []CommandResult{},
 	}
@@ -289,7 +343,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 	modTime := info.ModTime()
 	child := &CommandResult{
 		Name:             entry.Name(),
-		Path:             fullPath,
+		Path:             toWirePath(fullPath),
 		Code:             returnCodes[List].Success,
 		ModTime:          &modTime,
 		PermissionString: permString,
@@ -300,7 +354,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 
 	if isSymlink {
 		child.Type = "symlink"
-		child.Target = target
+		child.Target = toWirePath(target)
 		if targetInfo != nil {
 			child.Size = targetInfo.Size()
 		}
@@ -325,7 +379,7 @@ func (fc *FtpClient) getDiretoryStructure(entry os.DirEntry, path string, depth,
 func (fc *FtpClient) handleListErrorResult(path string, err error) CommandResult {
 	result := CommandResult{
 		Name:    filepath.Base(path),
-		Path:    path,
+		Path:    toWirePath(path),
 		Message: err.Error(),
 	}
 	_, result.Code = GetFtpErrorCode(List, result)
@@ -378,9 +432,10 @@ func (fc *FtpClient) cwd(path string) (CommandResult, error) {
 }
 
 func (fc *FtpClient) pwd() (CommandResult, error) {
+	wire := toWirePath(fc.workingDirectory)
 	return CommandResult{
-		Message: fmt.Sprintf("Current working directory: %s.", fc.workingDirectory),
-		Path:    fc.workingDirectory,
+		Message: fmt.Sprintf("Current working directory: %s.", wire),
+		Path:    wire,
 	}, nil
 }
 
@@ -464,8 +519,8 @@ func (fc *FtpClient) mv(src, dst string, allowOverwrite bool) (CommandResult, er
 	}
 
 	return CommandResult{
-		Dst:     dst,
-		Message: fmt.Sprintf("Move %s to %s.", src, dst),
+		Dst:     toWirePath(dst),
+		Message: fmt.Sprintf("Move %s to %s.", toWirePath(src), toWirePath(dst)),
 	}, nil
 }
 
@@ -520,8 +575,8 @@ func (fc *FtpClient) cpDir(src, dst string, allowOverwrite bool) (CommandResult,
 	}
 
 	return CommandResult{
-		Dst:     dst,
-		Message: fmt.Sprintf("Copy %s to %s.", src, dst),
+		Dst:     toWirePath(dst),
+		Message: fmt.Sprintf("Copy %s to %s.", toWirePath(src), toWirePath(dst)),
 	}, nil
 }
 
@@ -534,8 +589,8 @@ func (fc *FtpClient) cpFile(src, dst string, allowOverwrite bool) (CommandResult
 	}
 
 	return CommandResult{
-		Dst:     dst,
-		Message: fmt.Sprintf("Copy %s to %s.", src, dst),
+		Dst:     toWirePath(dst),
+		Message: fmt.Sprintf("Copy %s to %s.", toWirePath(src), toWirePath(dst)),
 	}, nil
 }
 

--- a/pkg/runner/ftp.go
+++ b/pkg/runner/ftp.go
@@ -34,6 +34,14 @@ func NewFtpClient(data FtpConfigData) *FtpClient {
 	}
 
 	homeDir := utils.FromWirePath(data.HomeDirectory)
+	if runtime.GOOS == "windows" && homeDir == "" {
+		// On Windows home-directory containment is the only access
+		// scope (no privilege demotion). Refuse to start a session
+		// that has nothing to contain to, rather than fail closed on
+		// every subsequent command with a confusing error.
+		data.Logger.Debug().Msg("Refusing to open WebFTP session with empty home directory on Windows.")
+		return nil
+	}
 	return &FtpClient{
 		requestHeader:    headers,
 		url:              data.URL,
@@ -201,10 +209,22 @@ func (fc *FtpClient) parsePath(path string) (string, error) {
 		// Enforce an explicit home-directory containment instead, so a
 		// malicious wire path cannot read system files like
 		// C:\Windows\System32\config\SAM.
-		if err := utils.EnsureUnderHome(fc.homeDirectory, cleanPath); err != nil {
+		//
+		// Resolve symlinks/junctions on both the target and the home
+		// directory so a user who creates a junction inside home
+		// cannot redirect subsequent operations outside home.
+		resolvedHome, err := utils.ResolveSymlinksBestEffort(fc.homeDirectory)
+		if err != nil {
 			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
 		}
-		return cleanPath, nil
+		resolvedPath, err := utils.ResolveSymlinksBestEffort(cleanPath)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
+		}
+		if err := utils.EnsureUnderHome(resolvedHome, resolvedPath); err != nil {
+			return "", fmt.Errorf("%s: %w", ErrInvalidArgument, err)
+		}
+		return resolvedPath, nil
 	}
 
 	// Unix: enforce that the resolved path stays under "/". OS-level

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -2,62 +2,10 @@ package runner
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/config"
 )
-
-func TestWirePathRoundtripUnix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-specific behavior")
-	}
-
-	cases := []string{"/home/foo", "/tmp/a/b", "/"}
-	for _, p := range cases {
-		got := toWirePath(p)
-		if got != p {
-			t.Errorf("toWirePath(%q) = %q, want %q (no-op on Unix)", p, got, p)
-		}
-		back := fromWirePath(p)
-		if back != p {
-			t.Errorf("fromWirePath(%q) = %q, want %q (no-op on Unix)", p, back, p)
-		}
-	}
-}
-
-func TestWirePathRoundtripWindows(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-specific behavior")
-	}
-
-	cases := []struct {
-		native string
-		wire   string
-	}{
-		{`C:\Users\Administrator`, "/C:/Users/Administrator"},
-		{`c:\foo\bar`, "/c:/foo/bar"},
-		{`C:\`, "/C:/"},
-	}
-	for _, tc := range cases {
-		if got := toWirePath(tc.native); got != tc.wire {
-			t.Errorf("toWirePath(%q) = %q, want %q", tc.native, got, tc.wire)
-		}
-		if got := fromWirePath(tc.wire); got != tc.native {
-			t.Errorf("fromWirePath(%q) = %q, want %q", tc.wire, got, tc.native)
-		}
-	}
-
-	// fromWirePath should also accept already-native input
-	if got := fromWirePath(`C:\Users\foo`); got != `C:\Users\foo` {
-		t.Errorf("fromWirePath(native) should pass through, got %q", got)
-	}
-
-	// Bare "/C:" (breadcrumb click on drive letter) normalizes to drive root
-	if got := fromWirePath("/C:"); got != `C:\` {
-		t.Errorf("fromWirePath(\"/C:\") = %q, want C:\\", got)
-	}
-}
 
 func newTestFtpClient(home string) *FtpClient {
 	return &FtpClient{

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -2,10 +2,62 @@ package runner
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/alpacax/alpamon/pkg/config"
 )
+
+func TestWirePathRoundtripUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	cases := []string{"/home/foo", "/tmp/a/b", "/"}
+	for _, p := range cases {
+		got := toWirePath(p)
+		if got != p {
+			t.Errorf("toWirePath(%q) = %q, want %q (no-op on Unix)", p, got, p)
+		}
+		back := fromWirePath(p)
+		if back != p {
+			t.Errorf("fromWirePath(%q) = %q, want %q (no-op on Unix)", p, back, p)
+		}
+	}
+}
+
+func TestWirePathRoundtripWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific behavior")
+	}
+
+	cases := []struct {
+		native string
+		wire   string
+	}{
+		{`C:\Users\Administrator`, "/C:/Users/Administrator"},
+		{`c:\foo\bar`, "/c:/foo/bar"},
+		{`C:\`, "/C:/"},
+	}
+	for _, tc := range cases {
+		if got := toWirePath(tc.native); got != tc.wire {
+			t.Errorf("toWirePath(%q) = %q, want %q", tc.native, got, tc.wire)
+		}
+		if got := fromWirePath(tc.wire); got != tc.native {
+			t.Errorf("fromWirePath(%q) = %q, want %q", tc.wire, got, tc.native)
+		}
+	}
+
+	// fromWirePath should also accept already-native input
+	if got := fromWirePath(`C:\Users\foo`); got != `C:\Users\foo` {
+		t.Errorf("fromWirePath(native) should pass through, got %q", got)
+	}
+
+	// Bare "/C:" (breadcrumb click on drive letter) normalizes to drive root
+	if got := fromWirePath("/C:"); got != `C:\` {
+		t.Errorf("fromWirePath(\"/C:\") = %q, want C:\\", got)
+	}
+}
 
 func newTestFtpClient(home string) *FtpClient {
 	return &FtpClient{

--- a/pkg/runner/ftp_types.go
+++ b/pkg/runner/ftp_types.go
@@ -31,6 +31,7 @@ const (
 	ErrFileExists            = "file exists"
 	ErrDirectoryNotEmpty     = "directory not empty"
 	ErrInfiniteRecursion     = "causing infinite recursion"
+	ErrNotSupported          = "not supported on this platform"
 )
 
 type FtpConfigData struct {
@@ -170,6 +171,7 @@ var returnCodes = map[FtpCommand]returnCode{
 			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
+			ErrNotSupported:          502,
 		},
 	},
 	Chown: {
@@ -179,6 +181,7 @@ var returnCodes = map[FtpCommand]returnCode{
 			ErrOperationNotPermitted: 450,
 			ErrInvalidArgument:       452,
 			ErrNoSuchFileOrDirectory: 550,
+			ErrNotSupported:          502,
 		},
 	},
 }

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -224,17 +224,20 @@ func (pc *PtyClient) writeToWebsocket(ctx context.Context, cancel context.Cancel
 // filterEnv returns a copy of env with entries whose key is in
 // excludeKeys removed. Used to drop inherited parent-process values
 // before re-setting them, so the child sees one definitive entry per
-// key instead of two.
+// key instead of two. Key comparison is case-insensitive so that
+// Windows-style inherited keys (e.g. "Userprofile=…") are caught
+// just like "USERPROFILE=…".
 func filterEnv(env []string, excludeKeys ...string) []string {
-	prefixes := make([]string, len(excludeKeys))
-	for i, k := range excludeKeys {
-		prefixes[i] = k + "="
-	}
 	filtered := make([]string, 0, len(env))
 outer:
 	for _, e := range env {
-		for _, pref := range prefixes {
-			if strings.HasPrefix(e, pref) {
+		key, _, found := strings.Cut(e, "=")
+		if !found {
+			filtered = append(filtered, e)
+			continue
+		}
+		for _, excludeKey := range excludeKeys {
+			if strings.EqualFold(key, excludeKey) {
 				continue outer
 			}
 		}

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -113,8 +113,9 @@ func (pc *PtyClient) initializeSession() error {
 	// Inherit the parent process environment so PowerShell has the
 	// Windows-specific variables it needs (SystemRoot, PSModulePath,
 	// COMPUTERNAME, etc.). Missing these causes error 8009001d at
-	// PowerShell startup.
-	envSlice := os.Environ()
+	// PowerShell startup. Filter out existing USER/USERPROFILE so our
+	// overrides don't end up as duplicate keys in the conpty env.
+	envSlice := filterEnv(os.Environ(), "USER", "USERPROFILE")
 	envSlice = append(envSlice, "USER="+pc.username)
 	if pc.homeDirectory != "" {
 		envSlice = append(envSlice, "USERPROFILE="+pc.homeDirectory)
@@ -218,6 +219,28 @@ func (pc *PtyClient) writeToWebsocket(ctx context.Context, cancel context.Cancel
 			}
 		}
 	}
+}
+
+// filterEnv returns a copy of env with entries whose key is in
+// excludeKeys removed. Used to drop inherited parent-process values
+// before re-setting them, so the child sees one definitive entry per
+// key instead of two.
+func filterEnv(env []string, excludeKeys ...string) []string {
+	prefixes := make([]string, len(excludeKeys))
+	for i, k := range excludeKeys {
+		prefixes[i] = k + "="
+	}
+	filtered := make([]string, 0, len(env))
+outer:
+	for _, e := range env {
+		for _, pref := range prefixes {
+			if strings.HasPrefix(e, pref) {
+				continue outer
+			}
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
 }
 
 func (pc *PtyClient) close() {

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -109,15 +110,14 @@ func (pc *PtyClient) initializeSession() error {
 		commandLine = shell + " " + strings.Join(args, " ")
 	}
 
-	// Build environment
-	env := getDefaultEnv()
-	env["USER"] = pc.username
+	// Inherit the parent process environment so PowerShell has the
+	// Windows-specific variables it needs (SystemRoot, PSModulePath,
+	// COMPUTERNAME, etc.). Missing these causes error 8009001d at
+	// PowerShell startup.
+	envSlice := os.Environ()
+	envSlice = append(envSlice, "USER="+pc.username)
 	if pc.homeDirectory != "" {
-		env["USERPROFILE"] = pc.homeDirectory
-	}
-	var envSlice []string
-	for k, v := range env {
-		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
+		envSlice = append(envSlice, "USERPROFILE="+pc.homeDirectory)
 	}
 
 	opts := []conpty.ConPtyOption{

--- a/pkg/utils/privilege_windows.go
+++ b/pkg/utils/privilege_windows.go
@@ -28,7 +28,7 @@ func Demote(username, groupname string, opts DemoteOptions) (*DemoteResult, erro
 		log.Debug().Msg("No username or groupname provided, running as the current user.")
 		return nil, nil
 	}
-	log.Warn().Str("username", username).
+	log.Debug().Str("username", username).
 		Msg("Privilege demotion not supported on Windows. Session will run as the service account.")
 	return nil, nil
 }

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -123,3 +123,21 @@ func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
 	}
 	return filepath.Join(resolvedParent, tail), nil
 }
+
+// ResolveAndEnsureUnderHome resolves symlinks/junctions on both home
+// and target, then verifies the resolved target is contained within
+// the resolved home. Returns the resolved target path on success.
+func ResolveAndEnsureUnderHome(home, target string) (string, error) {
+	resolvedHome, err := ResolveSymlinksBestEffort(home)
+	if err != nil {
+		return "", err
+	}
+	resolvedTarget, err := ResolveSymlinksBestEffort(target)
+	if err != nil {
+		return "", err
+	}
+	if err := EnsureUnderHome(resolvedHome, resolvedTarget); err != nil {
+		return "", err
+	}
+	return resolvedTarget, nil
+}

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -137,9 +137,9 @@ func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
 	return filepath.Join(resolvedParent, tail), nil
 }
 
-// trimTrailingSeparatorPreservingRoot strips a single trailing path
-// separator unless doing so would leave only a volume or filesystem
-// root. Examples:
+// trimTrailingSeparatorPreservingRoot strips trailing path separators
+// unless doing so would leave only a volume or filesystem root.
+// Examples:
 //
 //	"/foo/"    -> "/foo"
 //	"/"        -> "/"          (preserved)

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// Wire format for paths exchanged with the Alpacon web client is
+// POSIX-like with a leading "/".
+//   Unix native   "/home/foo"           <=> wire "/home/foo"
+//   Windows native "C:\\Users\\foo"     <=> wire "/C:/Users/foo"
+// The web client tokenizes paths on "/", so all paths sent over the
+// alpacon protocol use this format. Alpamon converts to the native
+// OS format before making file system calls and back to wire format
+// before sending responses.
+
+// FromWirePath converts a wire-format path to a native OS path.
+// It is a no-op on Unix. On Windows, "/C:/Users/foo" → "C:\\Users\\foo".
+// A bare "/C:" is normalized to the drive root "C:\\" since "C:"
+// alone is drive-relative on Windows, not what a breadcrumb click to
+// the drive letter means.
+func FromWirePath(p string) string {
+	if p == "" {
+		return p
+	}
+	if runtime.GOOS == "windows" && len(p) >= 3 && p[0] == '/' && isWireDriveLetter(p[1], p[2]) {
+		p = p[1:]
+		if len(p) == 2 {
+			p += `\`
+		}
+	}
+	return filepath.FromSlash(p)
+}
+
+// ToWirePath converts a native OS path to the wire format.
+// It is a no-op on Unix. On Windows, "C:\\Users\\foo" → "/C:/Users/foo".
+func ToWirePath(p string) string {
+	if p == "" {
+		return p
+	}
+	slashed := filepath.ToSlash(p)
+	if runtime.GOOS == "windows" && len(slashed) >= 2 && isWireDriveLetter(slashed[0], slashed[1]) {
+		return "/" + slashed
+	}
+	return slashed
+}
+
+func isWireDriveLetter(c0, c1 byte) bool {
+	return ((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z')) && c1 == ':'
+}

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -64,6 +64,11 @@ func isWireDriveLetter(c0, c1 byte) bool {
 // Callers should pass an absolute, cleaned home path and an absolute,
 // cleaned target path. An empty home is treated as "no containment
 // configured" and rejects everything to fail closed.
+//
+// This check is lexical only. To prevent symlink/junction escapes (a
+// user creating a link inside home that points outside), callers must
+// first resolve the target with ResolveSymlinksBestEffort and use the
+// resolved path for containment.
 func EnsureUnderHome(home, cleanPath string) error {
 	if home == "" {
 		return fmt.Errorf("%s: no home directory configured", errPathEscapesHome)
@@ -85,3 +90,36 @@ func EnsureUnderHome(home, cleanPath string) error {
 }
 
 const errPathEscapesHome = "path escapes home directory"
+
+// ResolveSymlinksBestEffort resolves all symlinks and junctions in
+// cleanPath. If cleanPath does not exist yet (for example, when a user
+// is about to create a new file), the nearest existing ancestor is
+// resolved and the remaining trailing components are appended
+// literally. This is needed so a symlink inside the home directory
+// cannot be used to redirect subsequent file operations outside the
+// home — see EnsureUnderHome.
+//
+// Note: this check is still subject to TOCTOU races. A user who can
+// create symlinks inside their home could swap a resolved component
+// between the check and the underlying os call. Closing that hole
+// requires atomic O_NOFOLLOW semantics which Go does not expose
+// portably on Windows.
+func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
+	if cleanPath == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	resolved, err := filepath.EvalSymlinks(cleanPath)
+	if err == nil {
+		return resolved, nil
+	}
+	parent, tail := filepath.Split(cleanPath)
+	parent = strings.TrimRight(parent, string(filepath.Separator))
+	if parent == "" || parent == cleanPath {
+		return cleanPath, nil
+	}
+	resolvedParent, err := ResolveSymlinksBestEffort(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedParent, tail), nil
+}

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -99,7 +99,7 @@ const errPathEscapesHome = "path escapes home directory"
 // resolved and the remaining trailing components are appended
 // literally. This is needed so a symlink inside the home directory
 // cannot be used to redirect subsequent file operations outside the
-// home — see EnsureUnderHome.
+// home: see EnsureUnderHome.
 //
 // Errors other than "not exist" are returned as-is (permission denied,
 // too many links, etc.) so callers can distinguish a missing leaf
@@ -123,7 +123,7 @@ func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
 	}
 	parent, tail := filepath.Split(cleanPath)
 	// Preserve a volume or filesystem root separator instead of
-	// trimming it away. On Windows `C:\\` must stay `C:\\` — trimming
+	// trimming it away. On Windows `C:\\` must stay `C:\\`; trimming
 	// to `C:` would turn an absolute path drive-relative and change
 	// path semantics for later os calls.
 	parent = trimTrailingSeparatorPreservingRoot(parent)
@@ -170,8 +170,8 @@ func trimTrailingSeparatorPreservingRoot(p string) string {
 // and target, then verifies the resolved target is contained within
 // the resolved home. Returns the resolved target path on success.
 // An empty home short-circuits with the EnsureUnderHome message so
-// callers get a clear, actionable error (the alternative — passing ""
-// to ResolveSymlinksBestEffort — emits a generic "empty path" error).
+// callers get a clear, actionable error; the alternative, passing ""
+// to ResolveSymlinksBestEffort, emits a generic "empty path" error.
 func ResolveAndEnsureUnderHome(home, target string) (string, error) {
 	if home == "" {
 		return "", fmt.Errorf("%s: no home directory configured", errPathEscapesHome)

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Wire format for paths exchanged with the Alpacon web client is
@@ -48,3 +50,38 @@ func ToWirePath(p string) string {
 func isWireDriveLetter(c0, c1 byte) bool {
 	return ((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z')) && c1 == ':'
 }
+
+// EnsureUnderHome verifies cleanPath is contained within the home
+// directory. Returns an error suitable for returning to the FTP client
+// if the path escapes home. Comparison is case-insensitive on Windows
+// (Windows file system is case-insensitive by default).
+//
+// This is the containment check WebFTP relies on to scope user access
+// on Windows, where privilege demotion is a no-op and the alpamon
+// process runs as the service account (typically SYSTEM). On Unix the
+// demoted process's OS-level ACLs provide an equivalent protection.
+//
+// Callers should pass an absolute, cleaned home path and an absolute,
+// cleaned target path. An empty home is treated as "no containment
+// configured" and rejects everything to fail closed.
+func EnsureUnderHome(home, cleanPath string) error {
+	if home == "" {
+		return fmt.Errorf("%s: no home directory configured", errPathEscapesHome)
+	}
+	root := filepath.Clean(home)
+	target := cleanPath
+	if runtime.GOOS == "windows" {
+		root = strings.ToLower(root)
+		target = strings.ToLower(target)
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errPathEscapesHome, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%s", errPathEscapesHome)
+	}
+	return nil
+}
+
+const errPathEscapesHome = "path escapes home directory"

--- a/pkg/utils/wirepath.go
+++ b/pkg/utils/wirepath.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -99,6 +101,10 @@ const errPathEscapesHome = "path escapes home directory"
 // cannot be used to redirect subsequent file operations outside the
 // home — see EnsureUnderHome.
 //
+// Errors other than "not exist" are returned as-is (permission denied,
+// too many links, etc.) so callers can distinguish a missing leaf
+// from a real failure.
+//
 // Note: this check is still subject to TOCTOU races. A user who can
 // create symlinks inside their home could swap a resolved component
 // between the check and the underlying os call. Closing that hole
@@ -112,8 +118,15 @@ func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
 	if err == nil {
 		return resolved, nil
 	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
 	parent, tail := filepath.Split(cleanPath)
-	parent = strings.TrimRight(parent, string(filepath.Separator))
+	// Preserve a volume or filesystem root separator instead of
+	// trimming it away. On Windows `C:\\` must stay `C:\\` — trimming
+	// to `C:` would turn an absolute path drive-relative and change
+	// path semantics for later os calls.
+	parent = trimTrailingSeparatorPreservingRoot(parent)
 	if parent == "" || parent == cleanPath {
 		return cleanPath, nil
 	}
@@ -124,10 +137,45 @@ func ResolveSymlinksBestEffort(cleanPath string) (string, error) {
 	return filepath.Join(resolvedParent, tail), nil
 }
 
+// trimTrailingSeparatorPreservingRoot strips a single trailing path
+// separator unless doing so would leave only a volume or filesystem
+// root. Examples:
+//
+//	"/foo/"    -> "/foo"
+//	"/"        -> "/"          (preserved)
+//	"C:\\foo\\" -> "C:\\foo"
+//	"C:\\"      -> "C:\\"       (preserved)
+//	"\\\\srv\\share\\" -> "\\\\srv\\share" (UNC share root)
+func trimTrailingSeparatorPreservingRoot(p string) string {
+	if p == "" {
+		return p
+	}
+	// filepath.VolumeName handles both drive letters (C:) and UNC
+	// prefixes (\\server\share) on Windows, and returns "" on Unix.
+	vol := filepath.VolumeName(p)
+	trimmed := strings.TrimRight(p, string(filepath.Separator))
+	// If trimming would leave us at or below the volume root, return
+	// the root form instead of the drive-relative form.
+	if trimmed == vol {
+		return vol + string(filepath.Separator)
+	}
+	if trimmed == "" {
+		// Unix "/" case.
+		return string(filepath.Separator)
+	}
+	return trimmed
+}
+
 // ResolveAndEnsureUnderHome resolves symlinks/junctions on both home
 // and target, then verifies the resolved target is contained within
 // the resolved home. Returns the resolved target path on success.
+// An empty home short-circuits with the EnsureUnderHome message so
+// callers get a clear, actionable error (the alternative — passing ""
+// to ResolveSymlinksBestEffort — emits a generic "empty path" error).
 func ResolveAndEnsureUnderHome(home, target string) (string, error) {
+	if home == "" {
+		return "", fmt.Errorf("%s: no home directory configured", errPathEscapesHome)
+	}
 	resolvedHome, err := ResolveSymlinksBestEffort(home)
 	if err != nil {
 		return "", err

--- a/pkg/utils/wirepath_test.go
+++ b/pkg/utils/wirepath_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestWirePathRoundtripUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific behavior")
+	}
+
+	cases := []string{"/home/foo", "/tmp/a/b", "/"}
+	for _, p := range cases {
+		if got := ToWirePath(p); got != p {
+			t.Errorf("ToWirePath(%q) = %q, want %q (no-op on Unix)", p, got, p)
+		}
+		if got := FromWirePath(p); got != p {
+			t.Errorf("FromWirePath(%q) = %q, want %q (no-op on Unix)", p, got, p)
+		}
+	}
+}
+
+func TestWirePathRoundtripWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific behavior")
+	}
+
+	cases := []struct {
+		native string
+		wire   string
+	}{
+		{`C:\Users\Administrator`, "/C:/Users/Administrator"},
+		{`c:\foo\bar`, "/c:/foo/bar"},
+		{`C:\`, "/C:/"},
+	}
+	for _, tc := range cases {
+		if got := ToWirePath(tc.native); got != tc.wire {
+			t.Errorf("ToWirePath(%q) = %q, want %q", tc.native, got, tc.wire)
+		}
+		if got := FromWirePath(tc.wire); got != tc.native {
+			t.Errorf("FromWirePath(%q) = %q, want %q", tc.wire, got, tc.native)
+		}
+	}
+
+	// FromWirePath should also accept already-native input
+	if got := FromWirePath(`C:\Users\foo`); got != `C:\Users\foo` {
+		t.Errorf("FromWirePath(native) should pass through, got %q", got)
+	}
+
+	// Bare "/C:" (breadcrumb click on drive letter) normalizes to drive root
+	if got := FromWirePath("/C:"); got != `C:\` {
+		t.Errorf("FromWirePath(\"/C:\") = %q, want C:\\", got)
+	}
+}

--- a/pkg/utils/wirepath_test.go
+++ b/pkg/utils/wirepath_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -97,5 +99,96 @@ func TestEnsureUnderHome(t *testing.T) {
 				t.Errorf("EnsureUnderHome(%q, %q) unexpected error: %v", tc.home, tc.target, err)
 			}
 		})
+	}
+}
+
+func TestResolveSymlinksBestEffort(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Creating symlinks on Windows requires either Admin or
+		// Developer Mode. Skip on Windows; the unit is exercised via
+		// the Unix test below which covers the code paths.
+		t.Skip("Windows symlink creation requires elevated permissions")
+	}
+
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve tmp: %v", err)
+	}
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	realFile := filepath.Join(realDir, "a.txt")
+	if err := os.WriteFile(realFile, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	t.Run("existing file through symlink", func(t *testing.T) {
+		got, err := ResolveSymlinksBestEffort(filepath.Join(linkDir, "a.txt"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != realFile {
+			t.Errorf("got %q, want %q", got, realFile)
+		}
+	})
+
+	t.Run("nonexistent leaf under symlinked parent", func(t *testing.T) {
+		// Path doesn't exist yet, but the parent symlink should still resolve.
+		got, err := ResolveSymlinksBestEffort(filepath.Join(linkDir, "newfile.txt"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(realDir, "newfile.txt")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty path rejected", func(t *testing.T) {
+		if _, err := ResolveSymlinksBestEffort(""); err == nil {
+			t.Error("expected error for empty path")
+		}
+	})
+}
+
+func TestResolveAndEnsureUnderHome_SymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires elevated permissions")
+	}
+
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve tmp: %v", err)
+	}
+	home := filepath.Join(tmp, "home")
+	if err := os.Mkdir(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	outside := filepath.Join(tmp, "outside")
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	// User plants a symlink inside home pointing at outside.
+	evil := filepath.Join(home, "evil")
+	if err := os.Symlink(outside, evil); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Lexical containment would accept /home/evil/secret.txt, but the
+	// resolver must reject it because it actually lives outside home.
+	via := filepath.Join(evil, "secret.txt")
+	if _, err := ResolveAndEnsureUnderHome(home, via); err == nil {
+		t.Fatal("expected containment error for symlink escape, got nil")
 	}
 }

--- a/pkg/utils/wirepath_test.go
+++ b/pkg/utils/wirepath_test.go
@@ -72,6 +72,7 @@ func TestEnsureUnderHome(t *testing.T) {
 			{"different volume", `C:\Users\alice`, `D:\foo`, true},
 			{"case-insensitive child", `C:\Users\Alice`, `c:\users\alice\docs\a.txt`, false},
 			{"sibling user escape", `C:\Users\alice`, `C:\Users\bob\a.txt`, true},
+			{"prefix substring does not pass", `C:\Users\alice`, `C:\Users\alicex\a.txt`, true},
 			{"empty home rejects", ``, `C:\anything`, true},
 		}
 	} else {
@@ -81,6 +82,7 @@ func TestEnsureUnderHome(t *testing.T) {
 			{"parent dir escape", "/home/alice", "/home", true},
 			{"system file escape", "/home/alice", "/etc/passwd", true},
 			{"sibling user escape", "/home/alice", "/home/bob/a.txt", true},
+			{"prefix substring does not pass", "/home/alice", "/home/alicex/a.txt", true},
 			{"empty home rejects", "", "/anything", true},
 		}
 	}

--- a/pkg/utils/wirepath_test.go
+++ b/pkg/utils/wirepath_test.go
@@ -53,3 +53,47 @@ func TestWirePathRoundtripWindows(t *testing.T) {
 		t.Errorf("FromWirePath(\"/C:\") = %q, want C:\\", got)
 	}
 }
+
+func TestEnsureUnderHome(t *testing.T) {
+	type row struct {
+		name    string
+		home    string
+		target  string
+		wantErr bool
+	}
+
+	var cases []row
+	if runtime.GOOS == "windows" {
+		cases = []row{
+			{"exact home", `C:\Users\alice`, `C:\Users\alice`, false},
+			{"child file", `C:\Users\alice`, `C:\Users\alice\docs\a.txt`, false},
+			{"parent dir escape", `C:\Users\alice`, `C:\Users`, true},
+			{"system file escape", `C:\Users\alice`, `C:\Windows\System32\config\SAM`, true},
+			{"different volume", `C:\Users\alice`, `D:\foo`, true},
+			{"case-insensitive child", `C:\Users\Alice`, `c:\users\alice\docs\a.txt`, false},
+			{"sibling user escape", `C:\Users\alice`, `C:\Users\bob\a.txt`, true},
+			{"empty home rejects", ``, `C:\anything`, true},
+		}
+	} else {
+		cases = []row{
+			{"exact home", "/home/alice", "/home/alice", false},
+			{"child file", "/home/alice", "/home/alice/docs/a.txt", false},
+			{"parent dir escape", "/home/alice", "/home", true},
+			{"system file escape", "/home/alice", "/etc/passwd", true},
+			{"sibling user escape", "/home/alice", "/home/bob/a.txt", true},
+			{"empty home rejects", "", "/anything", true},
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := EnsureUnderHome(tc.home, tc.target)
+			if tc.wantErr && err == nil {
+				t.Errorf("EnsureUnderHome(%q, %q) expected error", tc.home, tc.target)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("EnsureUnderHome(%q, %q) unexpected error: %v", tc.home, tc.target, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up bug fixes for Windows server support (#255 / #276) discovered while testing on Windows Server 2025. Three functional bugs plus a defense-in-depth security hardening that the functional fixes made necessary.

## What's broken (and fixed)

### 1. WebFTP list / copy / move / mkd / delete

`pkg/runner/ftp.go:parsePath` used \`filepath.Rel(\"/\", cleanPath)\` to enforce that the resolved path stays under \`/\`. On Windows, \`/\` and \`C:\\\` live on different volumes, so \`Rel\` errors out — every FTP command failed with \"invalid path\". In the web, this surfaced as \"Access error — The copied item is no longer available\" on paste, and empty file listings on list.

Introduced a wire format convention so the browser and alpamon agree on a single representation:

| | Native (alpamon uses with \`os.*\`) | Wire (what moves between web ↔ server ↔ alpamon) |
|-|-|-|
| Unix | \`/home/foo\` | \`/home/foo\` |
| Windows | \`C:\\Users\\foo\` | \`/C:/Users/foo\` |

\`pkg/utils/wirepath.go\` holds \`FromWirePath\` / \`ToWirePath\` (Unix: no-op). \`parsePath\` consumes the wire input, returns a native absolute path, and the response builders in ftp.go convert back to wire so the breadcrumb / \`FileSystemNode.path\` / copy dst construction in the web all stay forward-slash.

### 2. File upload / download on Windows (HTTP path)

After the WebFTP fix, the browser was sending wire paths to \`pkg/executor/handlers/file/file.go\` too (a different handler — HTTP based, not WebFTP socket). That handler called \`filepath.IsAbs(\"/C:/Users/foo\")\`, which returns false on Windows, and then \`filepath.Join(homeDir, \"/C:/Users/foo\")\` produced \`C:\\Users\\Administrator\\C:\\Users\\Administrator\\Desktop\\file.txt\`. Upload failed with \"The filename, directory name, or volume label syntax is incorrect.\"

Converted wire → native at the handler's entry points (\`parsePaths\`, \`fileDownload\`) using the same \`utils.FromWirePath\`.

### 3. PowerShell ConPTY terminal

\`pkg/runner/pty_windows.go\` spawned ConPTY with a minimal env map, so PowerShell started without \`SystemRoot\` / \`PSModulePath\` / \`COMPUTERNAME\` and blew up with CLR error \`8009001d\`. Now inherits \`os.Environ()\` and augments with \`USER\` / \`USERPROFILE\`.

### 4. chmod / chown not supported on Windows

Go's \`os.Chmod\` on Windows only honors the read-only bit, and \`os.Chown\` returns \`syscall.EWINDOWS\` unconditionally. POSIX mode / UID / GID don't map to Windows ACLs. Rather than silently do something meaningless, these now return \`ErrNotSupported\` (FTP reply code 502) with a short message pointing to ACL / SID. A companion alpacon-web issue requests disabling the UI (alpacax/alpacon-web#1111).

### 5. Privilege demotion log noise

\`pkg/utils/privilege_windows.go\` fires a WARN every time a supervised command runs on Windows (which is every command). Demoted to DEBUG — it's a documented platform constraint, not something the operator can act on.

## Security hardening

Fixing (1) accidentally exposed a pre-existing gap: alpamon on Windows has no privilege demotion, so the agent runs as the service account (typically SYSTEM), and there was no explicit containment on the resolved path. A wire path like \`/C:/Windows/System32/config/SAM\` would have been happily resolved and read by SYSTEM. The earlier \"broken\" code hid this only because paths got mangled before they reached the OS.

Added \`utils.EnsureUnderHome\` + \`utils.ResolveSymlinksBestEffort\` + \`utils.ResolveAndEnsureUnderHome\`, applied in:
- \`pkg/runner/ftp.go\` \`parsePath\` Windows branch
- \`pkg/executor/handlers/file/file.go\` \`parsePaths\` and \`fileDownload\` on Windows

Unix keeps its existing behavior — OS-level ACLs from \`Demote\` are the scoping mechanism there, and adding new containment would silently break legitimate flows (users uploading to \`/tmp\`, etc.).

Key details:
- Case-insensitive compare on Windows (\`strings.ToLower\` on both root and target before \`filepath.Rel\`).
- Symlink/junction resolution on both home and target so a junction inside home can't redirect to C:\\Windows. \`ResolveSymlinksBestEffort\` handles not-yet-existing paths (downloads, new files) by resolving the nearest existing ancestor and appending the remainder literally.
- \`NewFtpClient\` refuses to start on Windows with an empty home directory (containment needs a valid root). Fails fast instead of every command erroring.
- TOCTOU gap acknowledged in the function doc — Go doesn't expose \`O_NOFOLLOW\` portably on Windows.

## Review history

Two reviews by \`implementation-reviewer\` caught:
1. \"No home-dir containment on Windows — SAM exfil as SYSTEM\" → fixed via \`EnsureUnderHome\`.
2. \"Symlink escape bypasses lexical containment\" → fixed via \`ResolveSymlinksBestEffort\` + resolved-home-and-target compare.

Final pass: APPROVED, with two non-blocking suggestions both applied (extract shared helper, add symlink integration test).

## Tests

- \`pkg/utils/wirepath_test.go\` — roundtrip on each platform, \`EnsureUnderHome\` cases (exact home, child, parent escape, system file, different volume, case-insensitive, sibling user, prefix substring, empty home), symlink integration tests.
- \`pkg/runner/ftp_test.go\` — existing \`parsePath\` suite retained.
- All test suites pass on darwin; \`GOOS=windows go build/vet\` clean.

## Test plan

- [ ] On Windows Server 2025: WebFTP browse / create folder / upload file / download file / copy / move / delete
- [ ] Attempt path traversal: \`/C:/Windows/System32/config/SAM\` → should be rejected with \"path escapes home directory\"
- [ ] Attempt symlink escape: inside home, \`mklink /J evil C:\\Windows\\System32\\config\` then browse \`/C:/Users/Administrator/evil/SAM\` → should be rejected
- [ ] Terminal: PowerShell opens cleanly, no 8009001d
- [ ] chmod / chown from UI → gets back \"not supported on this platform\"
- [ ] Unix (linux, darwin): no regressions in existing FTP flows

## References

- alpamon #255 (Windows support tracking)
- alpamon #276 (initial Windows support, merged)
- alpacax/alpacon-web#1111 (UI disables for chmod/chown, user/group management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)