### PR TITLE
feat(windows): Windows Service wrapper + self-update support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,11 @@ checksum:
 archives:
   - id: alpamon
     name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-{{ .Os }}-{{ .Arch }}'
+    # Force tar.gz on all platforms including Windows. The self-updater
+    # (pkg/updater/updater.go) hardcodes the .tar.gz suffix in archiveFilename,
+    # and defaulting to zip on Windows would break the update URL.
+    formats:
+      - tar.gz
 
 nfpms:
   - builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,11 +55,17 @@ checksum:
 archives:
   - id: alpamon
     name_template: '{{ .ProjectName }}-{{ trimprefix .Version "v" }}-{{ .Os }}-{{ .Arch }}'
-    # Force tar.gz on all platforms including Windows. The self-updater
-    # (pkg/updater/updater.go) hardcodes the .tar.gz suffix in archiveFilename,
-    # and defaulting to zip on Windows would break the update URL.
+    # Default to tar.gz everywhere so the self-updater
+    # (pkg/updater/updater.go) which hardcodes the .tar.gz suffix keeps
+    # working. On Windows we additionally publish .zip so operators
+    # doing a manual download get the format native to Windows.
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - tar.gz
+          - zip
 
 nfpms:
   - builds:

--- a/README.md
+++ b/README.md
@@ -4,250 +4,214 @@
 
 Installed on each server, Alpamon establishes an outbound-only connection to the Alpacon console, enabling browser-based terminals (Websh), file transfers, system monitoring, and remote command execution—all without VPNs, SSH keys, or firewall changes. Every action is supervised and audited for compliance.
 
-This guide outlines the step-by-step process for installing Alpamon within a development environment.
+## Supported platforms
 
-## System requirements
+| Platform | Versions | Arch |
+| --- | --- | --- |
+| Linux | Ubuntu, Debian, RHEL, CentOS, Rocky, Alma, Fedora, Amazon Linux, Oracle Linux | amd64, arm64 |
+| macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
+| Windows | Windows Server 2019 / 2022 / 2025, Windows 10 1803+, Windows 11 | amd64 |
 
-To run Alpamon, ensure your system meets the following requirements:
-- Operating system: Linux, macOS, or Windows (via WSL)
-- Go version: 1.25.7 or higher
-- Memory: At least 512MB RAM
-- Disk space: At least 100MB free space
+**System requirements**: 128MB RAM, 150MB free disk, outbound HTTPS to your Alpacon workspace.
 
