### PR TITLE
ci,release,docs: windows-latest CI, publish windows release assets with stable-name alias, and lifecycle runbook

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -160,7 +160,7 @@ jobs:
       # construction (user/group handlers not registered on Windows,
       # Unix shell path contracts, Unix file-mode assertions) are gated
       # with //go:build !windows or per-test runtime.GOOS skips; no
-      # silent blanket skip. See alpamon Issue #1 acceptance criteria.
+      # silent blanket skip. See alpamon issue #284 acceptance criteria.
       - name: Run Tests
         run: go test -v ./... -p 1
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -156,8 +156,30 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Run Windows-safe tests
-        run: go test -v ./pkg/config/ ./pkg/executor/ ./pkg/updater/ ./internal/... -p 1
+      # Run the full suite on Windows. Packages that are Unix-only by
+      # construction (user/group handlers not registered on Windows,
+      # Unix shell path contracts, Unix file-mode assertions) are gated
+      # with //go:build !windows or per-test runtime.GOOS skips; no
+      # silent blanket skip. See alpamon Issue #1 acceptance criteria.
+      - name: Run Tests
+        run: go test -v ./... -p 1
+
+      # `--version` should print the version and exit 0 regardless of
+      # whether Alpamon is registered. Guards against regressions that
+      # would stall startup (e.g., trying to read config, hitting SCM).
+      - name: Smoke test (--version)
+        shell: pwsh
+        run: |
+          $exe = Join-Path $PWD 'cmd\alpamon\alpamon.exe'
+          if (-not (Test-Path $exe)) { throw "alpamon.exe not found at $exe" }
+          $output = & $exe --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "alpamon --version exited with code $LASTEXITCODE"
+          }
+          if ([string]::IsNullOrWhiteSpace($output)) {
+            throw "alpamon --version produced empty output"
+          }
+          Write-Host "alpamon --version: $output"
 
   build-and-test-macos:
     name: Build and Test (macos-arm64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
+      # Fail-fast guard: if `.goreleaser.yaml` silently drops the
+      # stable-alias archive (e.g. a future config edit moves it under
+      # a build id that doesn't match), goreleaser succeeds but
+      # downstream consumers of
+      # `releases/latest/download/alpamon-windows-amd64.zip` break with
+      # a 404 and we only find out from a user report. Check dist/
+      # before any downstream job spends runner time.
+      - name: Verify Windows stable-alias archive was produced
+        run: |
+          set -e
+          aliased="dist/alpamon-windows-amd64.zip"
+          if [ ! -f "$aliased" ]; then
+            echo "::error file=.goreleaser.yaml::expected $aliased in dist/ but it is missing; goreleaser did not produce the stable-name Windows alias"
+            echo "dist/ contents:"
+            ls -la dist/
+            exit 1
+          fi
+          echo "Found $aliased ($(stat -c%s "$aliased") bytes)"
+
       - name: Set TAG_NAME from channel output
         run: echo "TAG_NAME=${{ steps.channel.outputs.tag }}" >> $GITHUB_ENV
 
@@ -139,8 +158,97 @@ jobs:
       - name: Smoke test
         run: alpamon --help
 
+  windows-smoke-test:
+    # Windows archives are cross-compiled on the Ubuntu runner (see
+    # goreleaser job). This job is the only place in the pipeline that
+    # actually executes the produced alpamon.exe on Windows before we
+    # publish, so it must fail the release if the binary is broken or
+    # the checksum file disagrees with the archive. No continue-on-error.
+    #
+    # We smoke-test both the versioned archive (canonical, SHA-audited)
+    # and the unversioned stable alias that downstreams like
+    # alpacon-server consume via `releases/latest/download/<alias>`.
+    # Both must be attached to the release tag and both must hold an
+    # executable alpamon.exe that reports the expected version.
+    needs: [goreleaser]
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - flavor: versioned
+            archive: alpamon-${{ needs.goreleaser.outputs.tag }}-windows-amd64.zip
+          - flavor: stable-alias
+            archive: alpamon-windows-amd64.zip
+    steps:
+      - name: Resolve checksums file and release URL
+        shell: pwsh
+        run: |
+          $checksums = "alpamon-${{ needs.goreleaser.outputs.tag }}-checksums.sha256"
+          "CHECKSUMS_NAME=$checksums" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "REPO_URL=https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}" | `
+            Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Download archive and checksums from release
+        shell: pwsh
+        run: |
+          # goreleaser publishes Windows archives directly to the GitHub
+          # release; pull them straight from the release tag so we
+          # verify the exact bytes consumers will download (versioned
+          # archive via install.ps1, stable alias via
+          # `releases/latest/download/alpamon-windows-amd64.zip`).
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri "$env:REPO_URL/${{ matrix.archive }}" `
+            -OutFile "${{ matrix.archive }}"
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri "$env:REPO_URL/$env:CHECKSUMS_NAME" `
+            -OutFile $env:CHECKSUMS_NAME
+
+      - name: Verify SHA-256 against published checksums file
+        shell: pwsh
+        run: |
+          $line = Get-Content $env:CHECKSUMS_NAME | Where-Object {
+            $parts = $_ -split '\s+', 2
+            $parts.Length -eq 2 -and $parts[1].Trim() -eq "${{ matrix.archive }}"
+          } | Select-Object -First 1
+          if (-not $line) {
+            throw "checksum for ${{ matrix.archive }} not found in $env:CHECKSUMS_NAME"
+          }
+          $expected = ($line -split '\s+', 2)[0].Trim().ToLower()
+          $actual   = (Get-FileHash -Algorithm SHA256 -Path "${{ matrix.archive }}").Hash.ToLower()
+          if ($actual -ne $expected) {
+            throw "SHA-256 mismatch for ${{ matrix.archive }}: expected $expected, got $actual"
+          }
+          Write-Host "Checksum verified for ${{ matrix.archive }}: $actual"
+
+      - name: Extract archive
+        shell: pwsh
+        run: |
+          Expand-Archive -Path "${{ matrix.archive }}" -DestinationPath "extracted-${{ matrix.flavor }}" -Force
+          if (-not (Test-Path "extracted-${{ matrix.flavor }}\alpamon.exe")) {
+            throw "alpamon.exe not found in ${{ matrix.archive }} after extraction"
+          }
+
+      - name: Smoke test (--version)
+        shell: pwsh
+        run: |
+          $output = & ".\extracted-${{ matrix.flavor }}\alpamon.exe" --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "alpamon --version exited with code $LASTEXITCODE"
+          }
+          if ([string]::IsNullOrWhiteSpace($output)) {
+            throw "alpamon --version produced empty output"
+          }
+          # The release build injects the tag via ldflags; assert the
+          # smoke binary reports the tag we intended to ship.
+          $expected = "${{ needs.goreleaser.outputs.tag }}"
+          if ($output.Trim() -ne $expected -and $output.Trim() -ne "v$expected") {
+            throw "alpamon --version reports '$($output.Trim())', expected '$expected' or 'v$expected'"
+          }
+          Write-Host "${{ matrix.flavor }} -> alpamon --version: $output"
+
   packagecloud-deploy:
-    needs: [goreleaser, package-smoke-test]
+    needs: [goreleaser, package-smoke-test, windows-smoke-test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,6 +67,20 @@ archives:
           - tar.gz
           - zip
 
+  # Stable-name alias for Windows. Produces an unversioned
+  # `alpamon-windows-amd64.zip` in addition to the versioned archive in
+  # the block above, so alpacon-server (and any external consumer) can
+  # point at `releases/latest/download/alpamon-windows-amd64.zip`
+  # without having to bump a version constant on every alpamon release.
+  # The versioned archive remains the canonical one for the self-updater
+  # (which resolves an exact tag) and for SHA-256 audit trails.
+  - id: alpamon-windows-stable
+    ids:
+      - alpamon-windows
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    formats:
+      - zip
+
 nfpms:
   - builds:
       - alpamon-linux

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 
 ### Windows
 
+See [**docs/windows.md**](docs/windows.md) for the full install / upgrade / uninstall runbook, feature compatibility matrix, and troubleshooting.
+
 Open an elevated PowerShell (Administrator), then run one of:
 
 **Manual** — download `alpamon-X.Y.Z-windows-amd64.zip` from [Releases](https://github.com/alpacax/alpamon/releases), extract, and run:

--- a/cmd/alpamon/command/root.go
+++ b/cmd/alpamon/command/root.go
@@ -33,8 +33,9 @@ const (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "alpamon",
-	Short: "Secure Server Agent for Alpacon",
+	Use:     "alpamon",
+	Short:   "Secure Server Agent for Alpacon",
+	Version: version.Version,
 	Run: func(cmd *cobra.Command, args []string) {
 		// When launched by the Windows Service Control Manager, run
 		// under the svc dispatcher instead of as a plain console app.
@@ -50,6 +51,9 @@ var RootCmd = &cobra.Command{
 func init() {
 	setup.SetConfigPaths(name)
 	RootCmd.AddCommand(setup.SetupCmd, ftp.FtpCmd, tunnel.TunnelDaemonCmd, register.RegisterCmd)
+	// Emit just the version string (no "alpamon version ..." prefix) so
+	// shell one-liners like `alpamon --version` are easy to parse.
+	RootCmd.SetVersionTemplate("{{.Version}}\n")
 }
 
 // runAgent is the core agent loop. When ready is non-nil, it is

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -17,7 +17,7 @@ For Linux/macOS installation paths, see the [project README](../README.md).
 - **Administrator PowerShell.** Service registration, file placement
   under `%ProgramFiles%`, and the `alpamon.exe register` flow all
   require elevation. Non-admin sessions fail with a clear elevation
-  hint, but they fail — do not try to work around it by running from
+  hint, but they fail—do not try to work around it by running from
   a user-writable directory.
 - **Outbound HTTPS** to:
   - your Alpacon workspace URL
@@ -32,7 +32,7 @@ signing of the binary itself is tracked as a follow-up; see
 [unsupported features](#unsupported-on-windows)). There are
 two supported install paths.
 
-### Option A — `install.ps1` (recommended)
+### Option A: `install.ps1` (recommended)
 
 `scripts/install.ps1` is designed for cloud-init, EC2 UserData, Packer,
 and Azure Custom Script Extension. It verifies the SHA-256 of the
@@ -74,7 +74,7 @@ $env:ALPAMON_TOKEN = "<TOKEN>"
 iwr https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 -UseB | iex
 ```
 
-### Option B — manual extract + `alpamon register`
+### Option B: manual extract + `alpamon register`
 
 ```powershell
 # Elevated PowerShell (Run as Administrator)
@@ -94,7 +94,7 @@ Expand-Archive -Path "$env:TEMP\alpamon.zip" -DestinationPath "$env:TEMP\alpamon
 already-installed machine refreshes the service configuration (binary
 path, recovery actions) but does not re-provision the agent.
 
-> The zip can be extracted anywhere — `alpamon.exe register` copies
+> The zip can be extracted anywhere—`alpamon.exe register` copies
 > itself into `%ProgramFiles%\alpamon\alpamon.exe` and re-executes from
 > there, so the Windows Service Manager entry always points at a
 > stable install path.
@@ -173,11 +173,11 @@ Alpacon execute with SYSTEM rights regardless of the requesting user.
 
 The agent ships with a self-updater that handles the normal case:
 
-- **From the Alpacon console** — issue an `upgrade` command. The
+- **From the Alpacon console**: issue an `upgrade` command. The
   agent downloads the latest release archive from GitHub, verifies the
   SHA-256 checksum, swaps the running binary, and restarts itself
   under the Service Control Manager.
-- **Local CLI** — running `alpamon upgrade` (or re-running
+- **Local CLI**: running `alpamon upgrade` (or re-running
   `install.ps1` with a newer `$env:ALPAMON_VERSION`) triggers the same
   flow.
 
@@ -185,7 +185,7 @@ Because Windows holds the running `.exe` locked, the updater renames
 the current binary to `alpamon.exe.old` via `MoveFileEx`, writes the
 new binary, and then schedules the `.old` file for deletion on the
 next service start. If you see an `alpamon.exe.old` after an upgrade,
-leave it — the next service start cleans it up automatically.
+leave it—the next service start cleans it up automatically.
 
 ### Manual fallback
 
@@ -205,7 +205,7 @@ Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
 ```
 
 Do **not** use `alpamon register` to perform an upgrade on an
-already-registered machine — it refuses to run when a configuration
+already-registered machine—it refuses to run when a configuration
 file already exists, to avoid silently clobbering an existing
 registration.
 
@@ -244,7 +244,7 @@ implemented.
 | Capability | Implementation notes |
 |---|---|
 | Remote shell (`exec`, `shell`) | `powershell.exe -NoLogo -Command`; supports `&&`, `\|\|`, `;` operators |
-| Websh (browser terminal) | ConPTY / Microsoft Pseudoconsole — see `pkg/runner/pty_windows.go` |
+| Websh (browser terminal) | ConPTY / Microsoft Pseudoconsole—see `pkg/runner/pty_windows.go` |
 | File upload / download | Direct `ReadFile` / `WriteFile`, parent directories auto-created |
 | System info (commit / sync) | Via `gopsutil`; users enumerated via `Get-LocalUser`, groups via `Get-LocalGroup` |
 | System control | `restart`, `reboot`, `shutdown`, `upgrade`, `quit` |
@@ -256,12 +256,12 @@ implemented.
 
 | Capability | Status |
 |---|---|
-| User management (`adduser` / `deluser` / `moduser`) | Intentionally not registered in `factory_windows.go` — server enforces via `NO_ADDUSER_PLATFORMS` |
+| User management (`adduser` / `deluser` / `moduser`) | Intentionally not registered in `factory_windows.go`—server enforces via `NO_ADDUSER_PLATFORMS` |
 | Group management (`addgroup` / `delgroup`) | Same as above |
 | Windows Firewall integration | Not implemented; Linux `nftables` / `iptables` handler has no Windows equivalent today |
 | Tunnel (reverse-proxy) | `pkg/runner/tunnel_windows.go` returns an explicit error |
 | Code-Server integration | Returns an explicit error on Windows |
-| Privilege demotion (run-as user) | Stub — all commands execute as `LocalSystem`. No `setuid` equivalent; full fix requires `CreateProcessAsUser` |
+| Privilege demotion (run-as user) | Stub: all commands execute as `LocalSystem`. No `setuid` equivalent; full fix requires `CreateProcessAsUser` |
 | TTY resize via `SIGWINCH` | ConPTY has no Unix signal equivalent; the resize event is still forwarded over the wire, so terminals resize correctly |
 | Authenticode signing of `alpamon.exe` | Not yet signed; SmartScreen may warn on first run. Transport-layer integrity is provided by the checksums file |
 | ARM64 Windows builds | Not built today; tracking as a separate issue |
@@ -274,7 +274,7 @@ succeeding.
 
 ## Logs
 
-Alpamon writes to a single rolling file:
+Alpamon writes to a single log file:
 
 - **Path:** `%ProgramData%\alpamon\log\alpamon.log`
 - **Retention:** no automatic rotation today. On long-running
@@ -289,7 +289,7 @@ To tail the log live:
 Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
 ```
 
-The Windows Event Log is **not** currently a sink — failures that
+The Windows Event Log is **not** currently a sink—failures that
 happen before the log file is open (for example, missing config file)
 are reported to stdout and, under SCM, mirrored to the service
 recovery log.
@@ -303,5 +303,5 @@ recovery log.
 | `failed to create destination ... the process cannot access the file because it is being used by another process` | Existing `alpamon` service still holds the binary open | `Stop-Service alpamon` before rerunning |
 | `connect to service manager: access is denied` | Non-elevated session, or Group Policy blocking SCM access | Elevate; if policy-blocked, contact your domain admin |
 | Service enters `StartPending` and never reaches `Running` | Bad config file, missing network, or dispatcher panic at startup | Inspect `%ProgramData%\alpamon\log\alpamon.log`; the crash reason is logged before SCM times the service out |
-| `alpamon.exe.old` lingering after upgrade | Normal — deletion is scheduled for next service start | `Restart-Service alpamon` to force the cleanup |
+| `alpamon.exe.old` lingering after upgrade | Normal: deletion is scheduled for next service start | `Restart-Service alpamon` to force the cleanup |
 | SmartScreen blocks the downloaded binary | No Authenticode signature on the archive yet | Unblock the specific file via `Unblock-File`, or use `install.ps1` which triggers the run outside of the zone-taint flow |

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -27,10 +27,13 @@ For Linux/macOS installation paths, see the [project README](../README.md).
 
 ## Install
 
-Alpamon ships as a signed-on-transport `.zip` archive (Authenticode
-signing of the binary itself is tracked as a follow-up; see
-[unsupported features](#unsupported-on-windows)). There are
-two supported install paths.
+Windows releases publish both a versioned `.tar.gz` archive and a
+`.zip` archive, both signed on transport (Authenticode signing of the
+binary itself is tracked as a follow-up; see [unsupported
+features](#unsupported-on-windows)). The `.tar.gz` artifact is what
+`install.ps1` and the in-agent self-updater consume; the `.zip`
+artifact supports manual extract workflows and the stable-alias
+download described below. There are two supported install paths.
 
 ### Option A: `install.ps1` (recommended)
 
@@ -136,7 +139,8 @@ Notes:
 | Logs | `%ProgramData%\alpamon\log\alpamon.log` | agent runtime |
 | Runtime state | `%ProgramData%\alpamon\run\` | agent runtime |
 | Local metrics DB | `%ProgramData%\alpamon\data\` | agent runtime |
-| Staged update binary | `%ProgramFiles%\alpamon\alpamon.exe.old` | self-updater (cleaned up on next start) |
+| Staged new binary (during upgrade) | `%ProgramFiles%\alpamon\alpamon.exe.new` | self-updater (renamed into place atomically) |
+| Previous binary (pending deletion) | `%ProgramFiles%\alpamon\alpamon.exe.old` | self-updater (cleaned up on next start, or scheduled for reboot-time removal) |
 
 `%ProgramFiles%` and `%ProgramData%` are read from the process
 environment at runtime, so the agent tolerates non-default locations

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,307 @@
+# Alpamon on Windows
+
+This document is the canonical runbook for installing, upgrading, and
+uninstalling the Alpamon agent on Windows, plus the feature
+compatibility matrix versus Linux.
+
+For Linux/macOS installation paths, see the [project README](../README.md).
+
+## Prerequisites
+
+- **Windows Server 2019 or later** (Server 2022 / 2025), or **Windows 10
+  1803+ / Windows 11** on desktop SKUs. Windows Server 2016 and older
+  are not supported; the built-in `tar.exe` and modern PowerShell
+  features the installer relies on are not present there.
+- **amd64 (x64)** architecture. ARM64 Windows is not built today; see
+  [tracking in the release matrix](#unsupported-on-windows).
+- **Administrator PowerShell.** Service registration, file placement
+  under `%ProgramFiles%`, and the `alpamon.exe register` flow all
+  require elevation. Non-admin sessions fail with a clear elevation
+  hint, but they fail — do not try to work around it by running from
+  a user-writable directory.
+- **Outbound HTTPS** to:
+  - your Alpacon workspace URL
+  - `github.com` and `objects.githubusercontent.com` (for
+    `install.ps1` downloads and self-update checks)
+- **150 MB free disk**, **128 MB RAM** minimum.
+
+## Install
+
+Alpamon ships as a signed-on-transport `.zip` archive (Authenticode
+signing of the binary itself is tracked as a follow-up; see
+[unsupported features](#unsupported-on-windows)). There are
+two supported install paths.
+
+### Option A — `install.ps1` (recommended)
+
+`scripts/install.ps1` is designed for cloud-init, EC2 UserData, Packer,
+and Azure Custom Script Extension. It verifies the SHA-256 of the
+downloaded archive against the release checksums file before extracting
+or executing anything.
+
+```powershell
+# Elevated PowerShell (Run as Administrator)
+$env:ALPAMON_URL   = "https://<workspace>"
+$env:ALPAMON_TOKEN = "<TOKEN>"
+$installer = Join-Path $env:TEMP 'alpamon-install.ps1'
+Invoke-WebRequest -UseBasicParsing `
+    -Uri 'https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1' `
+    -OutFile $installer
+& powershell -ExecutionPolicy Bypass -File $installer
+```
+
+The installer will:
+
+1. Resolve the latest release tag (or use `$env:ALPAMON_VERSION` if
+   you pin one).
+2. Download the `alpamon-<version>-windows-amd64.tar.gz` archive and
+   the sibling `alpamon-<version>-checksums.sha256`.
+3. Verify the archive SHA-256 against the checksums file; fail hard if
+   they disagree.
+4. Extract into a scratch directory in `$env:TEMP`.
+5. Invoke `alpamon.exe register --url <workspace> --token <token>`,
+   which copies the binary into `%ProgramFiles%\alpamon\alpamon.exe`
+   and starts the service.
+6. Delete the scratch directory on success *or* failure.
+
+A terser pipe-to-`iex` form is also supported; it still performs the
+checksum verification inside the script, but trades local-audit
+friendliness for brevity:
+
+```powershell
+$env:ALPAMON_URL   = "https://<workspace>"
+$env:ALPAMON_TOKEN = "<TOKEN>"
+iwr https://raw.githubusercontent.com/alpacax/alpamon/main/scripts/install.ps1 -UseB | iex
+```
+
+### Option B — manual extract + `alpamon register`
+
+```powershell
+# Elevated PowerShell (Run as Administrator)
+$version = "X.Y.Z"  # tag without leading "v"
+
+Invoke-WebRequest -UseBasicParsing `
+  -Uri "https://github.com/alpacax/alpamon/releases/download/v$version/alpamon-$version-windows-amd64.zip" `
+  -OutFile "$env:TEMP\alpamon.zip"
+
+Expand-Archive -Path "$env:TEMP\alpamon.zip" -DestinationPath "$env:TEMP\alpamon-install" -Force
+
+& "$env:TEMP\alpamon-install\alpamon.exe" register `
+    --url "https://<workspace>" --token "<TOKEN>"
+```
+
+`register` is idempotent: re-running it with the same arguments on an
+already-installed machine refreshes the service configuration (binary
+path, recovery actions) but does not re-provision the agent.
+
+> The zip can be extracted anywhere — `alpamon.exe register` copies
+> itself into `%ProgramFiles%\alpamon\alpamon.exe` and re-executes from
+> there, so the Windows Service Manager entry always points at a
+> stable install path.
+
+#### Stable-name download URL
+
+For provisioning flows that don't want to pin to a specific version
+(image build pipelines, Ansible roles, `alpacon-server` registration
+templates), every release also attaches an unversioned
+`alpamon-windows-amd64.zip`:
+
+```powershell
+$stableUrl = "https://github.com/alpacax/alpamon/releases/latest/download/alpamon-windows-amd64.zip"
+Invoke-WebRequest -UseBasicParsing -Uri $stableUrl -OutFile "$env:TEMP\alpamon.zip"
+```
+
+The bytes are identical to the versioned archive (same SHA-256 in the
+published checksums file), so audit trails are preserved: compute the
+hash of the downloaded alias and look for a matching
+`alpamon-<ver>-windows-amd64.zip` line in the release's
+`alpamon-<ver>-checksums.sha256`.
+
+Notes:
+
+- This alias is available from **alpamon v2.1.3 onward**. For older
+  tags, only the versioned archive is published.
+- `install.ps1` and the in-agent self-updater intentionally continue
+  to resolve a specific tag and download the versioned `.tar.gz`
+  (`pkg/updater/updater.go` hardcodes the `.tar.gz` suffix and
+  requires an exact version to record), so they are unaffected by the
+  alias.
+
+## Paths
+
+| Role | Location | Created by |
+|---|---|---|
+| Binary | `%ProgramFiles%\alpamon\alpamon.exe` | `alpamon register` (self-copy from the extract location) |
+| Configuration | `%ProgramData%\alpamon\alpamon.conf` | `alpamon register` |
+| Logs | `%ProgramData%\alpamon\log\alpamon.log` | agent runtime |
+| Runtime state | `%ProgramData%\alpamon\run\` | agent runtime |
+| Local metrics DB | `%ProgramData%\alpamon\data\` | agent runtime |
+| Staged update binary | `%ProgramFiles%\alpamon\alpamon.exe.old` | self-updater (cleaned up on next start) |
+
+`%ProgramFiles%` and `%ProgramData%` are read from the process
+environment at runtime, so the agent tolerates non-default locations
+(custom drive, localized install). When `%ProgramData%` is unset
+(unusual but defensive), the agent falls back to `C:\ProgramData`.
+
+## Service management
+
+Alpamon runs as a Windows Service named `alpamon`, display name
+`"Alpamon Agent"`, start type `Automatic (Delayed Start)`, with
+recovery actions set to restart twice with a 5-second delay before
+giving up. All commands below require elevated PowerShell.
+
+```powershell
+# Status
+Get-Service alpamon
+sc.exe query alpamon          # verbose form with last exit code
+
+# Start / stop / restart
+Start-Service alpamon
+Stop-Service  alpamon
+Restart-Service alpamon
+
+# Follow the log
+Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
+```
+
+The service starts as `LocalSystem`. Alpamon cannot currently drop
+privileges on Windows (see [unsupported
+features](#unsupported-on-windows)), so *all* commands from
+Alpacon execute with SYSTEM rights regardless of the requesting user.
+
+## Upgrade
+
+The agent ships with a self-updater that handles the normal case:
+
+- **From the Alpacon console** — issue an `upgrade` command. The
+  agent downloads the latest release archive from GitHub, verifies the
+  SHA-256 checksum, swaps the running binary, and restarts itself
+  under the Service Control Manager.
+- **Local CLI** — running `alpamon upgrade` (or re-running
+  `install.ps1` with a newer `$env:ALPAMON_VERSION`) triggers the same
+  flow.
+
+Because Windows holds the running `.exe` locked, the updater renames
+the current binary to `alpamon.exe.old` via `MoveFileEx`, writes the
+new binary, and then schedules the `.old` file for deletion on the
+next service start. If you see an `alpamon.exe.old` after an upgrade,
+leave it — the next service start cleans it up automatically.
+
+### Manual fallback
+
+If the self-update path fails (for example, outbound access to
+`github.com` is blocked at upgrade time):
+
+```powershell
+Stop-Service alpamon
+
+# Download + verify the new archive as in "Option B" above.
+# Then overwrite the installed binary in place:
+Copy-Item -Force "$env:TEMP\alpamon-install\alpamon.exe" `
+    "$env:ProgramFiles\alpamon\alpamon.exe"
+
+Start-Service alpamon
+Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
+```
+
+Do **not** use `alpamon register` to perform an upgrade on an
+already-registered machine — it refuses to run when a configuration
+file already exists, to avoid silently clobbering an existing
+registration.
+
+## Uninstall
+
+There is no dedicated uninstaller; the footprint is small and cleanup
+is three commands. Run from elevated PowerShell:
+
+```powershell
+Stop-Service alpamon -ErrorAction SilentlyContinue
+sc.exe delete alpamon
+
+Remove-Item -Recurse -Force "$env:ProgramFiles\alpamon"  -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:ProgramData\alpamon"   -ErrorAction SilentlyContinue
+```
+
+Order matters: stop the service and unregister it from the SCM *before*
+deleting the binary. Otherwise `Remove-Item` will fail with a sharing
+violation because `alpamon.exe` is held open by the still-running
+service.
+
+After the uninstall, the server still exists on the Alpacon side.
+Delete it from the Alpacon console separately if you do not plan to
+re-register.
+
+## Feature compatibility
+
+Alpamon on Windows targets the same day-to-day operator workflows as
+Linux: remote shell, file transfer, system metrics, and the
+browser-based Websh terminal. Features that depend on Unix-specific
+kernels, configuration files, or privilege models are not yet
+implemented.
+
+### Supported on Windows
+
+| Capability | Implementation notes |
+|---|---|
+| Remote shell (`exec`, `shell`) | `powershell.exe -NoLogo -Command`; supports `&&`, `\|\|`, `;` operators |
+| Websh (browser terminal) | ConPTY / Microsoft Pseudoconsole — see `pkg/runner/pty_windows.go` |
+| File upload / download | Direct `ReadFile` / `WriteFile`, parent directories auto-created |
+| System info (commit / sync) | Via `gopsutil`; users enumerated via `Get-LocalUser`, groups via `Get-LocalGroup` |
+| System control | `restart`, `reboot`, `shutdown`, `upgrade`, `quit` |
+| Realtime metrics | CPU, memory, disk, network (gopsutil) |
+| Self-update | `MoveFileEx` for locked-binary replace; reboot-time cleanup of `.old` |
+| Service lifecycle | Windows SCM integration with Stop / Shutdown / recovery actions |
+
+### Unsupported on Windows
+
+| Capability | Status |
+|---|---|
+| User management (`adduser` / `deluser` / `moduser`) | Intentionally not registered in `factory_windows.go` — server enforces via `NO_ADDUSER_PLATFORMS` |
+| Group management (`addgroup` / `delgroup`) | Same as above |
+| Windows Firewall integration | Not implemented; Linux `nftables` / `iptables` handler has no Windows equivalent today |
+| Tunnel (reverse-proxy) | `pkg/runner/tunnel_windows.go` returns an explicit error |
+| Code-Server integration | Returns an explicit error on Windows |
+| Privilege demotion (run-as user) | Stub — all commands execute as `LocalSystem`. No `setuid` equivalent; full fix requires `CreateProcessAsUser` |
+| TTY resize via `SIGWINCH` | ConPTY has no Unix signal equivalent; the resize event is still forwarded over the wire, so terminals resize correctly |
+| Authenticode signing of `alpamon.exe` | Not yet signed; SmartScreen may warn on first run. Transport-layer integrity is provided by the checksums file |
+| ARM64 Windows builds | Not built today; tracking as a separate issue |
+| PAM integration (`alpamon-pam` package) | Linux-only by construction (relies on PAM) |
+
+Operators targeting Windows should not rely on the unsupported
+features listed above. Commands hitting an unsupported handler surface
+an explicit error in the Alpacon console rather than silently
+succeeding.
+
+## Logs
+
+Alpamon writes to a single rolling file:
+
+- **Path:** `%ProgramData%\alpamon\log\alpamon.log`
+- **Retention:** no automatic rotation today. On long-running
+  Windows servers the file will grow unbounded; operators who need
+  rotation should configure it externally (for example with a
+  scheduled task that archives and truncates on a size threshold) or
+  track this limitation for the log-rotation work item.
+
+To tail the log live:
+
+```powershell
+Get-Content "$env:ProgramData\alpamon\log\alpamon.log" -Wait -Tail 50
+```
+
+The Windows Event Log is **not** currently a sink — failures that
+happen before the log file is open (for example, missing config file)
+are reported to stdout and, under SCM, mirrored to the service
+recovery log.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `install.ps1 must be run from an elevated (Administrator) PowerShell` | Non-elevated session | Right-click PowerShell → Run as Administrator |
+| `failed to create install directory: access is denied` during `register` | Non-elevated session (same root cause) | As above |
+| `failed to create destination ... the process cannot access the file because it is being used by another process` | Existing `alpamon` service still holds the binary open | `Stop-Service alpamon` before rerunning |
+| `connect to service manager: access is denied` | Non-elevated session, or Group Policy blocking SCM access | Elevate; if policy-blocked, contact your domain admin |
+| Service enters `StartPending` and never reaches `Running` | Bad config file, missing network, or dispatcher panic at startup | Inspect `%ProgramData%\alpamon\log\alpamon.log`; the crash reason is logged before SCM times the service out |
+| `alpamon.exe.old` lingering after upgrade | Normal — deletion is scheduled for next service start | `Restart-Service alpamon` to force the cleanup |
+| SmartScreen blocks the downloaded binary | No Authenticode signature on the archive yet | Unblock the specific file via `Unblock-File`, or use `install.ps1` which triggers the run outside of the zone-taint flow |

--- a/pkg/collector/check/batch/daily/cpu/daily_cpu_test.go
+++ b/pkg/collector/check/batch/daily/cpu/daily_cpu_test.go
@@ -38,6 +38,13 @@ func (suite *DailyCPUUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *DailyCPUUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/daily/disk/io/daily_io_test.go
+++ b/pkg/collector/check/batch/daily/disk/io/daily_io_test.go
@@ -39,6 +39,13 @@ func (suite *DailyDiskIOCheckSuite) SetupSuite() {
 }
 
 func (suite *DailyDiskIOCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/daily/disk/usage/daily_usage_test.go
+++ b/pkg/collector/check/batch/daily/disk/usage/daily_usage_test.go
@@ -38,6 +38,13 @@ func (suite *DailyDiskUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *DailyDiskUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/daily/memory/daily_memory_test.go
+++ b/pkg/collector/check/batch/daily/memory/daily_memory_test.go
@@ -38,6 +38,13 @@ func (suite *DailyMemoryUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *DailyMemoryUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/daily/net/daily_net_test.go
+++ b/pkg/collector/check/batch/daily/net/daily_net_test.go
@@ -39,6 +39,13 @@ func (suite *DailyNetCheckSuite) SetupSuite() {
 }
 
 func (suite *DailyNetCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/hourly/cpu/hourly_cpu_test.go
+++ b/pkg/collector/check/batch/hourly/cpu/hourly_cpu_test.go
@@ -39,6 +39,13 @@ func (suite *HourlyCPUUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *HourlyCPUUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/hourly/disk/io/hourly_io_test.go
+++ b/pkg/collector/check/batch/hourly/disk/io/hourly_io_test.go
@@ -39,6 +39,13 @@ func (suite *HourlyDiskIOCheckSuite) SetupSuite() {
 }
 
 func (suite *HourlyDiskIOCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/hourly/disk/usage/hourly_usage_test.go
+++ b/pkg/collector/check/batch/hourly/disk/usage/hourly_usage_test.go
@@ -39,6 +39,13 @@ func (suite *HourlyDiskUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *HourlyDiskUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/hourly/memory/hourly_memory_test.go
+++ b/pkg/collector/check/batch/hourly/memory/hourly_memory_test.go
@@ -39,6 +39,13 @@ func (suite *HourlyMemoryUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *HourlyMemoryUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/batch/hourly/net/hourly_net_test.go
+++ b/pkg/collector/check/batch/hourly/net/hourly_net_test.go
@@ -39,6 +39,13 @@ func (suite *HourlyNetCheckSuite) SetupSuite() {
 }
 
 func (suite *HourlyNetCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/realtime/cpu/cpu_test.go
+++ b/pkg/collector/check/realtime/cpu/cpu_test.go
@@ -38,6 +38,13 @@ func (suite *CPUCheckSuite) SetupSuite() {
 }
 
 func (suite *CPUCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/realtime/disk/io/io_test.go
+++ b/pkg/collector/check/realtime/disk/io/io_test.go
@@ -48,6 +48,13 @@ func (suite *DiskIOCheckSuite) SetupSuite() {
 }
 
 func (suite *DiskIOCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/realtime/disk/usage/usage.go
+++ b/pkg/collector/check/realtime/disk/usage/usage.go
@@ -2,6 +2,7 @@ package diskusage
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"time"
 
@@ -102,12 +103,30 @@ func (c *Check) collectDiskPartitions() ([]disk.PartitionStat, error) {
 			continue
 		}
 
-		if strings.HasPrefix(partition.Device, "/dev") {
+		if isPhysicalDevice(partition) {
 			filteredPartitions = append(filteredPartitions, partition)
 		}
 	}
 
 	return filteredPartitions, nil
+}
+
+// isPhysicalDevice filters gopsutil PartitionStat entries to what we
+// consider a real, operator-relevant disk. The kernel-reported device
+// name shape differs by OS, so the allowlist has to be platform-aware:
+//
+//   - Linux / macOS: physical devices live under /dev (e.g. /dev/sda,
+//     /dev/nvme0n1p1, /dev/disk1s1). The /dev prefix keeps loop, tmpfs,
+//     and overlay entries out in case IsVirtualFileSystem missed one.
+//   - Windows: gopsutil reports the drive root (C:\, D:\, ...) as the
+//     device. There is no /dev equivalent; virtual entries are already
+//     filtered by IsVirtualFileSystem, so every remaining partition is
+//     a real volume we want to measure.
+func isPhysicalDevice(p disk.PartitionStat) bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return strings.HasPrefix(p.Device, "/dev")
 }
 
 func (c *Check) collectDiskUsage(path string) (*disk.UsageStat, error) {

--- a/pkg/collector/check/realtime/disk/usage/usage_test.go
+++ b/pkg/collector/check/realtime/disk/usage/usage_test.go
@@ -38,6 +38,13 @@ func (suite *DiskUsageCheckSuite) SetupSuite() {
 }
 
 func (suite *DiskUsageCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/realtime/memory/memory_test.go
+++ b/pkg/collector/check/realtime/memory/memory_test.go
@@ -38,6 +38,13 @@ func (suite *MemoryCheckSuite) SetupSuite() {
 }
 
 func (suite *MemoryCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/collector/check/realtime/net/net_test.go
+++ b/pkg/collector/check/realtime/net/net_test.go
@@ -48,6 +48,13 @@ func (suite *NetCheckSuite) SetupSuite() {
 }
 
 func (suite *NetCheckSuite) TearDownSuite() {
+	// Close the ent client first. On Windows, os.Remove fails with
+	// a sharing violation if the underlying SQLite file handle is still
+	// open. On Unix, the unlink succeeds either way, so this is a no-op
+	// for Linux/macOS runners.
+	if suite.client != nil {
+		_ = suite.client.Close()
+	}
 	err := os.Remove(dbFileName)
 	suite.Require().NoError(err, "failed to delete test db file")
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -59,19 +59,25 @@ func InitTestDB(path string) *ent.Client {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to open test db file: %v\n", err)
 		os.Exit(1)
 	}
+	// We only needed OpenFile to create-on-absence; the filename (and
+	// the sqlite driver, which opens its own handle) is what the
+	// migration and ent client consume. Keeping this handle open would
+	// prevent the test's TearDownSuite from os.Remove'ing the file on
+	// Windows, where open handles block deletion.
+	_ = dbFile.Close()
 
 	sql.Register("sqlite3", &sqlite.Driver{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = RunMigration(dbFile.Name(), ctx)
+	err = RunMigration(fileName, ctx)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to migrate test db: %v.", err)
 		os.Exit(1)
 	}
 
-	dbManager := NewDBClientManager(dbFile.Name())
+	dbManager := NewDBClientManager(fileName)
 	client, err := dbManager.GetClient()
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to get db client: %v.", err)

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -1,3 +1,10 @@
+//go:build !windows
+
+// Group management is unsupported on Windows (see pkg/executor/factory_windows.go:
+// GroupHandler is not registered there). These assertions hardcode
+// /usr/sbin/addgroup invocations, so they are Unix-only. Tracked in alpamon
+// Issue #1 under "excluded test packages".
+
 package group
 
 import (

--- a/pkg/executor/handlers/group/group_test.go
+++ b/pkg/executor/handlers/group/group_test.go
@@ -3,7 +3,7 @@
 // Group management is unsupported on Windows (see pkg/executor/factory_windows.go:
 // GroupHandler is not registered there). These assertions hardcode
 // /usr/sbin/addgroup invocations, so they are Unix-only. Tracked in alpamon
-// Issue #1 under "excluded test packages".
+// issue #284 under "excluded test packages".
 
 package group
 

--- a/pkg/executor/handlers/shell/shell_test.go
+++ b/pkg/executor/handlers/shell/shell_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -456,6 +457,13 @@ func TestShellHandler_MixedOperators(t *testing.T) {
 }
 
 func TestShellHandler_AllowSh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// On Windows, handleShellCommand routes AllowSh=true through
+		// powershell with different args. This unit test locks in the
+		// Unix /bin/sh -c contract; the Windows path is exercised by
+		// integration tests.
+		t.Skip("AllowSh=true uses powershell on Windows; /bin/sh contract is Unix-only.")
+	}
 	mockExec := common.NewMockCommandExecutor(t)
 	// When AllowSh is true, handler calls /bin/sh -c <command>
 	// Mock key: "/bin/sh" + " " + "-c" + " " + "grep err /log | head"

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -3,7 +3,7 @@
 // User management is unsupported on Windows (see pkg/executor/factory_windows.go:
 // UserHandler is not registered there). The assertions in this file bake in
 // Unix shadow/passwd semantics and hardcoded /usr/sbin/{adduser,deluser,usermod}
-// paths, so they are Unix-only by construction. Tracked in alpamon Issue #1
+// paths, so they are Unix-only by construction. Tracked in alpamon issue #284
 // under "excluded test packages".
 
 package user

--- a/pkg/executor/handlers/user/user_test.go
+++ b/pkg/executor/handlers/user/user_test.go
@@ -1,3 +1,11 @@
+//go:build !windows
+
+// User management is unsupported on Windows (see pkg/executor/factory_windows.go:
+// UserHandler is not registered there). The assertions in this file bake in
+// Unix shadow/passwd semantics and hardcoded /usr/sbin/{adduser,deluser,usermod}
+// paths, so they are Unix-only by construction. Tracked in alpamon Issue #1
+// under "excluded test packages".
+
 package user
 
 import (

--- a/pkg/runner/commit_test.go
+++ b/pkg/runner/commit_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -63,6 +64,12 @@ func TestGetUserData(t *testing.T) {
 }
 
 func TestLoadValidShells(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// loadValidShells on Windows returns a fixed list of
+		// {powershell.exe, cmd.exe, pwsh.exe} — see commit_windows.go.
+		// The /etc/shells parsing contract exercised here is Unix-only.
+		t.Skip("/etc/shells is Unix-only; Windows has a fixed shell list.")
+	}
 	// This test verifies that loadValidShells can read and parse the shells file
 	// On macOS/Linux, /etc/shells should exist with common shells
 	shells := loadValidShells()

--- a/pkg/runner/ftp_test.go
+++ b/pkg/runner/ftp_test.go
@@ -1,3 +1,16 @@
+//go:build !windows
+
+// parsePath has two distinct branches (see ftp.go): on Windows it
+// enforces strict home-directory containment via
+// utils.ResolveAndEnsureUnderHome, while on Unix it only scopes to "/"
+// because privilege demotion provides the finer scoping. The test
+// cases in this file encode the Unix contract — hardcoded wire paths
+// like "/tmp/file.txt" and "/home/testuser" are interpreted on
+// Windows with a drive-letter prefix and fail the home-containment
+// check, producing assertion mismatches that do not indicate a real
+// regression. The Windows branch is exercised by integration tests
+// (see pkg/runner/ftp.go:205 and utils.ResolveAndEnsureUnderHome).
+
 package runner
 
 import (

--- a/pkg/utils/systemd_test.go
+++ b/pkg/utils/systemd_test.go
@@ -19,6 +19,13 @@ func TestDetectSystemd_Darwin(t *testing.T) {
 }
 
 func TestEnsureDirectoriesWithRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows os.Stat reports a synthetic Mode().Perm() based on the
+		// read-only attribute, not the Unix mode bits we set. The chmod
+		// call itself still runs via ensureDirectoriesWithRoot, but the
+		// assertion below is Unix-only and would falsely fail here.
+		t.Skip("Unix file-mode assertions; Windows does not expose Unix perm bits.")
+	}
 	root := t.TempDir()
 
 	if err := ensureDirectoriesWithRoot(root); err != nil {
@@ -47,6 +54,9 @@ func TestEnsureDirectoriesWithRoot(t *testing.T) {
 }
 
 func TestEnsureDirectoriesWithRoot_Idempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file-mode assertions; Windows does not expose Unix perm bits.")
+	}
 	root := t.TempDir()
 
 	// Call twice to verify idempotency


### PR DESCRIPTION
## Summary

Bring alpamon's Windows support up to a release-ready baseline. Three areas are landed together in one PR, but split into separate commits so each scope can be reviewed independently.

- **CI (Section A)**: expand the `windows-latest` job to run the full test suite + `go vet` + an `alpamon.exe --version` smoke. ConPTY, SCM, and self-updater code paths now execute on a real Windows runner on every PR.
- **Release pipeline (Section B)**: goreleaser now emits a stable-name Windows alias (`alpamon-windows-amd64.zip`), and `release.yml` smoke-tests both the versioned archive and the alias as a matrix. Applies automatically from the next tag (`v2.1.3+`) onward; v2.1.2 is not touched.
- **Docs (Section C)**: new `docs/windows.md` lifecycle runbook (install / upgrade / uninstall / compatibility matrix / troubleshooting) and a README pointer.

Closes #284.

## Motivation

| Problem | Evidence |
|---|---|
| The Windows binary has never been executed on a Windows host before release | `.goreleaser.yaml` cross-compiles on Ubuntu. The existing `build-and-test-windows` job ran only `./pkg/config/ ./pkg/executor/ ./pkg/updater/ ./internal/...`, leaving SCM / ConPTY / self-updater with zero coverage |
| The latest Windows regression was only found post-release | `85a7e22 fix(windows): detect shell exit in ConPTY Websh sessions` |
| Every alpamon release forces an `ALPAMON_WINDOWS_VERSION` bump PR on alpacon-server | Linux (PackageCloud) and macOS (Homebrew) have a stable "latest" abstraction; Windows is the only platform missing it |
| No Windows lifecycle documentation | Install, upgrade, and **uninstall** are undocumented. The `system/byebye` handler exists but Windows-specific steps are nowhere |

## What's in this PR

### Commit 1 — `ci(windows): add full test suite, vet, and --version smoke on windows-latest`
- `cmd/alpamon/command/root.go`: wire `pkg/version.Version` into cobra `RootCmd.Version` and install a custom `SetVersionTemplate`, so `alpamon --version` exits 0 with a parseable output
- Five test files gated **explicitly** as Unix-only (no silent blanket skip): two with file-level `//go:build !windows`, three with per-test `runtime.GOOS` skip
- `.github/workflows/build-and-test.yml`: `go test ./... -p 1` plus a pwsh `--version` smoke step, no `continue-on-error` anywhere

### Commit 2 — `build,ci(windows): publish stable-name windows alias with release smoke guard`
- `.goreleaser.yaml`: second archive entry (`alpamon-windows-stable`) producing the unversioned zip. Reuses the existing `alpamon-windows` build via `ids: [alpamon-windows]`, so there is no extra compile cost
- `.github/workflows/release.yml`:
  - **fail-fast guard**: immediately after `Run GoReleaser`, assert that `dist/alpamon-windows-amd64.zip` exists. If a future config edit drops the alias, the release halts here with a `::error file=.goreleaser.yaml::` annotation
  - **windows-smoke-test matrix**: `versioned` / `stable-alias` flavors each run `release tag download → SHA-256 verify → Expand-Archive → --version exec`, with `fail-fast: false` so both flavors report independently
  - **`packagecloud-deploy` dependency expanded**: `needs: [goreleaser, package-smoke-test, windows-smoke-test]`

### Commit 3 — `docs(windows): add install / upgrade / uninstall runbook, link from README`
- New `docs/windows.md` (~300 lines): prerequisites, Options A/B install, stable URL, path table, service management, upgrade (self-updater + manual fallback), three-step uninstall, supported / unsupported feature matrix, logs, and seven-entry troubleshooting table
- `README.md`: one-line pointer to the runbook at the top of the Windows section

## Why 3 commits (not 1, not 7)

The issue's §Notes explicitly asks for "CI / release pipeline / docs in separate commits". The 3-commit split means:

- Each commit is a **complete functional slice**: no orphan commits sitting in history without standalone value
- Each commit maps **1:1 to one AC section** (A / B / C), so reviewers can sign off on each scope in isolation
- At 10 files / ~502 added lines, finer granularity would only hurt review ergonomics without meaningfully improving `git bisect` precision

## Verification

### Local (darwin + goreleaser v2.14.3)

| Check | Command | Result |
|---|---|---|
| Windows cross-compile | `GOOS=windows GOARCH=amd64 go build ./...` | ✅ clean |
| Windows vet | `GOOS=windows GOARCH=amd64 go vet ./...` | ✅ clean |
| Windows test compile | `GOOS=windows GOARCH=amd64 go test -count=0 ./...` | ✅ all package binaries produced |
| `--version` ldflags injection | `go build -ldflags=".../version.Version=v1.0.0" && ./a --version` | ✅ `v1.0.0`, exit 0 |
| Darwin regression on gated tests | `go test ./pkg/executor/handlers/{user,group,shell}/ ./pkg/utils/ ./pkg/runner/` | ✅ all ok |
| goreleaser snapshot | `goreleaser release --snapshot --clean` | ✅ versioned + alias both produced |
| Alias file exists | `ls dist/alpamon-windows-amd64.zip` | ✅ |
| Alias is byte-identical to versioned | SHA-256 comparison | ✅ **identical** (`d21804...`) |
| Alias entry in checksums file | `grep alpamon-windows-amd64.zip dist/*checksums*` | ✅ |
| PE binary validity | `unzip -p ... alpamon.exe | head -c 4 | xxd` | ✅ `MZ..` PE header |
| goreleaser config | `goreleaser check` | ✅ valid (pre-existing nfpms / brews deprecations are unrelated) |
| Docs anchor links | `grep '\[.*\](#' docs/windows.md` | ✅ all resolve |

### CI (runs automatically on this PR)

- `lint` — golangci-lint
- `build-and-test` (Linux matrix)
- `build-and-test-windows` — **the headline check for this PR. Confirm the first run is green with the full test suite enabled**
- `build-and-test-macos`

## Manual post-release checklist (AC #8, #9)

After the next tag is pushed (`v2.1.3` or any `-rc` / `-dev` pre-release), a reviewer or release owner should confirm:

- [ ] **Assets attached** — `gh api repos/alpacax/alpamon/releases/tags/<tag> --jq '.assets[].name' | sort` includes all four:
  - `alpamon-<ver>-windows-amd64.tar.gz`
  - `alpamon-<ver>-windows-amd64.zip`
  - `alpamon-windows-amd64.zip` ← **stable alias**
  - `alpamon-<ver>-checksums.sha256`
- [ ] **Checksums verify** — after download, `sha256sum -c alpamon-<ver>-checksums.sha256` passes for both the alias and the versioned archive
- [ ] **Stable URL returns 200** — `curl -sL -o /dev/null -w '%{http_code}' https://github.com/alpacax/alpamon/releases/latest/download/alpamon-windows-amd64.zip` → `200`
- [ ] **Manual smoke on a fresh Windows Server 2022 VM** — register via `install.ps1`, confirm `Get-Service alpamon` → `Running`, `%ProgramData%\alpamon\log\alpamon.log` is created
- [ ] **Walk through the docs/windows.md uninstall procedure** — confirm no leftover files or services

## Rollout impact

| Target | Impact |
|---|---|
| v2.1.2 (current latest) | **No change.** `release.yml` triggers on `push: tags: ["*"]`, so existing tags are never re-processed |
| Next tag (v2.1.3+) | **Automatic.** Alias added and matrix smoke runs |
| Existing `install.ps1` users | **No change.** The script keeps using the versioned `.tar.gz` |
| Existing self-updater | **No change.** `pkg/updater/updater.go` hardcodes `.tar.gz` and requires an exact version string |
| alpacon-server | Path opens to remove `ALPAMON_WINDOWS_VERSION`; that work is a follow-up PR in that repo |
| Existing Linux / macOS CI matrix | **No change** |
| Per-PR CI runtime | Windows job goes from subset to full suite, adding a few minutes (intentional; required by AC #1) |

## Out of scope

Matches the issue's "Out of scope":

- ARM64 Windows builds (separate issue)
- Authenticode signing (separate issue, pre-GA)
- Full Windows registration E2E (issue #2)
- MSI / Chocolatey / WinGet packaging
- Linux / macOS stable-name alias (PackageCloud / Homebrew already cover this)
- Removing `ALPAMON_WINDOWS_VERSION` from alpacon-server (separate PR after the first stable Windows release)

## Key design decisions

1. **Option A (goreleaser-native) vs Option B (post-release `gh upload --clobber`)**
   Went with Option A. A local goreleaser v2.14.3 snapshot accepts the `ids: [alpamon-windows]` re-reference, so Option B is not needed. Option A automatically includes the alias in the checksums file and keeps upload atomic within a single goreleaser invocation, leaving less room for drift.

2. **The alias is byte-identical to the versioned archive**
   Both archives reuse the same `alpamon-windows` build. Downloading the alias still lets consumers match the SHA-256 against a versioned line in the checksums file, preserving the audit trail.

3. **`install.ps1` and the self-updater are left alone**
   Both paths require an **exact tag version**. A stable URL tracks latest and breaks their reproducibility contract, so the alias is documented as a provisioning / image-baking tool only.

4. **Placement of the `Verify Windows stable-alias archive was produced` step**
   Put immediately after the goreleaser step: goreleaser populates `dist/` and does its upload in the same action invocation, so if `dist/` is missing the alias, the release also lacks it. The smoke matrix already fails on a 404 from the release URL, but the guard makes the failure visible early without burning smoke-runner time.

5. **Choice of Unix-only test gating technique**
   Files that are entirely Unix-specific get `//go:build !windows` at the file level (e.g., `user_test.go`, `group_test.go`). Files with a mix of portable and Unix-specific tests use a per-test `runtime.GOOS == "windows"` skip. Per the AC's "no silent blanket skip" requirement, every gate carries a comment explaining the reason.

## Test plan

- [ ] `build-and-test-windows` job is green on the first CI run
- [ ] Linux `build-and-test` matrix shows no regression
- [ ] `lint` passes
- [ ] After merge, next tag push triggers `windows-smoke-test` matrix and both flavors are green
- [ ] Manual post-release checklist above is completed

## References

- Issue: #284
- Recent Windows regression that a Windows CI would have caught: `85a7e22 fix(windows): detect shell exit in ConPTY Websh sessions`
- Prior Windows work: PR #279 (Service wrapper + self-update), PR #280 (ConPTY exit detection)
- Downstream consumer that benefits from the stable alias: `alpacon-server` (`ALPAMON_WINDOWS_VERSION` constant)
