### PR TITLE
feat: make alpamon-pam a default install dependency

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,7 +98,7 @@ nfpms:
           - sqlite3
           - nftables | iptables
         file_name_template: '{{ .PackageName }}_{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}'
-        suggests:
+        recommends:
           - alpamon-pam
       rpm:
         dependencies:
@@ -106,7 +106,7 @@ nfpms:
           - sqlite
           - nftables | iptables
         file_name_template: '{{ .PackageName }}-{{ trimprefix .Version "v" }}-1.{{ .Os }}.{{ .Arch }}'
-        suggests:
+        recommends:
           - alpamon-pam
       
 brews:


### PR DESCRIPTION
## Summary
- Change `alpamon-pam` from `suggests` to `recommends` in `.goreleaser.yaml` for both deb and rpm packages
- `alpamon-pam` now installs by default alongside alpamon
- Users can still opt out with `--no-install-recommends` (apt) or equivalent (dnf/yum)

## Test plan
- [ ] Verify goreleaser config is valid (`goreleaser check`)
- [ ] Build deb package and confirm `alpamon-pam` appears in `Recommends` field
- [ ] Build rpm package and confirm `alpamon-pam` appears as a weak dependency
- [ ] Test `apt install alpamon` installs `alpamon-pam` by default
- [ ] Test `apt install --no-install-recommends alpamon` skips `alpamon-pam`