-## Getting started
-To build Alpamon, ensure you have:
-- [Go](https://go.dev/doc/install) version 1.25.7 or higher installed (required for building).
-  - Make sure `$GOPATH` is set and `$GOPATH/bin` is added to your system’s `PATH`.
-  
 ## Installation
-Download the latest `alpamon` directly from our releases page or install it using package managers on Linux.
+
+All platforms share the same second step: `alpamon register` writes the config, sets up the service, and starts it. Only the first step (getting the binary onto the machine) differs.
 
 ### Linux
 
-#### Debian and Ubuntu
+**Debian / Ubuntu**
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.deb.sh?any=true | sudo bash
 sudo apt-get install alpamon
+sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```
 
-#### CentOS and RHEL
+**RHEL / CentOS / Rocky / Alma / Fedora**
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.rpm.sh?any=true | sudo bash
 sudo yum install alpamon
+sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```
 
-> [!TIP]
-> To use Alpacon-managed sudo authentication, install the optional PAM module:
-> `sudo apt-get install alpamon-pam` (Debian/Ubuntu) or `sudo yum install alpamon-pam` (CentOS/RHEL).
-> See [PAM module](#pam-module) for details.
+### macOS
 
-### PAM module
+```bash
+# Pick the right arch for your Mac: amd64 (Intel) or arm64 (Apple Silicon)
+ARCH=$(uname -m | sed 's/x86_64/amd64/')
+VERSION=$(curl -s https://api.github.com/repos/alpacax/alpamon/releases/latest | grep tag_name | cut -d'"' -f4)
+curl -LO "https://github.com/alpacax/alpamon/releases/download/${VERSION}/alpamon-${VERSION#v}-darwin-${ARCH}.tar.gz"
+tar xzf alpamon-*.tar.gz
+sudo mv alpamon /usr/local/bin/
+sudo alpamon register --url https://<workspace> --token <TOKEN>
+```
 
-The optional `alpamon-pam` package provides PAM (Pluggable Authentication Modules) integration for Alpacon-managed sudo authentication:
+### Windows
+
+Open an elevated PowerShell (Administrator), then run one of:
+
+**Automated — cloud-init, EC2 UserData, Packer, Azure Custom Script Extension**
+```powershell
+$env:ALPAMON_URL   = "https://<workspace>"
+$env:ALPAMON_TOKEN = "<TOKEN>"
+iwr https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 -UseB | iex
+```
+
+**Manual** — download `alpamon-X.Y.Z-windows-amd64.zip` from [Releases](https://github.com/alpacax/alpamon/releases), extract, and run:
+```powershell
+.\alpamon.exe register --url https://<workspace> --token <TOKEN>
+```
+
+`register` copies the binary to `C:\Program Files\alpamon\`, creates the Windows Service (`StartType=Automatic (Delayed)`, Recovery Actions configured), and starts it. Re-running `register` is idempotent.
+
+## PAM module (optional, Linux only)
+
+The optional `alpamon-pam` package provides PAM integration for Alpacon-managed sudo authentication:
 - **pam_alpamon.so**: Verifies Alpacon users during sudo authentication
 - **alpacon_approval.so**: Handles sudo command approval requests
-
-#### Installing the PAM module
-
-The PAM module is packaged separately and must be installed explicitly:
 
 ```bash
 # Debian / Ubuntu
 sudo apt-get install alpamon-pam
-
-# CentOS / RHEL
+# RHEL / CentOS
 sudo yum install alpamon-pam
 ```
 
-#### Configuration
-
-After installation, configure PAM and sudo to enable the authentication features:
-
-1. Add to `/etc/pam.d/sudo`:
+After install, add to `/etc/pam.d/sudo`:
 ```
 auth [user_unknown=ignore auth_err=die success=done default=bad] pam_alpamon.so
 ```
-
-2. Add to `/etc/sudo.conf`:
+And to `/etc/sudo.conf`:
 ```
 Plugin approval_plugin alpacon_approval.so
 ```
+The alpamon service must be running with the socket at `/var/run/alpamon/auth.sock`.
 
-**Note**: The Alpamon service must be running with socket at `/var/run/alpamon/auth.sock` for PAM authentication to work.
+## Configuration
 
-### macOS
+Alpamon reads the first file it finds in this order:
 
-#### Clone the source code
-To get started on macOS, clone the source code from the repository:
-```bash
-git clone https://github.com/alpacax/alpamon.git
-```
+- `/etc/alpamon/alpamon.conf` (Linux production)
+- `/Library/Application Support/alpamon/alpamon.conf` (macOS)
+- `%ProgramData%\alpamon\alpamon.conf` (Windows)
+- `~/.alpamon.conf` (any platform, development)
 
-#### Generate Ent schema code with Entgo
-To generate Ent schema code with custom features, navigate to the root of the project and use the following command:
-```bash
-go run -mod=mod entgo.io/ent/cmd/ent@v0.14.5 generate --feature sql/modifier --target ./pkg/db/ent ./pkg/db/schema
-```
-
-#### Install Atlas CLI (development only)
-Atlas CLI is **only required for development** when you need to generate new migration files after modifying database schemas in `pkg/db/schema/`. Production deployments do not require Atlas CLI as migrations are executed directly from embedded SQL files.
-
-To install Atlas CLI for development:
-```bash
-curl -sSf https://atlasgo.sh | sh
-```
-
-After modifying Ent schemas, generate migration files:
-```bash
-atlas migrate diff <migration_name> \
-  --dir "file://pkg/db/migration" \
-  --to "ent://pkg/db/ent/schema" \
-  --dev-url "sqlite://alpamon.db?mode=memory"
-```
-
-#### Install Go dependencies
-Make sure you have Go installed. Then, navigate to the project root and download the necessary Go packages:
-```bash
-go mod tidy
-```
-
-## Configure
-
-Alpamon can be configured via the files listed below.
-
-- `/etc/alpamon/alpamon.conf`
-- `~/.alpamon.conf`
-
-It is recommended to use `/etc/alpamon/alpamon.conf` for deployment, but you can use `~/.alpamon.conf` for development.
+`register` generates this file for you. Example:
 
 ```ini
 [server]
-url = http://localhost:8000
-id = 
-key = 
+url = https://<workspace>
+id = <server-id>
+key = <server-key>
 
 [ssl]
 verify = true
-ca_cert = 
+# ca_cert = /path/to/ca.crt
+
+[logging]
+debug = false
+```
+
+## Service management
+
+### Linux (systemd)
+
+```bash
+sudo systemctl status alpamon
+sudo systemctl restart alpamon
+sudo journalctl -u alpamon -f
+```
+
+### macOS (launchd)
+
+```bash
+sudo launchctl print system/com.alpacax.alpamon
+sudo launchctl kickstart -k system/com.alpacax.alpamon
+tail -f /var/log/alpamon/alpamon.log
+```
+
+### Windows Service
+
+```powershell
+sc.exe query alpamon
+Restart-Service alpamon
+Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
+```
+
+## Upgrade
+
+Alpamon supports in-place self-update: from the Alpacon console, send an upgrade command, or run `alpamon upgrade` locally. The agent downloads the release archive from GitHub, verifies its SHA-256 checksum, validates the binary header, and swaps the running binary atomically. On Windows the running `.exe` is renamed to `alpamon.exe.old` first and cleaned up on next service start.
+
+## Development
+
+### Build from source
+
+```bash
+git clone https://github.com/alpacax/alpamon.git
+cd alpamon
+go build -o alpamon ./cmd/alpamon         # native
+GOOS=windows GOARCH=amd64 go build ./cmd/alpamon   # Windows cross-compile
+```
+
+Go 1.25.7+ is required. `GOPATH/bin` should be on `PATH`.
+
+### Generate Ent schema code
+
+```bash
+go run -mod=mod entgo.io/ent/cmd/ent@v0.14.5 generate \
+    --feature sql/modifier \
+    --target ./pkg/db/ent ./pkg/db/schema
+```
+
+### Install Atlas CLI (only for new migrations)
+
+Atlas is only needed when modifying schemas under `pkg/db/schema/`. Production deployments execute the embedded SQL files in `pkg/db/migration/` directly.
+
+```bash
+curl -sSf https://atlasgo.sh | sh
+atlas migrate diff <migration_name> \
+    --dir "file://pkg/db/migration" \
+    --to "ent://pkg/db/ent/schema" \
+    --dev-url "sqlite://alpamon.db?mode=memory"
+```
+
+### Docker testing (Linux distros)
+
+```bash
+./Dockerfiles/build.sh
+docker run alpamon:ubuntu-22.04
+
+# Custom workspace
+docker run \
+    -e ALPACON_URL="https://<workspace>" \
+    -e PLUGIN_ID="<plugin_id>" \
+    -e PLUGIN_KEY="<plugin_key>" \
+    alpamon:latest
+```
+
+Covered distros: Ubuntu 18.04/20.04/22.04, Debian 10/11, RedHat 8/9, CentOS 7.
+
+### Run locally
+
+```bash
+go run ./cmd/alpamon
+# or
+./alpamon
+```
+
+Local config lives at `~/.alpamon.conf`; for a fresh run against a dev server:
+```ini
+[server]
+url = http://localhost:8000
+id = 7a50ea6c-2138-4d3f-9633-e50694c847c4
+key = alpaca
 
 [logging]
 debug = true
 ```
 
-### Configuration details
+## Further reading
 
-- `server`: Server settings
-    - `url`: The URL for Alpaca Console. If you are in a local development environment, this will be `https://localhost:8000`.
-    - `id`: Server ID
-    - `key`: Server Key
-    - `ca_cert`: Path for the CA certificate
-- `logging`: Logging settings
-    - `debug`: Whether to print debug logs or not
- 
-For testing with the `Alpacon-Server`, you can use the following values:
-- `url` = `http://localhost:8000`
-- `id` = `7a50ea6c-2138-4d3f-9633-e50694c847c4`
-- `key` = `alpaca`
-
-
-## Run
-
-### Local build
-
-To build Alpamon as a binary for local development, run the following command from the project root:
-```sh
-go build -o alpamon ./cmd/alpamon
-```
-This will create an `alpamon` executable in your project root. You can run it directly:
-
-```sh
-./alpamon
-```
-
-### Local environment
-
-To run Alpamon in a local development environment, you can also use Go directly:
-```sh
-go run ./cmd/alpamon
-```
-
-### Docker
-You can also use docker to test alpamon in various Linux distributions. We use Docker Desktop to test alpamon on following distributions.
-
-- Ubuntu: 18.04, 20.04, 22.04
-- Debian: 10, 11
-- RedHat: 8, 9
-- CentOS: 7
-
-#### Build
-Build docker images with the build script.
-```
-./Dockerfiles/build.sh
-```
-
-#### Run
-You can run containers for these images in Docker Desktop or using command line like below.
-```
-docker run alpamon:ubuntu-22.04
-```
-- Note: This will run the container with the default workspace URL (http://localhost:8000), plugin ID, and key values. 
-For more details, refer to the `entrypoint.sh` file in the Dockerfiles directory corresponding to each operating system.
-
-To run the container with a custom workspace URL, plugin ID, and key, use the following command:
-```
-docker run \
-  -e ALPACON_URL="your_workspace_url" \
-  -e PLUGIN_ID="your_plugin_id" \
-  -e PLUGIN_KEY="your_plugin_key" \
-  alpamon:latest
-```
-- Replace the environment variable values (your_workspace_url, your_plugin_id, your_plugin_key) with your actual workspace configuration.
-
-### Deploy as a service
-
-For Linux systems supporting `systemd`, you can run `alpamon` as a systemd service. In this case, you need to adapt `alpamon/config/alpamon.service` for your environment.
-
-Specifically, `ExecStart` should be something like `/usr/local/bin/alpamon`.
-
-Run the following commands to prepare system directories.
-
-```sh
-sudo cp alpamon/config/tmpfile.conf /usr/lib/tmpfiles.d/alpamon.conf
-sudo systemd-tmpfiles --create
-```
-
-Run the following commands to install a systemd service.
-
-```sh
-sudo cp alpamon/config/alpamon.service /lib/systemd/system/alpamon.service
-sudo systemctl daemon-reload
-sudo systemctl start alpamon.service
-sudo systemctl enable alpamon.service
-systemctl status alpamon.service
-```
-
-The result would look like the following. The status must be loaded and active (running).
-
-```
-alpamon.service - alpamon agent for Alpacon
-     Loaded: loaded (/lib/systemd/system/alpamon.service; enabled; vendor preset: enabled)
-     Active: active (running) since Thu 2023-09-28 23:48:55 KST; 4 days ago
-```
-
-### Logs
-
-Alpamon logs are managed by systemd's journald. Use the following commands to view logs:
-
-```bash
-# View all logs
-journalctl -u alpamon
-
-# Follow logs in real-time
-journalctl -u alpamon -f
-
-# View logs since today
-journalctl -u alpamon --since today
-
-# View recent logs (last 100 lines)
-journalctl -u alpamon -n 100
-```
+- [Alpacon documentation](https://docs.alpacax.com)
+- [Register a server](https://docs.alpacax.com/use/servers/register/)
+- [Agent troubleshooting](https://docs.alpacax.com/reference/troubleshooting/agent-issues/)

--- a/README.md
+++ b/README.md
@@ -50,16 +50,29 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 
 Open an elevated PowerShell (Administrator), then run one of:
 
-**Automated — cloud-init, EC2 UserData, Packer, Azure Custom Script Extension**
+**Manual** — download `alpamon-X.Y.Z-windows-amd64.zip` from [Releases](https://github.com/alpacax/alpamon/releases), extract, and run:
+```powershell
+.\alpamon.exe register --url https://<workspace> --token <TOKEN>
+```
+
+**Automated download-then-run** — preferred for cloud-init, EC2 UserData, Packer, Azure Custom Script Extension. Keeps the installer on disk for audit and avoids executing arbitrary remote content under Administrator:
+```powershell
+$env:ALPAMON_URL   = "https://<workspace>"
+$env:ALPAMON_TOKEN = "<TOKEN>"
+$installer = Join-Path $env:TEMP 'alpamon-install.ps1'
+Invoke-WebRequest -UseBasicParsing `
+    -Uri 'https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1' `
+    -OutFile $installer
+& powershell -ExecutionPolicy Bypass -File $installer
+```
+
+The install script itself verifies the release archive's SHA-256 against the checksums file published with the release before extracting or executing anything.
+
+A terser pipe-to-`iex` form is also supported for quick one-liners but trades auditability for brevity:
 ```powershell
 $env:ALPAMON_URL   = "https://<workspace>"
 $env:ALPAMON_TOKEN = "<TOKEN>"
 iwr https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 -UseB | iex
-```
-
-**Manual** — download `alpamon-X.Y.Z-windows-amd64.zip` from [Releases](https://github.com/alpacax/alpamon/releases), extract, and run:
-```powershell
-.\alpamon.exe register --url https://<workspace> --token <TOKEN>
 ```
 
 `register` copies the binary to `C:\Program Files\alpamon\`, creates the Windows Service (`StartType=Automatic (Delayed)`, Recovery Actions configured), and starts it. Re-running `register` is idempotent.

--- a/cmd/alpamon/command/platform_windows.go
+++ b/cmd/alpamon/command/platform_windows.go
@@ -20,7 +20,21 @@ func setupSignalHandler(ctxManager *agent.ContextManager) {
 
 // restartAgent on Windows spawns a new process and exits.
 // Windows does not support syscall.Exec (process replacement).
+//
+// When running under the Service Control Manager, we instead rely on
+// SCM's Recovery Actions to relaunch alpamon. Spawning a child while
+// the SCM thinks we're a running service would fight the service's
+// lifecycle; exiting with a non-zero status lets SCM notice the
+// "failure" and restart us with the newly-installed binary.
 func restartAgent() {
+	if runningAsWindowsService() {
+		log.Warn().Msgf(
+			"%s is exiting with status 1 so SCM Recovery Actions restart it with the newly-installed binary. "+
+				"If Recovery Actions are not configured the service will remain stopped; "+
+				"re-run 'alpamon register' to apply the recommended configuration.", name,
+		)
+		os.Exit(1)
+	}
 	executable, err := os.Executable()
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to restart the %s.", name)

--- a/cmd/alpamon/command/register/install_other.go
+++ b/cmd/alpamon/command/register/install_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package register
+
+// ensureInstalled is a no-op on Unix. Package managers (apt, brew)
+// place the binary in the canonical location before `register` is
+// invoked, so there is nothing for us to do.
+func ensureInstalled() (relaunched bool, err error) {
+	return false, nil
+}

--- a/cmd/alpamon/command/register/install_windows.go
+++ b/cmd/alpamon/command/register/install_windows.go
@@ -1,0 +1,113 @@
+package register
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+const installExeName = "alpamon.exe"
+
+// ensureInstalled makes register work from any download location on
+// Windows, mirroring how `apt install alpamon` or `brew install
+// alpamon` place the binary before `alpamon register` is run on
+// Linux and macOS.
+//
+// If the current process is already running from the canonical
+// install path (%ProgramFiles%\alpamon\alpamon.exe), the function is
+// a no-op. Otherwise it copies the current executable there and
+// re-executes register with the original arguments, then exits with
+// the child's status. The child process sees "already installed" and
+// continues to the normal register flow.
+func ensureInstalled() (relaunched bool, err error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return false, fmt.Errorf("determine current executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+
+	target := filepath.Join(installDir(), installExeName)
+	if strings.EqualFold(exe, target) {
+		return false, nil
+	}
+
+	fmt.Printf("Installing alpamon to %s...\n", target)
+
+	if err := os.MkdirAll(filepath.Dir(target), 0); err != nil {
+		return false, fmt.Errorf("create install directory: %w%s", err, installErrorHint(err, filepath.Dir(target)))
+	}
+	if err := copySelf(exe, target); err != nil {
+		return false, err
+	}
+
+	fmt.Println("Re-running register from the installed location...")
+	cmd := exec.Command(target, os.Args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	exitCode := 0
+	if runErr := cmd.Run(); runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return true, runErr
+		}
+	}
+	os.Exit(exitCode)
+	return true, nil // unreachable
+}
+
+// installDir returns %ProgramFiles%\alpamon, or the hardcoded English
+// path if ProgramFiles is unset (unlikely but defensive).
+func installDir() string {
+	if pf := os.Getenv("ProgramFiles"); pf != "" {
+		return filepath.Join(pf, "alpamon")
+	}
+	return `C:\Program Files\alpamon`
+}
+
+func copySelf(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("create destination (%s): %w%s", dst, err, installErrorHint(err, dst))
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("write destination: %w", err)
+	}
+	return out.Close()
+}
+
+// installErrorHint annotates the two error classes users hit most
+// often when copying the binary into Program Files:
+//   - ACCESS_DENIED: the shell isn't elevated.
+//   - SHARING_VIOLATION: the existing alpamon.exe is being held open
+//     by a running service; the operator must stop it first.
+func installErrorHint(err error, path string) string {
+	var errno windows.Errno
+	if !errors.As(err, &errno) {
+		return ""
+	}
+	switch errno {
+	case windows.ERROR_ACCESS_DENIED:
+		return "\nHint: run this command from an elevated (Administrator) prompt."
+	case windows.ERROR_SHARING_VIOLATION:
+		return fmt.Sprintf("\nHint: %s is in use (likely the running alpamon service). Stop it first:\n  sc.exe stop alpamon", path)
+	}
+	return ""
+}

--- a/cmd/alpamon/command/register/install_windows.go
+++ b/cmd/alpamon/command/register/install_windows.go
@@ -86,11 +86,32 @@ func copySelf(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("create destination (%s): %w%s", dst, err, installErrorHint(err, dst))
 	}
+
+	// Roll back the destination on any failure past this point, so a
+	// retry doesn't find a truncated alpamon.exe that would then pass
+	// the os.Executable() check and skip reinstall.
+	success := false
+	defer func() {
+		if out != nil {
+			_ = out.Close()
+		}
+		if !success {
+			_ = os.Remove(dst)
+		}
+	}()
+
 	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
 		return fmt.Errorf("write destination: %w", err)
 	}
-	return out.Close()
+
+	closeErr := out.Close()
+	out = nil
+	if closeErr != nil {
+		return fmt.Errorf("close destination: %w", closeErr)
+	}
+
+	success = true
+	return nil
 }
 
 // installErrorHint annotates the two error classes users hit most

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -326,4 +326,3 @@ debug = false
 		"CACert": caCert,
 	})
 }
-

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -87,6 +87,16 @@ func init() {
 }
 
 func runRegister(cmd *cobra.Command, args []string) error {
+	// 0. On Windows, place the binary in %ProgramFiles%\alpamon and
+	// re-exec from there so the Service Manager entry we're about to
+	// create points at a stable path. No-op on Linux/macOS, where
+	// apt/brew already handled placement.
+	if relaunched, err := ensureInstalled(); err != nil {
+		return err
+	} else if relaunched {
+		return nil
+	}
+
 	// 1. Check if config file already exists (prevent re-registration)
 	if info, err := os.Stat(configPath); err == nil {
 		if info.Size() > 0 {

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alpacax/alpamon/pkg/utils"
@@ -12,7 +14,6 @@ import (
 )
 
 const (
-	alpamonBinPath       = `C:\Program Files\alpamon\alpamon.exe`
 	serviceName          = "alpamon"
 	serviceDisplayName   = "Alpamon Agent"
 	serviceDescription   = "Secure server agent for the Alpacon infrastructure access platform."
@@ -20,17 +21,31 @@ const (
 	recoveryRestartDelay = 5 * time.Second
 )
 
+// defaultInstallBinPath returns the canonical SCM BinaryPathName that
+// ensureInstalled() targets. Used as a fallback when os.Executable()
+// fails; derived from installDir() so both the installer and the
+// service entry stay in sync across systems where %ProgramFiles% is
+// non-default (different drive / localized install).
+func defaultInstallBinPath() string {
+	return filepath.Join(installDir(), installExeName)
+}
+
 func ensureDirectories() error {
 	return utils.EnsureDirectories()
 }
 
 func startService() error {
-	binPath := alpamonBinPath
+	binPath := defaultInstallBinPath()
 	if exe, err := os.Executable(); err == nil {
 		binPath = exe
 	} else {
 		fmt.Printf("Warning: os.Executable() failed (%v); falling back to %s\n", err, binPath)
 	}
+	// SCM stores BinaryPathName as a command line; a path that contains
+	// whitespace must be quoted. Leaving it unquoted triggers the
+	// classic "unquoted service path" behavior where Windows may
+	// search and execute sibling files (C:\Program.exe, etc.).
+	serviceBinPath := quoteServicePath(binPath)
 
 	m, err := mgr.Connect()
 	if err != nil {
@@ -50,7 +65,7 @@ func startService() error {
 		}
 		s, err = m.CreateService(
 			serviceName,
-			binPath,
+			serviceBinPath,
 			mgr.Config{
 				DisplayName:      serviceDisplayName,
 				Description:      serviceDescription,
@@ -69,7 +84,7 @@ func startService() error {
 		// pointing at an older location, services created by the old
 		// sc.exe instructions without DelayedAutoStart, etc.
 		if cfg, cfgErr := s.Config(); cfgErr == nil {
-			cfg.BinaryPathName = binPath
+			cfg.BinaryPathName = serviceBinPath
 			cfg.DisplayName = serviceDisplayName
 			cfg.Description = serviceDescription
 			cfg.StartType = mgr.StartAutomatic
@@ -132,4 +147,23 @@ func elevationHint(err error) string {
 func isServiceNotExist(err error) bool {
 	var errno windows.Errno
 	return errors.As(err, &errno) && errno == windows.ERROR_SERVICE_DOES_NOT_EXIST
+}
+
+// quoteServicePath wraps p in double quotes when it contains
+// whitespace and is not already quoted. SCM treats BinaryPathName as
+// a command line, so an unquoted "C:\Program Files\alpamon\..." can
+// be parsed as "C:\Program.exe Files\alpamon\..." and execute a
+// sibling file if one exists. Paths without whitespace are returned
+// unchanged to keep SCM output readable.
+func quoteServicePath(p string) string {
+	if p == "" {
+		return p
+	}
+	if strings.HasPrefix(p, `"`) {
+		return p
+	}
+	if !strings.ContainsAny(p, " \t") {
+		return p
+	}
+	return `"` + p + `"`
 }

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -63,6 +63,25 @@ func startService() error {
 		if err != nil {
 			return fmt.Errorf("create service: %w%s", err, elevationHint(err))
 		}
+	} else {
+		// Service already exists. Refresh its config so re-running
+		// register is idempotent and corrects any drift: a binPath
+		// pointing at an older location, services created by the old
+		// sc.exe instructions without DelayedAutoStart, etc.
+		if cfg, cfgErr := s.Config(); cfgErr == nil {
+			cfg.BinaryPathName = binPath
+			cfg.DisplayName = serviceDisplayName
+			cfg.Description = serviceDescription
+			cfg.StartType = mgr.StartAutomatic
+			cfg.DelayedAutoStart = true
+			cfg.ServiceType = windows.SERVICE_WIN32_OWN_PROCESS
+			cfg.ErrorControl = mgr.ErrorNormal
+			if err := s.UpdateConfig(cfg); err != nil {
+				fmt.Printf("Warning: failed to refresh service configuration: %v\n", err)
+			}
+		} else {
+			fmt.Printf("Warning: failed to read existing service configuration: %v\n", cfgErr)
+		}
 	}
 	defer func() { _ = s.Close() }()
 

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -1,13 +1,24 @@
 package register
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/alpacax/alpamon/pkg/utils"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
 )
 
-const alpamonBinPath = `C:\Program Files\alpamon\alpamon.exe`
+const (
+	alpamonBinPath       = `C:\Program Files\alpamon\alpamon.exe`
+	serviceName          = "alpamon"
+	serviceDisplayName   = "Alpamon Agent"
+	serviceDescription   = "Secure server agent for the Alpacon infrastructure access platform."
+	recoveryResetSeconds = 60
+	recoveryRestartDelay = 5 * time.Second
+)
 
 func ensureDirectories() error {
 	return utils.EnsureDirectories()
@@ -17,15 +28,75 @@ func startService() error {
 	binPath := alpamonBinPath
 	if exe, err := os.Executable(); err == nil {
 		binPath = exe
+	} else {
+		fmt.Printf("Warning: os.Executable() failed (%v); falling back to %s\n", err, binPath)
 	}
-	fmt.Println("Windows Service management is not yet supported.")
-	fmt.Println("Please install alpamon as a Windows Service manually:")
-	fmt.Printf("  sc.exe create alpamon binPath= \"%s\"\n", binPath)
-	fmt.Println("  sc.exe start alpamon")
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("connect to service manager: %w%s", err, elevationHint(err))
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	// If alpamon is already installed, reuse the existing service
+	// entry rather than failing: operators commonly re-run register.
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		s, err = m.CreateService(
+			serviceName,
+			binPath,
+			mgr.Config{
+				DisplayName:      serviceDisplayName,
+				Description:      serviceDescription,
+				StartType:        mgr.StartAutomatic,
+				DelayedAutoStart: true,
+				ServiceType:      windows.SERVICE_WIN32_OWN_PROCESS,
+				ErrorControl:     mgr.ErrorNormal,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("create service: %w%s", err, elevationHint(err))
+		}
+	}
+	defer func() { _ = s.Close() }()
+
+	// Auto-restart on crash. Use conservative delays so a broken
+	// binary doesn't thrash SCM.
+	recoveryActions := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
+		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
+		{Type: mgr.NoAction},
+	}
+	if err := s.SetRecoveryActions(recoveryActions, recoveryResetSeconds); err != nil {
+		// Non-fatal; log and continue. The service will still start,
+		// just without automatic recovery.
+		fmt.Printf("Warning: failed to configure service recovery actions: %v\n", err)
+	}
+
+	if err := s.Start(); err != nil {
+		// ERROR_SERVICE_ALREADY_RUNNING (1056) is fine.
+		if errno, ok := err.(windows.Errno); ok && errno == windows.ERROR_SERVICE_ALREADY_RUNNING {
+			return nil
+		}
+		return fmt.Errorf("start service: %w", err)
+	}
 	return nil
 }
 
 func printManualStartHint() {
 	fmt.Println("Please start alpamon manually:")
 	fmt.Println("  sc.exe start alpamon")
+}
+
+// elevationHint returns an annotation to append to error messages
+// when the underlying Windows error indicates a missing privilege.
+// Service Manager operations require an Administrator-elevated
+// process; the raw "Access is denied." error from the API is
+// unhelpful without that context.
+func elevationHint(err error) string {
+	var errno windows.Errno
+	if errors.As(err, &errno) && errno == windows.ERROR_ACCESS_DENIED {
+		return "\nHint: run this command from an elevated (Administrator) prompt."
+	}
+	return ""
 }

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -40,8 +40,14 @@ func startService() error {
 
 	// If alpamon is already installed, reuse the existing service
 	// entry rather than failing: operators commonly re-run register.
+	// Only treat ERROR_SERVICE_DOES_NOT_EXIST as "go create it"; any
+	// other OpenService failure (access denied, RPC issues) should
+	// surface so the operator can address it.
 	s, err := m.OpenService(serviceName)
 	if err != nil {
+		if !isServiceNotExist(err) {
+			return fmt.Errorf("open service: %w%s", err, elevationHint(err))
+		}
 		s, err = m.CreateService(
 			serviceName,
 			binPath,
@@ -99,4 +105,12 @@ func elevationHint(err error) string {
 		return "\nHint: run this command from an elevated (Administrator) prompt."
 	}
 	return ""
+}
+
+// isServiceNotExist reports whether err indicates that the service is
+// not registered with the SCM (i.e. this is a fresh install). Used to
+// distinguish "go create the service" from real OpenService failures.
+func isServiceNotExist(err error) bool {
+	var errno windows.Errno
+	return errors.As(err, &errno) && errno == windows.ERROR_SERVICE_DOES_NOT_EXIST
 }

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/alpacax/alpamon/cmd/alpamon/command/ftp"
@@ -19,11 +20,56 @@ import (
 	"github.com/alpacax/alpamon/pkg/pidfile"
 	"github.com/alpacax/alpamon/pkg/runner"
 	"github.com/alpacax/alpamon/pkg/scheduler"
+	"github.com/alpacax/alpamon/pkg/updater"
 	"github.com/alpacax/alpamon/pkg/utils"
 	"github.com/alpacax/alpamon/pkg/version"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
+
+// shutdownHook lets non-signal callers (e.g. the Windows Service
+// handler on SCM Stop) trigger the same graceful-shutdown path that
+// setupSignalHandler uses. It is installed by runAgent once its
+// ContextManager is ready and reset to a no-op when runAgent returns.
+var (
+	shutdownMu   sync.Mutex
+	shutdownFunc func()
+)
+
+// pendingShutdown records that triggerShutdown was called before the
+// shutdown hook was installed. When setShutdownFunc later installs the
+// real hook, it checks this flag and fires immediately, closing the
+// SCM Stop-before-ready race.
+var pendingShutdown bool
+
+func setShutdownFunc(f func()) {
+	shutdownMu.Lock()
+	shutdownFunc = f
+	fire := pendingShutdown && f != nil
+	if fire {
+		pendingShutdown = false
+	}
+	shutdownMu.Unlock()
+	if fire {
+		f()
+	}
+}
+
+// triggerShutdown is called from platform integrations (Windows SCM)
+// to initiate the same shutdown flow as a SIGTERM on Unix. Safe to
+// call before runAgent is ready: the request is recorded and fired as
+// soon as the hook is installed. Also safe after shutdown has run.
+func triggerShutdown() {
+	shutdownMu.Lock()
+	f := shutdownFunc
+	if f == nil {
+		pendingShutdown = true
+	}
+	shutdownMu.Unlock()
+	if f != nil {
+		f()
+	}
+}
 
 const (
 	name          = "alpamon"
@@ -35,7 +81,14 @@ var RootCmd = &cobra.Command{
 	Use:   "alpamon",
 	Short: "Secure Server Agent for Alpacon",
 	Run: func(cmd *cobra.Command, args []string) {
-		runAgent()
+		// When launched by the Windows Service Control Manager, run
+		// under the svc dispatcher instead of as a plain console app.
+		// No-op / always false on Unix.
+		if runningAsWindowsService() {
+			runService()
+			return
+		}
+		runAgent(nil)
 	},
 }
 
@@ -44,15 +97,28 @@ func init() {
 	RootCmd.AddCommand(setup.SetupCmd, ftp.FtpCmd, tunnel.TunnelDaemonCmd, register.RegisterCmd)
 }
 
-func runAgent() {
+// runAgent is the core agent loop. When ready is non-nil, it is
+// closed as soon as the shutdown hook is installed — the Windows
+// Service handler uses this to delay reporting Running until a
+// Stop request can actually be honored.
+func runAgent(ready chan<- struct{}) {
 	// Create global context manager for the entire application
 	ctxManager := agent.NewContextManager()
 	ctx := ctxManager.Root()
 
 	setupSignalHandler(ctxManager)
+	setShutdownFunc(ctxManager.Shutdown)
+	defer setShutdownFunc(nil)
+	if ready != nil {
+		close(ready)
+	}
 
 	// Logger
 	logger.InitLogger()
+
+	// On Windows, clean up any ".old" binary left behind by a prior
+	// self-update before the new process takes over. No-op on Unix.
+	updater.CleanupStaleOld()
 
 	// platform
 	utils.InitPlatform()

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -3,7 +3,6 @@ package command
 import (
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/alpacax/alpamon/cmd/alpamon/command/ftp"
@@ -26,50 +25,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
-
-// shutdownHook lets non-signal callers (e.g. the Windows Service
-// handler on SCM Stop) trigger the same graceful-shutdown path that
-// setupSignalHandler uses. It is installed by runAgent once its
-// ContextManager is ready and reset to a no-op when runAgent returns.
-var (
-	shutdownMu   sync.Mutex
-	shutdownFunc func()
-)
-
-// pendingShutdown records that triggerShutdown was called before the
-// shutdown hook was installed. When setShutdownFunc later installs the
-// real hook, it checks this flag and fires immediately, closing the
-// SCM Stop-before-ready race.
-var pendingShutdown bool
-
-func setShutdownFunc(f func()) {
-	shutdownMu.Lock()
-	shutdownFunc = f
-	fire := pendingShutdown && f != nil
-	if fire {
-		pendingShutdown = false
-	}
-	shutdownMu.Unlock()
-	if fire {
-		f()
-	}
-}
-
-// triggerShutdown is called from platform integrations (Windows SCM)
-// to initiate the same shutdown flow as a SIGTERM on Unix. Safe to
-// call before runAgent is ready: the request is recorded and fired as
-// soon as the hook is installed. Also safe after shutdown has run.
-func triggerShutdown() {
-	shutdownMu.Lock()
-	f := shutdownFunc
-	if f == nil {
-		pendingShutdown = true
-	}
-	shutdownMu.Unlock()
-	if f != nil {
-		f()
-	}
-}
 
 const (
 	name          = "alpamon"

--- a/cmd/alpamon/command/svc_other.go
+++ b/cmd/alpamon/command/svc_other.go
@@ -9,3 +9,9 @@ func runningAsWindowsService() bool { return false }
 // runService is a no-op on Unix; the Windows implementation hands
 // control off to golang.org/x/sys/windows/svc.
 func runService() {}
+
+// setShutdownFunc is a no-op on Unix. The shutdown hook bridges the
+// Windows Service Control Manager into ContextManager.Shutdown; on
+// Unix runAgent's setupSignalHandler handles SIGINT / SIGTERM
+// directly so nothing else needs to reach into the agent.
+func setShutdownFunc(f func()) {}

--- a/cmd/alpamon/command/svc_other.go
+++ b/cmd/alpamon/command/svc_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package command
+
+// runningAsWindowsService is the non-Windows stub. Always false so the
+// normal interactive runAgent() path is taken.
+func runningAsWindowsService() bool { return false }
+
+// runService is a no-op on Unix; the Windows implementation hands
+// control off to golang.org/x/sys/windows/svc.
+func runService() {}

--- a/cmd/alpamon/command/svc_windows.go
+++ b/cmd/alpamon/command/svc_windows.go
@@ -1,0 +1,101 @@
+package command
+
+import (
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows/svc"
+)
+
+// svcName is the Windows Service name registered by `alpamon register`.
+// Must match what register creates.
+const svcName = "alpamon"
+
+// runningAsWindowsService reports whether the current process was
+// launched by the Windows Service Control Manager.
+func runningAsWindowsService() bool {
+	isSvc, err := svc.IsWindowsService()
+	if err != nil {
+		// IsWindowsService touches the Windows API; if it fails we
+		// assume interactive and let runAgent() handle things.
+		return false
+	}
+	return isSvc
+}
+
+// runService starts alpamon under the Windows Service Control Manager.
+// It maps SCM events to the existing runAgent flow by:
+//   - launching runAgent in a goroutine (it manages its own lifecycle
+//     via ContextManager and returns when shutdown is signalled);
+//   - mirroring Stop / Shutdown / Preshutdown requests into
+//     agentCtrl.stop(), which we wire to ContextManager.Shutdown via
+//     a package-level hook;
+//   - reporting status transitions back to SCM.
+//
+// SCM blocks ChangeServiceConfig2W callers on StartPending / StopPending
+// transitions, so we report Running as soon as runAgent has started
+// and Stopped once it returns.
+func runService() {
+	handler := &alpamonService{}
+	// svc.Run blocks until the service stops. It returns the last
+	// error it encountered, if any; log it and exit normally so SCM
+	// doesn't reboot the service under a Recovery Action for a
+	// clean stop.
+	if err := svc.Run(svcName, handler); err != nil {
+		log.Error().Err(err).Msg("Windows Service dispatcher returned an error.")
+	}
+}
+
+type alpamonService struct{}
+
+// Execute is the svc.Handler contract. It accepts SCM requests on r
+// and reports service status on changes. When the goroutine running
+// runAgent returns (because ctx is cancelled), Execute reports
+// Stopped and exits.
+func (s *alpamonService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+
+	changes <- svc.Status{State: svc.StartPending}
+
+	// Let runAgent start up. When triggerShutdown() is invoked by the
+	// SCM branch below, runAgent's ContextManager is cancelled and the
+	// function returns, which closes agentDone.
+	// ready is closed once runAgent has installed the shutdown hook.
+	// We wait for it before reporting Running so SCM can't deliver a
+	// Stop that we'd be unable to honor.
+	agentDone := make(chan struct{})
+	ready := make(chan struct{})
+	go func() {
+		defer close(agentDone)
+		runAgent(ready)
+	}()
+	<-ready
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepted}
+
+	for {
+		select {
+		case <-agentDone:
+			changes <- svc.Status{State: svc.Stopped}
+			return false, 0
+
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+
+			case svc.Stop, svc.Shutdown:
+				log.Info().Msgf("Windows Service received %v; initiating shutdown.", c.Cmd)
+				changes <- svc.Status{State: svc.StopPending}
+				triggerShutdown()
+				// Wait for runAgent to finish rather than returning
+				// immediately; SCM kills the process once Execute
+				// returns, cutting off in-flight graceful-shutdown.
+				<-agentDone
+				changes <- svc.Status{State: svc.Stopped}
+				return false, 0
+
+			default:
+				log.Debug().Msgf("Unexpected Windows Service control request: %v", c.Cmd)
+			}
+		}
+	}
+}

--- a/cmd/alpamon/command/svc_windows.go
+++ b/cmd/alpamon/command/svc_windows.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"sync"
+
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows/svc"
 )
@@ -8,6 +10,50 @@ import (
 // svcName is the Windows Service name registered by `alpamon register`.
 // Must match what register creates.
 const svcName = "alpamon"
+
+// Shutdown hook bridge: runAgent installs its ContextManager.Shutdown
+// via setShutdownFunc, and the SCM handler below invokes it on Stop /
+// Shutdown / control-channel-close. pendingShutdown covers the
+// Stop-before-ready race where SCM delivers Stop while runAgent is
+// still coming up.
+var (
+	shutdownMu      sync.Mutex
+	shutdownFunc    func()
+	pendingShutdown bool
+)
+
+// setShutdownFunc installs (or clears, when f == nil) the agent's
+// shutdown hook. If a Stop arrived before the hook was ready, it is
+// fired immediately now.
+func setShutdownFunc(f func()) {
+	shutdownMu.Lock()
+	shutdownFunc = f
+	fire := pendingShutdown && f != nil
+	if fire {
+		pendingShutdown = false
+	}
+	shutdownMu.Unlock()
+	if fire {
+		f()
+	}
+}
+
+// triggerShutdown is called from the SCM handler to initiate graceful
+// shutdown via ContextManager. Safe to call before runAgent has
+// installed the hook (the request is recorded and fired when
+// setShutdownFunc runs) and after shutdown has completed (becomes a
+// no-op).
+func triggerShutdown() {
+	shutdownMu.Lock()
+	f := shutdownFunc
+	if f == nil {
+		pendingShutdown = true
+	}
+	shutdownMu.Unlock()
+	if f != nil {
+		f()
+	}
+}
 
 // runningAsWindowsService reports whether the current process was
 // launched by the Windows Service Control Manager.

--- a/cmd/alpamon/command/svc_windows.go
+++ b/cmd/alpamon/command/svc_windows.go
@@ -25,9 +25,9 @@ func runningAsWindowsService() bool {
 // It maps SCM events to the existing runAgent flow by:
 //   - launching runAgent in a goroutine (it manages its own lifecycle
 //     via ContextManager and returns when shutdown is signalled);
-//   - mirroring Stop / Shutdown / Preshutdown requests into
-//     agentCtrl.stop(), which we wire to ContextManager.Shutdown via
-//     a package-level hook;
+//   - mirroring Stop / Shutdown requests into triggerShutdown(),
+//     which we wire to ContextManager.Shutdown via a package-level
+//     hook;
 //   - reporting status transitions back to SCM.
 //
 // SCM blocks ChangeServiceConfig2W callers on StartPending / StopPending
@@ -77,7 +77,17 @@ func (s *alpamonService) Execute(args []string, r <-chan svc.ChangeRequest, chan
 			changes <- svc.Status{State: svc.Stopped}
 			return false, 0
 
-		case c := <-r:
+		case c, ok := <-r:
+			if !ok {
+				// SCM closed the request channel without sending
+				// Stop; treat as a stop so we don't spin. Wait for
+				// runAgent to drain before reporting Stopped.
+				log.Warn().Msg("Windows Service control channel closed unexpectedly; shutting down.")
+				triggerShutdown()
+				<-agentDone
+				changes <- svc.Status{State: svc.Stopped}
+				return false, 0
+			}
 			switch c.Cmd {
 			case svc.Interrogate:
 				changes <- c.CurrentStatus

--- a/pkg/updater/cleanup_unix.go
+++ b/pkg/updater/cleanup_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package updater
+
+// CleanupStaleOld is a no-op on Unix. Unix's os.Rename can replace a
+// running executable in place, so the ".old" staging file created by
+// the Windows updater does not exist here.
+func CleanupStaleOld() {}

--- a/pkg/updater/cleanup_windows.go
+++ b/pkg/updater/cleanup_windows.go
@@ -1,0 +1,35 @@
+package updater
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+// CleanupStaleOld removes the ".old" copy of the current executable
+// left behind by a previous self-update. Windows cannot delete a
+// running .exe, so the updater renames the running binary aside and
+// relies on the next startup (or reboot) to clean it up.
+//
+// Safe to call unconditionally at startup; no-op when the file is
+// absent.
+func CleanupStaleOld() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	oldPath := exe + ".old"
+	info, err := os.Stat(oldPath)
+	if err != nil {
+		return
+	}
+	if info.IsDir() {
+		return
+	}
+	if err := os.Remove(oldPath); err != nil {
+		log.Debug().Err(err).Str("path", oldPath).
+			Msg("Could not remove stale .old binary; reboot will clear it.")
+		return
+	}
+	log.Debug().Str("path", oldPath).Msg("Removed stale .old binary.")
+}

--- a/pkg/updater/format_unix.go
+++ b/pkg/updater/format_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func validateBinaryFormat(binaryPath string) error {
+	f, err := os.Open(binaryPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	magic := make([]byte, 4)
+	if _, err := readFull(f, magic); err != nil {
+		return fmt.Errorf("failed to read binary header: %w", err)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if !isMachO(magic) {
+			return fmt.Errorf("not a valid Mach-O binary (magic: %x)", magic)
+		}
+	case "linux":
+		if magic[0] != 0x7f || magic[1] != 'E' || magic[2] != 'L' || magic[3] != 'F' {
+			return fmt.Errorf("not a valid ELF binary (magic: %x)", magic)
+		}
+	default:
+		return fmt.Errorf("binary format validation not supported on platform %q", runtime.GOOS)
+	}
+	return nil
+}

--- a/pkg/updater/format_windows.go
+++ b/pkg/updater/format_windows.go
@@ -1,0 +1,101 @@
+package updater
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+)
+
+// Windows PE/COFF constants (see PE Format reference).
+const (
+	peDOSMagic      = 0x5A4D     // "MZ" little-endian
+	peSignature     = 0x00004550 // "PE\0\0"
+	peHeaderOffset  = 0x3C       // offset of e_lfanew in DOS header
+	peMachineAMD64  = 0x8664
+	peMachineARM64  = 0xAA64
+	peMachineI386   = 0x014C
+	peMaxHeaderSeek = 1024 * 1024 // guard against absurd e_lfanew values
+)
+
+// validateBinaryFormat checks that binaryPath is a valid PE/COFF
+// executable whose IMAGE_FILE_HEADER.Machine matches runtime.GOARCH.
+// The file is inspected by magic bytes only; it is never executed.
+func validateBinaryFormat(binaryPath string) error {
+	f, err := os.Open(binaryPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// 1. DOS header: MZ magic at offset 0.
+	var dosMagic uint16
+	if err := binary.Read(f, binary.LittleEndian, &dosMagic); err != nil {
+		return fmt.Errorf("failed to read DOS magic: %w", err)
+	}
+	if dosMagic != peDOSMagic {
+		return fmt.Errorf("not a valid PE binary (DOS magic: 0x%04x)", dosMagic)
+	}
+
+	// 2. e_lfanew: 32-bit offset of the PE signature, at 0x3C.
+	var peOffset uint32
+	if _, err := f.Seek(peHeaderOffset, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek to PE header offset: %w", err)
+	}
+	if err := binary.Read(f, binary.LittleEndian, &peOffset); err != nil {
+		return fmt.Errorf("failed to read PE header offset: %w", err)
+	}
+	if peOffset == 0 || peOffset > peMaxHeaderSeek {
+		return fmt.Errorf("invalid PE header offset: %d", peOffset)
+	}
+
+	// 3. PE signature: "PE\0\0" at peOffset.
+	if _, err := f.Seek(int64(peOffset), io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek to PE signature: %w", err)
+	}
+	var sig uint32
+	if err := binary.Read(f, binary.LittleEndian, &sig); err != nil {
+		return fmt.Errorf("failed to read PE signature: %w", err)
+	}
+	if sig != peSignature {
+		return fmt.Errorf("not a valid PE binary (signature: 0x%08x)", sig)
+	}
+
+	// 4. IMAGE_FILE_HEADER.Machine is the next field after the PE
+	// signature. Confirm it matches this process's architecture so we
+	// don't replace a 64-bit alpamon with a 32-bit binary or vice versa.
+	var machine uint16
+	if err := binary.Read(f, binary.LittleEndian, &machine); err != nil {
+		return fmt.Errorf("failed to read IMAGE_FILE_HEADER.Machine: %w", err)
+	}
+	if err := checkPEMachine(machine); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkPEMachine matches the runtime architecture against the
+// IMAGE_FILE_HEADER.Machine field.
+//
+// Note: .goreleaser.yaml currently only builds windows/amd64; the
+// arm64 and 386 cases here are forward-compatible but today there is
+// no corresponding release artifact. Update the release matrix before
+// relying on anything other than amd64.
+func checkPEMachine(machine uint16) error {
+	var want uint16
+	switch runtime.GOARCH {
+	case "amd64":
+		want = peMachineAMD64
+	case "arm64":
+		want = peMachineARM64
+	case "386":
+		want = peMachineI386
+	default:
+		return fmt.Errorf("unsupported GOARCH for Windows update: %q", runtime.GOARCH)
+	}
+	if machine != want {
+		return fmt.Errorf("PE machine 0x%04x does not match runtime.GOARCH=%s (want 0x%04x)", machine, runtime.GOARCH, want)
+	}
+	return nil
+}

--- a/pkg/updater/format_windows_test.go
+++ b/pkg/updater/format_windows_test.go
@@ -1,0 +1,107 @@
+package updater
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildPEFixture writes a minimal PE layout that passes validateBinaryFormat.
+// It's not a loadable executable — just enough header bytes to satisfy the
+// magic-byte checks the updater performs before executing a new binary.
+func buildPEFixture(t *testing.T, machine uint16) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alpamon.exe")
+	const peOffset = 0x80
+	buf := make([]byte, peOffset+6)
+
+	// DOS header: MZ magic + e_lfanew at 0x3C.
+	binary.LittleEndian.PutUint16(buf[0:], peDOSMagic)
+	binary.LittleEndian.PutUint32(buf[peHeaderOffset:], uint32(peOffset))
+
+	// PE header: "PE\0\0" + machine (start of IMAGE_FILE_HEADER).
+	binary.LittleEndian.PutUint32(buf[peOffset:], peSignature)
+	binary.LittleEndian.PutUint16(buf[peOffset+4:], machine)
+
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func currentArchMachine(t *testing.T) uint16 {
+	t.Helper()
+	switch runtime.GOARCH {
+	case "amd64":
+		return peMachineAMD64
+	case "arm64":
+		return peMachineARM64
+	case "386":
+		return peMachineI386
+	default:
+		t.Skipf("no PE fixture machine for GOARCH=%s", runtime.GOARCH)
+		return 0
+	}
+}
+
+func TestValidatePE_Valid(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PE validation is Windows-only; the helper lives under _windows.go build tag")
+	}
+	path := buildPEFixture(t, currentArchMachine(t))
+	if err := validateBinaryFormat(path); err != nil {
+		t.Fatalf("expected valid PE to pass, got %v", err)
+	}
+}
+
+func TestValidatePE_BadMZ(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PE validation is Windows-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.exe")
+	// Two zero bytes at position 0 — not MZ.
+	if err := os.WriteFile(path, []byte{0, 0, 0, 0, 0, 0}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := validateBinaryFormat(path); err == nil {
+		t.Fatal("expected error for non-MZ file")
+	}
+}
+
+func TestValidatePE_WrongMachine(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PE validation is Windows-only")
+	}
+	// Pick a different machine than the runtime arch to force a mismatch.
+	wrong := uint16(peMachineI386)
+	if runtime.GOARCH == "386" {
+		wrong = peMachineAMD64
+	}
+	path := buildPEFixture(t, wrong)
+	if err := validateBinaryFormat(path); err == nil {
+		t.Fatal("expected machine-mismatch error")
+	}
+}
+
+func TestValidatePE_BadOffset(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PE validation is Windows-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.exe")
+	// Valid MZ but e_lfanew points way out of file.
+	buf := make([]byte, peHeaderOffset+4)
+	binary.LittleEndian.PutUint16(buf[0:], peDOSMagic)
+	binary.LittleEndian.PutUint32(buf[peHeaderOffset:], uint32(peMaxHeaderSeek+1))
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := validateBinaryFormat(path); err == nil {
+		t.Fatal("expected error for out-of-range PE header offset")
+	}
+}

--- a/pkg/updater/replace_unix.go
+++ b/pkg/updater/replace_unix.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+func replaceBinary(newPath, currentPath string) error {
+	info, err := os.Stat(currentPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat current binary: %w", err)
+	}
+
+	// Backup current binary for rollback on failure.
+	backupPath := currentPath + ".bak"
+	if err := copyFile(currentPath, backupPath, info.Mode()); err != nil {
+		return fmt.Errorf("failed to backup current binary: %w", err)
+	}
+
+	// Stage new binary next to current (same filesystem for atomic rename).
+	// Create with 0600 first, then chmod to match current binary (immune to
+	// umask).
+	stagePath := currentPath + ".new"
+	if err := copyFile(newPath, stagePath, 0600); err != nil {
+		return fmt.Errorf("failed to stage new binary: %w", err)
+	}
+	defer func() { _ = os.Remove(stagePath) }()
+
+	if err := os.Chmod(stagePath, info.Mode()); err != nil {
+		return fmt.Errorf("failed to set permissions on staged binary: %w", err)
+	}
+
+	// Atomic replace. Unix allows renaming over a running executable
+	// because file lookups use inodes, not paths.
+	if err := os.Rename(stagePath, currentPath); err != nil {
+		return fmt.Errorf("failed to rename binary: %w", err)
+	}
+
+	_ = os.Remove(backupPath)
+	log.Debug().Msg("Binary replaced successfully, backup removed.")
+	return nil
+}

--- a/pkg/updater/replace_windows.go
+++ b/pkg/updater/replace_windows.go
@@ -1,0 +1,87 @@
+package updater
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
+)
+
+// Windows cannot overwrite a running .exe via os.Rename because the
+// file is locked while the process holds it open. The standard self-
+// update trick is to rename the current binary to a sibling ".old"
+// path first (Windows does allow renaming a running binary) and then
+// drop the new binary in its place. The .old file is cleaned up on
+// the next restart via CleanupStaleOld; if the process is killed
+// before that, MOVEFILE_DELAY_UNTIL_REBOOT is used as a backstop so
+// reboot eventually removes it.
+func replaceBinary(newPath, currentPath string) error {
+	info, err := os.Stat(currentPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat current binary: %w", err)
+	}
+
+	// Stage the new binary next to the current one so the final step
+	// is a rename on the same volume.
+	stagePath := currentPath + ".new"
+	if err := copyFile(newPath, stagePath, info.Mode()); err != nil {
+		return fmt.Errorf("failed to stage new binary: %w", err)
+	}
+	defer func() { _ = os.Remove(stagePath) }()
+
+	// 1. Move the currently-running binary out of the way.
+	oldPath := currentPath + ".old"
+	// Best-effort remove any stale .old from a prior update; if the
+	// old one is still locked, MoveFileEx with REPLACE_EXISTING
+	// below will fail and we'll surface a clear error.
+	_ = os.Remove(oldPath)
+	if err := moveFileEx(currentPath, oldPath, windows.MOVEFILE_REPLACE_EXISTING); err != nil {
+		return fmt.Errorf("failed to move running binary aside: %w", err)
+	}
+
+	// 2. Put the new binary in place.
+	if err := moveFileEx(stagePath, currentPath, windows.MOVEFILE_REPLACE_EXISTING); err != nil {
+		// Roll back: put the old binary back under its original name.
+		// A stale partial file at currentPath may still be present
+		// (e.g., AV held it open); try to remove before the rename so
+		// we don't fight the same sharing violation twice.
+		_ = os.Remove(currentPath)
+		if rbErr := moveFileEx(oldPath, currentPath, windows.MOVEFILE_REPLACE_EXISTING); rbErr != nil {
+			return fmt.Errorf("failed to install new binary (%v) and rollback failed (%v); manual recovery: rename %s back to %s", err, rbErr, oldPath, currentPath)
+		}
+		return fmt.Errorf("failed to install new binary: %w", err)
+	}
+
+	// 3. Schedule the .old file for removal on next reboot as a
+	// backstop in case the startup cleanup never runs.
+	if err := moveFileEx(oldPath, "", windows.MOVEFILE_DELAY_UNTIL_REBOOT); err != nil {
+		log.Warn().Err(err).Str("path", oldPath).
+			Msg("Could not schedule delete-on-reboot for the old binary; it will be cleaned up on next alpamon start.")
+	}
+
+	log.Debug().Str("old", oldPath).Msg("Windows binary replaced; old exe will be cleaned up later.")
+	return nil
+}
+
+// moveFileEx wraps the Windows MoveFileExW syscall.
+// If newPath is empty, the Windows API uses a NULL pointer, which
+// combined with MOVEFILE_DELAY_UNTIL_REBOOT schedules oldPath for
+// deletion on reboot.
+func moveFileEx(oldPath, newPath string, flags uint32) error {
+	oldPtr, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	var newPtr *uint16
+	if newPath != "" {
+		newPtr, err = windows.UTF16PtrFromString(newPath)
+		if err != nil {
+			return err
+		}
+	}
+	if err := windows.MoveFileEx(oldPtr, newPtr, flags); err != nil {
+		return fmt.Errorf("MoveFileEx(%q, %q, 0x%x): %w", oldPath, newPath, flags, err)
+	}
+	return nil
+}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -51,6 +51,11 @@ func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 		return fmt.Errorf("invalid version format: %q", latestVersion)
 	}
 
+	// On Windows, clear any ".old" binary left behind by a prior update
+	// before we stage a new one, otherwise MoveFileEx will collide.
+	// No-op on Unix.
+	CleanupStaleOld()
+
 	log.Info().Str("version", latestVersion).Msg("Starting self-update.")
 
 	currentPath, err := os.Executable()
@@ -115,6 +120,14 @@ func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 func archiveFilename(version string) string {
 	v := strings.TrimPrefix(version, "v")
 	return fmt.Sprintf("%s-%s-%s-%s.tar.gz", binaryName, v, runtime.GOOS, runtime.GOARCH)
+}
+
+// isAlpamonBinary reports whether the tar entry name refers to the
+// alpamon executable, allowing for the ".exe" suffix that goreleaser
+// appends on Windows.
+func isAlpamonBinary(name string) bool {
+	base := filepath.Base(name)
+	return base == binaryName || base == binaryName+".exe"
 }
 
 func checksumURL(baseURL, version string) string {
@@ -252,8 +265,9 @@ func extractBinary(archivePath, destPath string) error {
 			return fmt.Errorf("archive contains too many entries (max %d)", maxTarEntries)
 		}
 
-		// Look for the alpamon binary (may be at root or in a subdirectory)
-		if filepath.Base(hdr.Name) == binaryName && hdr.Typeflag == tar.TypeReg {
+		// Look for the alpamon binary (may be at root or in a subdirectory).
+		// goreleaser appends ".exe" on Windows.
+		if isAlpamonBinary(hdr.Name) && hdr.Typeflag == tar.TypeReg {
 			if hdr.Size > maxExtractSize {
 				return fmt.Errorf("binary size %d exceeds maximum allowed %d bytes", hdr.Size, maxExtractSize)
 			}
@@ -282,37 +296,10 @@ func extractBinary(archivePath, destPath string) error {
 	return fmt.Errorf("binary %q not found in archive", binaryName)
 }
 
-// validateBinaryFormat checks that the extracted file is a valid executable
-// for the current platform by inspecting magic bytes. This avoids executing
-// an unverified binary.
-func validateBinaryFormat(binaryPath string) error {
-	f, err := os.Open(binaryPath)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	magic := make([]byte, 4)
-	if _, err := io.ReadFull(f, magic); err != nil {
-		return fmt.Errorf("failed to read binary header: %w", err)
-	}
-
-	switch runtime.GOOS {
-	case "darwin":
-		// Mach-O: 0xFEEDFACE (32-bit), 0xFEEDFACF (64-bit), 0xCAFEBABE (universal)
-		if !isMachO(magic) {
-			return fmt.Errorf("not a valid Mach-O binary (magic: %x)", magic)
-		}
-	case "linux":
-		// ELF: 0x7F 'E' 'L' 'F'
-		if magic[0] != 0x7f || magic[1] != 'E' || magic[2] != 'L' || magic[3] != 'F' {
-			return fmt.Errorf("not a valid ELF binary (magic: %x)", magic)
-		}
-	default:
-		return fmt.Errorf("binary format validation not supported on platform %q", runtime.GOOS)
-	}
-
-	return nil
+// readFull is a thin wrapper so platform-specific format validators
+// can read magic bytes without each re-implementing the loop.
+func readFull(r io.Reader, buf []byte) (int, error) {
+	return io.ReadFull(r, buf)
 }
 
 // machoMagics contains all recognized Mach-O magic byte sequences.
@@ -338,41 +325,6 @@ func isMachO(magic []byte) bool {
 		}
 	}
 	return false
-}
-
-func replaceBinary(newPath, currentPath string) error {
-	info, err := os.Stat(currentPath)
-	if err != nil {
-		return fmt.Errorf("failed to stat current binary: %w", err)
-	}
-
-	// Backup current binary for rollback on failure
-	backupPath := currentPath + ".bak"
-	if err := copyFile(currentPath, backupPath, info.Mode()); err != nil {
-		return fmt.Errorf("failed to backup current binary: %w", err)
-	}
-
-	// Stage new binary next to current (same filesystem for atomic rename).
-	// Create with 0600 first, then chmod to match current binary (immune to umask).
-	stagePath := currentPath + ".new"
-	if err := copyFile(newPath, stagePath, 0600); err != nil {
-		return fmt.Errorf("failed to stage new binary: %w", err)
-	}
-	defer func() { _ = os.Remove(stagePath) }()
-
-	if err := os.Chmod(stagePath, info.Mode()); err != nil {
-		return fmt.Errorf("failed to set permissions on staged binary: %w", err)
-	}
-
-	// Atomic replace
-	if err := os.Rename(stagePath, currentPath); err != nil {
-		return fmt.Errorf("failed to rename binary: %w", err)
-	}
-
-	// Replace succeeded — remove backup
-	_ = os.Remove(backupPath)
-	log.Debug().Msg("Binary replaced successfully, backup removed.")
-	return nil
 }
 
 // copyFile copies src to dst with the given permissions.

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -20,6 +20,14 @@ import (
 // createTestArchive creates a tar.gz archive containing a fake alpamon binary.
 func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 	t.Helper()
+	return createTestArchiveNamed(t, binaryName, binaryContent)
+}
+
+// createTestArchiveNamed creates a tar.gz archive containing a single
+// file with the given name. Used to test both Unix-style "alpamon"
+// and Windows-style "alpamon.exe" archive entries.
+func createTestArchiveNamed(t *testing.T, entryName string, binaryContent []byte) []byte {
+	t.Helper()
 	tmpFile, err := os.CreateTemp("", "test-archive-*.tar.gz")
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +41,7 @@ func createTestArchive(t *testing.T, binaryContent []byte) []byte {
 	tw := tar.NewWriter(gw)
 
 	hdr := &tar.Header{
-		Name: binaryName,
+		Name: entryName,
 		Mode: 0755,
 		Size: int64(len(binaryContent)),
 	}
@@ -198,6 +206,33 @@ func TestExtractBinary(t *testing.T) {
 	}
 	if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
 		t.Error("extracted binary should be executable")
+	}
+}
+
+func TestExtractBinary_WindowsExe(t *testing.T) {
+	// goreleaser appends ".exe" to the binary name on Windows; the
+	// extractor must recognise that entry too. Regression guard for
+	// isAlpamonBinary.
+	binaryContent := []byte("fake pe binary")
+	archive := createTestArchiveNamed(t, "alpamon.exe", binaryContent)
+
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.gz")
+	if err := os.WriteFile(archivePath, archive, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	destPath := filepath.Join(tempDir, "extracted")
+	if err := extractBinary(archivePath, destPath); err != nil {
+		t.Fatalf("extractBinary() error on alpamon.exe entry: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(binaryContent) {
+		t.Errorf("extracted content = %q, want %q", got, binaryContent)
 	}
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,11 +4,12 @@
 
 .DESCRIPTION
     Downloads the latest Alpamon release, verifies its SHA-256
-    checksum against the publisher-signed checksums manifest, extracts
-    alpamon.exe, and runs `alpamon register`. The register command
-    copies the binary to %ProgramFiles%\alpamon\ and creates a Windows
-    Service. Intended for cloud-init, Packer, EC2 UserData, and Azure
-    Custom Script Extension.
+    checksum against the checksums file published alongside the
+    release (transport is HTTPS; signature verification is not yet
+    implemented), extracts alpamon.exe, and runs `alpamon register`.
+    The register command copies the binary to %ProgramFiles%\alpamon\
+    and creates a Windows Service. Intended for cloud-init, Packer,
+    EC2 UserData, and Azure Custom Script Extension.
 
     Parameters can be provided on the command line or via environment
     variables (ALPAMON_URL, ALPAMON_TOKEN, ALPAMON_NAME,
@@ -46,9 +47,9 @@
     & powershell -ExecutionPolicy Bypass -File $installer
 
 .EXAMPLE
-    # Terse form, trades auditability for brevity. The script itself
-    # still verifies the downloaded release archive against the
-    # publisher-signed checksums file.
+    # Terse form, trades auditability for brevity. The script still
+    # verifies the downloaded release archive against the checksums
+    # file published alongside the release.
     $env:ALPAMON_URL   = "https://alpacon.example.com"
     $env:ALPAMON_TOKEN = "<TOKEN>"
     Invoke-WebRequest -UseBasicParsing `
@@ -107,10 +108,11 @@ try {
     Write-Host "Downloading $checksumsUrl ..."
     Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath -UseBasicParsing
 
-    # Verify the archive against the publisher-signed checksums file
-    # before we extract and execute anything from it. This mirrors the
-    # agent's built-in self-updater and is what protects a pipe-to-iex
-    # install path from a tampered release asset.
+    # Verify the archive against the checksums file published with
+    # the release, before we extract and execute anything from it.
+    # Transport is HTTPS; signature verification of the checksums
+    # file itself is not yet implemented (see updater.go TODO). This
+    # mirrors the agent's built-in self-updater.
     $expectedLine = Get-Content $checksumsPath | Where-Object {
         $parts = $_ -split '\s+', 2
         $parts.Length -eq 2 -and $parts[1].Trim() -eq $archiveName

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,11 +3,12 @@
     Install the Alpamon agent on Windows.
 
 .DESCRIPTION
-    Downloads the latest Alpamon release, extracts alpamon.exe to a
-    temporary directory, and runs `alpamon register`. The register
-    command copies the binary to %ProgramFiles%\alpamon\ and creates
-    a Windows Service. Intended for cloud-init, Packer, EC2 UserData,
-    and Azure Custom Script Extension.
+    Downloads the latest Alpamon release, verifies its SHA-256
+    checksum against the publisher-signed checksums manifest, extracts
+    alpamon.exe, and runs `alpamon register`. The register command
+    copies the binary to %ProgramFiles%\alpamon\ and creates a Windows
+    Service. Intended for cloud-init, Packer, EC2 UserData, and Azure
+    Custom Script Extension.
 
     Parameters can be provided on the command line or via environment
     variables (ALPAMON_URL, ALPAMON_TOKEN, ALPAMON_NAME,
@@ -23,15 +24,31 @@
     Server name. Defaults to the machine hostname.
 
 .PARAMETER Version
-    Specific release tag to install (e.g., "v1.2.3"). Defaults to the
-    latest release.
+    Specific release tag to install (e.g., "v1.2.3" or "1.2.3").
+    Defaults to the latest release. A leading "v" is added if missing.
 
 .EXAMPLE
     # Interactive install.
     .\install.ps1 -Url https://alpacon.example.com -Token <TOKEN>
 
 .EXAMPLE
-    # cloud-init / UserData style.
+    # cloud-init / UserData. Preferred form: download and run the
+    # script from a file rather than piping into Invoke-Expression.
+    # This keeps the installer auditable on the target machine and
+    # avoids running arbitrary remote content under Administrator
+    # if the delivery URL is ever tampered with.
+    $env:ALPAMON_URL   = "https://alpacon.example.com"
+    $env:ALPAMON_TOKEN = "<TOKEN>"
+    $installer = Join-Path $env:TEMP 'alpamon-install.ps1'
+    Invoke-WebRequest -UseBasicParsing `
+        -Uri 'https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1' `
+        -OutFile $installer
+    & powershell -ExecutionPolicy Bypass -File $installer
+
+.EXAMPLE
+    # Terse form, trades auditability for brevity. The script itself
+    # still verifies the downloaded release archive against the
+    # publisher-signed checksums file.
     $env:ALPAMON_URL   = "https://alpacon.example.com"
     $env:ALPAMON_TOKEN = "<TOKEN>"
     Invoke-WebRequest -UseBasicParsing `
@@ -64,19 +81,49 @@ if (-not $Version) {
         "https://api.github.com/repos/alpacax/alpamon/releases/latest"
     $Version = $latest.tag_name
 }
+# Accept both "v1.2.3" and "1.2.3"; GitHub release tags use the "v"
+# prefix so we need it on the download URL path.
+if (-not $Version.StartsWith("v")) {
+    $Version = "v$Version"
+}
 $versionBare = $Version.TrimStart("v")
 
 $arch = "amd64"
-$archiveName = "alpamon-$versionBare-windows-$arch.tar.gz"
-$archiveUrl  = "https://github.com/alpacax/alpamon/releases/download/$Version/$archiveName"
+$archiveName   = "alpamon-$versionBare-windows-$arch.tar.gz"
+$checksumsName = "alpamon-$versionBare-checksums.sha256"
+$archiveUrl    = "https://github.com/alpacax/alpamon/releases/download/$Version/$archiveName"
+$checksumsUrl  = "https://github.com/alpacax/alpamon/releases/download/$Version/$checksumsName"
 
 $tempDir = Join-Path $env:TEMP ("alpamon-install-" + [System.Guid]::NewGuid().ToString().Substring(0, 8))
 New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
 try {
-    $archivePath = Join-Path $tempDir "alpamon.tar.gz"
+    $archivePath   = Join-Path $tempDir "alpamon.tar.gz"
+    $checksumsPath = Join-Path $tempDir $checksumsName
+
     Write-Host "Downloading $archiveUrl ..."
     Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+
+    Write-Host "Downloading $checksumsUrl ..."
+    Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath -UseBasicParsing
+
+    # Verify the archive against the publisher-signed checksums file
+    # before we extract and execute anything from it. This mirrors the
+    # agent's built-in self-updater and is what protects a pipe-to-iex
+    # install path from a tampered release asset.
+    $expectedLine = Get-Content $checksumsPath | Where-Object {
+        $parts = $_ -split '\s+', 2
+        $parts.Length -eq 2 -and $parts[1].Trim() -eq $archiveName
+    } | Select-Object -First 1
+    if (-not $expectedLine) {
+        throw "Checksum for $archiveName not found in $checksumsName."
+    }
+    $expectedHash = ($expectedLine -split '\s+', 2)[0].Trim()
+    $actualHash   = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash
+    if ($actualHash.ToLower() -ne $expectedHash.ToLower()) {
+        throw "SHA-256 mismatch for ${archiveName}: expected $expectedHash, got $actualHash."
+    }
+    Write-Host "Checksum verified."
 
     Write-Host "Extracting..."
     # tar.exe has shipped with Windows since 10 1803 / Server 2019.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Install the Alpamon agent on Windows.
+
+.DESCRIPTION
+    Downloads the latest Alpamon release, extracts alpamon.exe to a
+    temporary directory, and runs `alpamon register`. The register
+    command copies the binary to %ProgramFiles%\alpamon\ and creates
+    a Windows Service. Intended for cloud-init, Packer, EC2 UserData,
+    and Azure Custom Script Extension.
+
+    Parameters can be provided on the command line or via environment
+    variables (ALPAMON_URL, ALPAMON_TOKEN, ALPAMON_NAME,
+    ALPAMON_VERSION).
+
+.PARAMETER Url
+    Alpacon console URL. Required.
+
+.PARAMETER Token
+    Registration token with the servers:register scope. Required.
+
+.PARAMETER Name
+    Server name. Defaults to the machine hostname.
+
+.PARAMETER Version
+    Specific release tag to install (e.g., "v1.2.3"). Defaults to the
+    latest release.
+
+.EXAMPLE
+    # Interactive install.
+    .\install.ps1 -Url https://alpacon.example.com -Token <TOKEN>
+
+.EXAMPLE
+    # cloud-init / UserData style.
+    $env:ALPAMON_URL   = "https://alpacon.example.com"
+    $env:ALPAMON_TOKEN = "<TOKEN>"
+    Invoke-WebRequest -UseBasicParsing `
+        https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 `
+        | Invoke-Expression
+#>
+[CmdletBinding()]
+param(
+    [string]$Url     = $env:ALPAMON_URL,
+    [string]$Token   = $env:ALPAMON_TOKEN,
+    [string]$Name    = $env:ALPAMON_NAME,
+    [string]$Version = $env:ALPAMON_VERSION
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $Url -or -not $Token) {
+    throw "Url and Token are required (pass as parameters or set ALPAMON_URL / ALPAMON_TOKEN)."
+}
+
+$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    throw "install.ps1 must be run from an elevated (Administrator) PowerShell."
+}
+
+if (-not $Version) {
+    Write-Host "Resolving latest Alpamon release..."
+    $latest  = Invoke-RestMethod -UseBasicParsing `
+        "https://api.github.com/repos/alpacax/alpamon/releases/latest"
+    $Version = $latest.tag_name
+}
+$versionBare = $Version.TrimStart("v")
+
+$arch = "amd64"
+$archiveName = "alpamon-$versionBare-windows-$arch.tar.gz"
+$archiveUrl  = "https://github.com/alpacax/alpamon/releases/download/$Version/$archiveName"
+
+$tempDir = Join-Path $env:TEMP ("alpamon-install-" + [System.Guid]::NewGuid().ToString().Substring(0, 8))
+New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+
+try {
+    $archivePath = Join-Path $tempDir "alpamon.tar.gz"
+    Write-Host "Downloading $archiveUrl ..."
+    Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+
+    Write-Host "Extracting..."
+    # tar.exe has shipped with Windows since 10 1803 / Server 2019.
+    & tar.exe -xzf $archivePath -C $tempDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "tar extraction failed (exit code $LASTEXITCODE). Windows 10 1803 / Server 2019 or newer required."
+    }
+
+    $exePath = Join-Path $tempDir "alpamon.exe"
+    if (-not (Test-Path $exePath)) {
+        throw "alpamon.exe not found in the extracted archive."
+    }
+
+    $registerArgs = @("register", "--url", $Url, "--token", $Token)
+    if ($Name) { $registerArgs += @("--name", $Name) }
+
+    Write-Host "Running alpamon register (installs to Program Files and starts the service)..."
+    & $exePath @registerArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "alpamon register failed with exit code $LASTEXITCODE."
+    }
+
+    Write-Host ""
+    Write-Host "Alpamon installed and registered."
+}
+finally {
+    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Completes the Windows support initiative (#255) by wiring the two remaining gaps identified after the initial Windows PRs (#276, #278) merged. Follow-up bug fixes only; no user-facing protocol changes.

### 1. Windows Service wrapper

Before this PR, \`alpamon register\` on Windows just printed \`sc.exe create alpamon binPath= \"...\"\` instructions. There was no \`svc.Handler\` so alpamon did not respond to SCM Stop / Shutdown / Interrogate events.

- \`cmd/alpamon/command/svc_windows.go\` — \`svc.Handler.Execute\` maps SCM events to the existing \`ContextManager.Shutdown()\` path. \`svc.IsWindowsService()\` in \`RootCmd.Run\` branches between SCM-managed and interactive launches.
- \`cmd/alpamon/command/svc_other.go\` — Unix stubs so \`root.go\` stays platform-agnostic.
- \`runAgent\` now accepts a \`ready\` channel that closes once the shutdown hook is installed. The svc handler waits for it before reporting \`Running\` so SCM cannot deliver a \`Stop\` we'd be unable to honor. A \`pendingShutdown\` flag also covers the pre-install race.
- \`register/service_windows.go\` — replaces the \`sc.exe\` hint with \`mgr.Connect\` → \`OpenService\` / \`CreateService\` (\`StartAutomatic\`, \`DelayedAutoStart\`, Recovery Actions: two 5s restarts then no-action). Surfaces an elevation hint on \`ERROR_ACCESS_DENIED\`.
- \`platform_windows.go\` — \`restartAgent\` exits with status 1 under SCM so Recovery Actions pick up the newly-installed binary. \`os.Exit(0)\` would leave the service stopped.

### 2. Self-update on Windows

Before this PR, \`updater.SelfUpdate\` failed on Windows at \`validateBinaryFormat\` (no PE case) and would have failed again at \`replaceBinary\` because \`os.Rename\` cannot overwrite a running \`.exe\`.

- \`pkg/updater/format_windows.go\` — PE/COFF validator. Checks MZ magic, e_lfanew bounds, PE signature, and matches \`IMAGE_FILE_HEADER.Machine\` against \`runtime.GOARCH\`. Mach-O / ELF logic moved verbatim to \`format_unix.go\`.
- \`pkg/updater/replace_windows.go\` — Windows self-update dance via \`MoveFileEx\`:
  1. Stage new binary next to current (same volume for atomic rename)
  2. \`MoveFileEx(current, current+\".old\", MOVEFILE_REPLACE_EXISTING)\` — Windows allows renaming a running binary
  3. \`MoveFileEx(staged, current, MOVEFILE_REPLACE_EXISTING)\` — install the new binary
  4. \`MoveFileEx(.old, \"\", MOVEFILE_DELAY_UNTIL_REBOOT)\` — backstop cleanup
  
  Rollback path removes a lingering partial file before retry so a sharing violation (e.g., AV scanning the staged file) can't deadlock recovery.
- \`pkg/updater/cleanup_windows.go\` — \`CleanupStaleOld()\` removes \`alpamon.exe.old\` at process startup and at \`SelfUpdate\` entry. Unix stub is a no-op.
- \`updater.go\` — archive extractor now recognizes \`alpamon.exe\` in addition to \`alpamon\`, since GoReleaser appends \`.exe\` on Windows.

### 3. Release

- \`.goreleaser.yaml\` — force \`tar.gz\` archive format on all platforms, including Windows. GoReleaser defaults to \`.zip\` on Windows, which would break the self-updater's hardcoded \`.tar.gz\` URL. **This is the release-blocker that made Windows self-update non-functional even before the updater code fix.**

## Review history

\`implementation-reviewer\` caught:
1. **CRITICAL** — GoReleaser Windows archive format (fixed via \`formats: [tar.gz]\`)
2. **HIGH** — SCM Stop-before-ready race (fixed via \`ready\` channel + \`pendingShutdown\` flag)
3. **HIGH** — \`replaceBinary\` rollback could hit the same sharing violation (fixed by removing currentPath before rollback)
4. **HIGH** — \`mgr.Connect\` ACCESS_DENIED was opaque (fixed with elevation hint)
5. **MEDIUM** — gofmt, PE machine matching comment, fallback logging, peOffset signedness (all addressed)
6. **LOW** — \`restartAgent\` SCM-without-recovery warning (added explicit log)

## Tests

- \`pkg/updater/format_windows_test.go\` — PE validator with synthetic fixtures (valid, bad MZ, wrong machine, bad offset). Build-tagged for Windows.
- Existing Mach-O test (\`TestIsMachO\`) still runs on darwin/linux.
- Cross-compile clean: \`go build\`, \`go vet\` pass on darwin/linux/windows.

## Test plan

Cross-compile verification already done. Manual Windows VM:

- [ ] Fresh \`alpamon register\` creates service, service starts
- [ ] \`sc.exe query alpamon\` shows Running, StartType=Auto Delayed
- [ ] \`net stop alpamon\` → graceful shutdown, PID file removed, ftp/tunnel sessions closed
- [ ] Kill \`alpamon.exe\` → Recovery Actions restart within 5s
- [ ] System reboot → service starts after login (DelayedAutoStart)
- [ ] Run \`alpamon.exe\` from PowerShell → foreground mode, Ctrl-C shuts down
- [ ] Self-update while running as service → new binary active after Recovery-restart, \`.old\` cleaned on next startup
- [ ] Self-update while running interactively → \`restartAgent\` spawns child and exits 0
- [ ] Reboot after an update → any leftover \`.old\` gone (MOVEFILE_DELAY_UNTIL_REBOOT)
- [ ] \`alpamon register\` from non-elevated prompt → clear \"run as Administrator\" hint

## Out of scope (follow-up)

- Windows code signing (Authenticode)
- MSI / Chocolatey / winget packaging
- GPG/cosign release signature verification (tracked in \`updater.go:89\` TODO)
- Event Log integration
- Non-admin per-user service install
- SCM preshutdown timeout tuning

## References

- alpamon #255 (Windows support tracking)
- alpamon #276 (initial Windows support)
- alpamon #278 (WebFTP path handling + containment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)