### PR TITLE
fix(windows): detect shell exit in ConPTY Websh sessions

### DIFF
--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -90,7 +90,7 @@ func (pc *PtyClient) RunPtyBackground() {
 // waitForChildExit cancels the session when the shell inside the
 // ConPTY exits (e.g. the user types `exit` in PowerShell). ConPTY's
 // output pipe stays open across the child exit, so Read() alone does
-// not notice — without this the websocket would linger until the
+// not notice—without this the websocket would linger until the
 // client disconnects or idle-timeouts elsewhere fire. conpty.Wait
 // polls WaitForSingleObject on the child process handle.
 func (pc *PtyClient) waitForChildExit(ctx context.Context, cancel context.CancelFunc) {
@@ -282,7 +282,7 @@ func (pc *PtyClient) close() {
 		// Emit CloseNormalClosure on our end so the web client
 		// treats a clean shell exit like a Unix bash exit rather
 		// than an abnormal disconnect. sessionCloseCode (4000) is
-		// still recognised in IsCloseError filters so a peer that
+		// still recognized in IsCloseError filters so a peer that
 		// happens to send it is accepted silently.
 		_ = pc.conn.WriteControl(
 			websocket.CloseMessage,

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -106,7 +106,9 @@ func (pc *PtyClient) waitForChildExit(ctx context.Context, cancel context.Cancel
 	if err != nil {
 		log.Debug().Err(err).Str("sessionID", pc.sessionID).Msg("ConPTY wait returned an error.")
 	} else {
-		log.Info().Uint32("exitCode", exitCode).Str("sessionID", pc.sessionID).
+		// Debug level: Websh sessions end frequently and a clean
+		// shell exit is the expected termination path.
+		log.Debug().Uint32("exitCode", exitCode).Str("sessionID", pc.sessionID).
 			Msg("ConPTY child shell exited; closing Websh session.")
 	}
 	cancel()
@@ -277,9 +279,14 @@ func (pc *PtyClient) close() {
 		_ = pc.cpty.Close()
 	}
 	if pc.conn != nil {
+		// Emit CloseNormalClosure on our end so the web client
+		// treats a clean shell exit like a Unix bash exit rather
+		// than an abnormal disconnect. sessionCloseCode (4000) is
+		// still recognised in IsCloseError filters so a peer that
+		// happens to send it is accepted silently.
 		_ = pc.conn.WriteControl(
 			websocket.CloseMessage,
-			websocket.FormatCloseMessage(sessionCloseCode, ""),
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 			time.Now().Add(5*time.Second),
 		)
 		_ = pc.conn.Close()

--- a/pkg/runner/pty_windows.go
+++ b/pkg/runner/pty_windows.go
@@ -82,8 +82,34 @@ func (pc *PtyClient) RunPtyBackground() {
 	go pc.writeToWebsocket(ctx, cancel)
 	go pc.readFromWebsocket(ctx, cancel)
 	go pc.writeToPty(ctx, cancel)
+	go pc.waitForChildExit(ctx, cancel)
 
 	<-ctx.Done()
+}
+
+// waitForChildExit cancels the session when the shell inside the
+// ConPTY exits (e.g. the user types `exit` in PowerShell). ConPTY's
+// output pipe stays open across the child exit, so Read() alone does
+// not notice — without this the websocket would linger until the
+// client disconnects or idle-timeouts elsewhere fire. conpty.Wait
+// polls WaitForSingleObject on the child process handle.
+func (pc *PtyClient) waitForChildExit(ctx context.Context, cancel context.CancelFunc) {
+	if pc.cpty == nil {
+		return
+	}
+	exitCode, err := pc.cpty.Wait(ctx)
+	if ctx.Err() != nil {
+		// Context was already canceled by another goroutine (read
+		// error, websocket close, etc.). Nothing to do.
+		return
+	}
+	if err != nil {
+		log.Debug().Err(err).Str("sessionID", pc.sessionID).Msg("ConPTY wait returned an error.")
+	} else {
+		log.Info().Uint32("exitCode", exitCode).Str("sessionID", pc.sessionID).
+			Msg("ConPTY child shell exited; closing Websh session.")
+	}
+	cancel()
 }
 
 func (pc *PtyClient) initializeSession() error {


### PR DESCRIPTION
## Summary

Typing \`exit\` in a PowerShell Websh session on Windows did not close the websocket — the browser terminal sat idle until the client disconnected or another side killed the session.

**Root cause**: On Unix the PTY master returns EOF when bash exits; \`readFromPty\` sees the error, cancels the session, and \`defer pc.close()\` tears everything down. Windows ConPTY does not work the same way — the output pipe stays open across the child exit, so \`conpty.Read()\` keeps blocking forever and the session never notices the shell is gone.

## Fix

Add a \`waitForChildExit\` goroutine that calls \`cpty.Wait(ctx)\`. The conpty library's \`Wait\` polls \`WaitForSingleObject\` on the child process handle (see \`github.com/UserExistsError/conpty/conpty.go:252\`) and returns when PowerShell / cmd.exe actually exits. On return it cancels the session context, driving the existing cleanup path:

1. Other I/O goroutines unwind on \`ctx.Done()\`
2. \`defer pc.close()\` tears down the websocket and ConPTY handles
3. Client sees the websocket close — same UX as Linux

No changes to the Unix path.

## Test plan

- [ ] Open Websh to a Windows server → PowerShell prompt
- [ ] Type \`exit\`
- [ ] Expect: browser terminal closes the session, alpamon log shows \`ConPTY child shell exited; closing Websh session.\`
- [ ] Repeat with \`cmd.exe\` if available
- [ ] Regression: Linux Websh still behaves normally — \`exit\` in bash closes session as before

## References

- alpamon #276 (initial Windows support — Websh with ConPTY)
- alpamon #279 (Windows Service + updater follow-ups)