### PR TITLE
fix(windows): harden install.ps1 and publish stable checksums alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,34 @@ jobs:
           fi
           echo "Found $aliased ($(stat -c%s "$aliased") bytes)"
 
+      # Publish a version-independent alias of the checksums file so
+      # downstream consumers (alpacon-server's Windows install guide, any
+      # `releases/latest/download/…` flow) can verify SHA-256 without
+      # having to resolve the release tag first. The alias is a byte-for-
+      # byte copy of the versioned file; entries inside still reference
+      # the versioned artifact names, which is what consumers match on.
+      # goreleaser has already uploaded the versioned checksums file and
+      # created the release, so we attach the alias with `gh release
+      # upload`.
+      - name: Publish stable-alias checksums file
+        env:
+          GH_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+        run: |
+          set -e
+          versioned="dist/alpamon-${{ steps.channel.outputs.tag }}-checksums.sha256"
+          aliased="dist/alpamon-checksums.sha256"
+          if [ ! -f "$versioned" ]; then
+            echo "::error file=.goreleaser.yaml::expected $versioned in dist/ but it is missing; goreleaser did not produce the versioned checksums file"
+            echo "dist/ contents:"
+            ls -la dist/
+            exit 1
+          fi
+          cp "$versioned" "$aliased"
+          # --clobber lets the step be retried without failing on an
+          # already-attached asset.
+          gh release upload "${{ github.ref_name }}" "$aliased" --clobber
+          echo "Uploaded $aliased alongside $versioned"
+
       - name: Set TAG_NAME from channel output
         run: echo "TAG_NAME=${{ steps.channel.outputs.tag }}" >> $GITHUB_ENV
 
@@ -220,6 +248,27 @@ jobs:
             throw "SHA-256 mismatch for ${{ matrix.archive }}: expected $expected, got $actual"
           }
           Write-Host "Checksum verified for ${{ matrix.archive }}: $actual"
+
+      # Runs once per job-matrix execution; guard so we only exercise the
+      # byte-identical comparison under a single matrix entry (otherwise
+      # we'd do the same network fetch twice for no extra coverage).
+      # The check guards against a future regression where the "Publish
+      # stable-alias checksums file" step in the goreleaser job silently
+      # uploads the wrong bytes (or nothing at all).
+      - name: Verify stable-alias checksums file matches versioned file
+        if: matrix.flavor == 'versioned'
+        shell: pwsh
+        run: |
+          $aliasName = "alpamon-checksums.sha256"
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri "$env:REPO_URL/$aliasName" `
+            -OutFile $aliasName
+          $versionedHash = (Get-FileHash -Algorithm SHA256 -Path $env:CHECKSUMS_NAME).Hash.ToLower()
+          $aliasHash     = (Get-FileHash -Algorithm SHA256 -Path $aliasName).Hash.ToLower()
+          if ($versionedHash -ne $aliasHash) {
+            throw "stable-alias checksums file diverges from versioned file: $aliasName=$aliasHash vs $env:CHECKSUMS_NAME=$versionedHash"
+          }
+          Write-Host "Alias checksums file matches versioned file: $aliasHash"
 
       - name: Extract archive
         shell: pwsh

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -67,6 +67,28 @@ The installer will:
    and starts the service.
 6. Delete the scratch directory on success *or* failure.
 
+#### Re-running `install.ps1`
+
+`install.ps1` is safe to re-run on a host that already has the
+`alpamon` service installed. If the service exists, the script stops
+it (and waits for the SCM to release the binary handle) before
+touching `%ProgramFiles%\alpamon\alpamon.exe`, so you will not see the
+`ERROR_SHARING_VIOLATION` that a naive re-run would otherwise hit.
+
+Re-running on an **already-registered** host still fails at the
+`alpamon register` step, because `register` refuses to run when
+`%ProgramData%\alpamon\alpamon.conf` already exists—this matches the
+Linux and macOS behavior and prevents a silent re-registration. To
+upgrade an already-registered host, use `alpamon upgrade` or the
+[Manual fallback](#manual-fallback) recipe below.
+
+If the install fails after the service was stopped, the script
+best-effort restarts the previously-running service before exiting
+non-zero, so a transient network or checksum failure does not leave
+the host with a downed agent. TLS 1.2 is forced before any network
+call, so stock Server 2019 images do not need a manual
+`[Net.ServicePointManager]::SecurityProtocol` shim.
+
 A terser pipe-to-`iex` form is also supported; it still performs the
 checksum verification inside the script, but trades local-audit
 friendliness for brevity:
@@ -304,7 +326,8 @@ recovery log.
 |---|---|---|
 | `install.ps1 must be run from an elevated (Administrator) PowerShell` | Non-elevated session | Right-click PowerShell → Run as Administrator |
 | `failed to create install directory: access is denied` during `register` | Non-elevated session (same root cause) | As above |
-| `failed to create destination ... the process cannot access the file because it is being used by another process` | Existing `alpamon` service still holds the binary open | `Stop-Service alpamon` before rerunning |
+| `failed to create destination ... the process cannot access the file because it is being used by another process` | Existing `alpamon` service still holds the binary open (only seen when running `alpamon register` directly, not via `install.ps1`) | `Stop-Service alpamon` before rerunning, or use `install.ps1` which stops the service automatically |
+| `Install failed; attempting to restart previously-running alpamon service` (warning from `install.ps1`) | Download, checksum, extract, or `register` failed after the service was stopped | Read the preceding error for the root cause; the previously-running service is restarted on a best-effort basis, so the host is back in its prior state |
 | `connect to service manager: access is denied` | Non-elevated session, or Group Policy blocking SCM access | Elevate; if policy-blocked, contact your domain admin |
 | Service enters `StartPending` and never reaches `Running` | Bad config file, missing network, or dispatcher panic at startup | Inspect `%ProgramData%\alpamon\log\alpamon.log`; the crash reason is logged before SCM times the service out |
 | `alpamon.exe.old` lingering after upgrade | Normal: deletion is scheduled for next service start | `Restart-Service alpamon` to force the cleanup |

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -115,9 +115,13 @@ Expand-Archive -Path "$env:TEMP\alpamon.zip" -DestinationPath "$env:TEMP\alpamon
     --url "https://<workspace>" --token "<TOKEN>"
 ```
 
-`register` is idempotent: re-running it with the same arguments on an
-already-installed machine refreshes the service configuration (binary
-path, recovery actions) but does not re-provision the agent.
+`register` refuses to run on an already-registered host: if
+`%ProgramData%\alpamon\alpamon.conf` exists it exits non-zero rather
+than silently re-provisioning. This matches the Linux and macOS
+behavior. To upgrade an already-registered host use `alpamon upgrade`
+(or the [Manual fallback](#manual-fallback) recipe below); to
+re-register from scratch, first [Uninstall](#uninstall) and then run
+Option A or Option B.
 
 > The zip can be extracted anywhere—`alpamon.exe register` copies
 > itself into `%ProgramFiles%\alpamon\alpamon.exe` and re-executes from

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -74,79 +74,81 @@ $ErrorActionPreference = "Stop"
 $previousProgressPreference = $ProgressPreference
 $ProgressPreference = "SilentlyContinue"
 
-try {
-
-if (-not $Url -or -not $Token) {
-    throw "Url and Token are required (pass as parameters or set ALPAMON_URL / ALPAMON_TOKEN)."
-}
-
-$isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
-    [Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-    throw "install.ps1 must be run from an elevated (Administrator) PowerShell."
-}
-
-# Force TLS 1.2+ before any Invoke-WebRequest / Invoke-RestMethod.
-# Older Server 2019 base images default to SSL3/TLS1.0, which fails
-# the GitHub API handshake. TLS 1.3 only exists on .NET Framework 4.8+,
-# so probe for the enum value rather than referencing the literal.
-$tls = [Net.SecurityProtocolType]::Tls12
-if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
-    $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
-}
-[Net.ServicePointManager]::SecurityProtocol = $tls
-
-# If an alpamon service already exists, stop it so `alpamon register`
-# can replace %ProgramFiles%\alpamon\alpamon.exe without hitting
-# ERROR_SHARING_VIOLATION. Track whether it was running so a failure
-# in the install block can put it back, matching Linux/macOS where a
-# failed register leaves the existing service untouched.
+# Pre-declared here so the outer catch/finally can reference them even
+# if a throw happens before the assignment points below.
 $serviceWasRunning = $false
-$existingService = Get-Service -Name alpamon -ErrorAction SilentlyContinue
-if ($existingService) {
-    if ($existingService.Status -eq 'Running') { $serviceWasRunning = $true }
-    if ($existingService.Status -eq 'Stopped') {
-        Write-Host "Existing alpamon service detected (status: Stopped); leaving as-is."
-    }
-    else {
-        Write-Host "Existing alpamon service detected (status: $($existingService.Status)). Stopping..."
-        # Skip Stop-Service if the SCM is already tearing the service
-        # down; the subsequent WaitForStatus will still block until the
-        # transition completes.
-        if ($existingService.Status -ne 'StopPending') {
-            Stop-Service -Name alpamon -Force -ErrorAction Stop
-        }
-        # Stop-Service returns before the SCM fully releases the binary
-        # handle; without the wait, the subsequent copy can still race.
-        # WaitForStatus refreshes the ServiceController's state internally,
-        # so reusing $existingService is safe.
-        $existingService.WaitForStatus('Stopped', '00:00:30')
-    }
-}
-
-if (-not $Version) {
-    Write-Host "Resolving latest Alpamon release..."
-    $latest  = Invoke-RestMethod -UseBasicParsing `
-        "https://api.github.com/repos/alpacax/alpamon/releases/latest"
-    $Version = $latest.tag_name
-}
-# Accept both "v1.2.3" and "1.2.3"; GitHub release tags use the "v"
-# prefix so we need it on the download URL path.
-if (-not $Version.StartsWith("v")) {
-    $Version = "v$Version"
-}
-$versionBare = $Version.TrimStart("v")
-
-$arch = "amd64"
-$archiveName   = "alpamon-$versionBare-windows-$arch.tar.gz"
-$checksumsName = "alpamon-$versionBare-checksums.sha256"
-$archiveUrl    = "https://github.com/alpacax/alpamon/releases/download/$Version/$archiveName"
-$checksumsUrl  = "https://github.com/alpacax/alpamon/releases/download/$Version/$checksumsName"
-
-$tempDir = Join-Path $env:TEMP ("alpamon-install-" + [System.Guid]::NewGuid().ToString().Substring(0, 8))
-New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+$tempDir = $null
 
 try {
+    if (-not $Url -or -not $Token) {
+        throw "Url and Token are required (pass as parameters or set ALPAMON_URL / ALPAMON_TOKEN)."
+    }
+
+    $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)
+    if (-not $isAdmin) {
+        throw "install.ps1 must be run from an elevated (Administrator) PowerShell."
+    }
+
+    # Force TLS 1.2+ before any Invoke-WebRequest / Invoke-RestMethod.
+    # Older Server 2019 base images default to SSL3/TLS1.0, which fails
+    # the GitHub API handshake. TLS 1.3 only exists on .NET Framework 4.8+,
+    # so probe for the enum value rather than referencing the literal.
+    $tls = [Net.SecurityProtocolType]::Tls12
+    if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
+        $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
+    }
+    [Net.ServicePointManager]::SecurityProtocol = $tls
+
+    # If an alpamon service already exists, stop it so `alpamon register`
+    # can replace %ProgramFiles%\alpamon\alpamon.exe without hitting
+    # ERROR_SHARING_VIOLATION. Track whether it was running so a failure
+    # anywhere below can put it back, matching Linux/macOS where a failed
+    # register leaves the existing service untouched.
+    $existingService = Get-Service -Name alpamon -ErrorAction SilentlyContinue
+    if ($existingService) {
+        if ($existingService.Status -eq 'Running') { $serviceWasRunning = $true }
+        if ($existingService.Status -eq 'Stopped') {
+            Write-Host "Existing alpamon service detected (status: Stopped); leaving as-is."
+        }
+        else {
+            Write-Host "Existing alpamon service detected (status: $($existingService.Status)). Stopping..."
+            # Skip Stop-Service if the SCM is already tearing the service
+            # down; the subsequent WaitForStatus will still block until the
+            # transition completes.
+            if ($existingService.Status -ne 'StopPending') {
+                Stop-Service -Name alpamon -Force -ErrorAction Stop
+            }
+            # Stop-Service returns before the SCM fully releases the binary
+            # handle; without the wait, the subsequent copy can still race.
+            # WaitForStatus refreshes the ServiceController's state internally,
+            # so reusing $existingService is safe.
+            $existingService.WaitForStatus('Stopped', '00:00:30')
+        }
+    }
+
+    if (-not $Version) {
+        Write-Host "Resolving latest Alpamon release..."
+        $latest  = Invoke-RestMethod -UseBasicParsing `
+            "https://api.github.com/repos/alpacax/alpamon/releases/latest"
+        $Version = $latest.tag_name
+    }
+    # Accept both "v1.2.3" and "1.2.3"; GitHub release tags use the "v"
+    # prefix so we need it on the download URL path.
+    if (-not $Version.StartsWith("v")) {
+        $Version = "v$Version"
+    }
+    $versionBare = $Version.TrimStart("v")
+
+    $arch = "amd64"
+    $archiveName   = "alpamon-$versionBare-windows-$arch.tar.gz"
+    $checksumsName = "alpamon-$versionBare-checksums.sha256"
+    $archiveUrl    = "https://github.com/alpacax/alpamon/releases/download/$Version/$archiveName"
+    $checksumsUrl  = "https://github.com/alpacax/alpamon/releases/download/$Version/$checksumsName"
+
+    $tempDir = Join-Path $env:TEMP ("alpamon-install-" + [System.Guid]::NewGuid().ToString().Substring(0, 8))
+    New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+
     $archivePath   = Join-Path $tempDir "alpamon.tar.gz"
     $checksumsPath = Join-Path $tempDir $checksumsName
 
@@ -203,10 +205,12 @@ try {
     Write-Host "Alpamon installed and registered."
 }
 catch {
-    # If we stopped a running service but then failed before register
-    # could bring it back up, restore the prior state on a best-effort
-    # basis. This mirrors Linux/macOS, where a failed `alpamon register`
-    # does not touch the existing service.
+    # Any throw after the service was stopped leaves a previously-running
+    # alpamon down; best-effort restart to match Linux/macOS semantics
+    # where a failed `alpamon register` does not touch the existing
+    # service. Covers failures anywhere after service stop: WaitForStatus
+    # timeout, tag resolution, tempDir creation, download, extract,
+    # register.
     if ($serviceWasRunning) {
         Write-Warning "Install failed; attempting to restart previously-running alpamon service."
         Start-Service -Name alpamon -ErrorAction SilentlyContinue
@@ -214,10 +218,8 @@ catch {
     throw
 }
 finally {
-    Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
-}
-
-}  # end of outer try (ProgressPreference guard)
-finally {
+    if ($tempDir -and (Test-Path $tempDir)) {
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
     $ProgressPreference = $previousProgressPreference
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -67,8 +67,14 @@ param(
 $ErrorActionPreference = "Stop"
 # Suppress Invoke-WebRequest progress bar; on PS 5.1 the default
 # rendering slows downloads by one to two orders of magnitude, which
-# is painful in cloud-init / UserData runs.
+# is painful in cloud-init / UserData runs. Save the caller's value
+# so a `iwr ... | iex` invocation doesn't inherit the suppression
+# after the installer exits (script-scope assignment would normally
+# shield the caller, but iex runs in the caller's scope).
+$previousProgressPreference = $ProgressPreference
 $ProgressPreference = "SilentlyContinue"
+
+try {
 
 if (-not $Url -or -not $Token) {
     throw "Url and Token are required (pass as parameters or set ALPAMON_URL / ALPAMON_TOKEN)."
@@ -99,13 +105,23 @@ $serviceWasRunning = $false
 $existingService = Get-Service -Name alpamon -ErrorAction SilentlyContinue
 if ($existingService) {
     if ($existingService.Status -eq 'Running') { $serviceWasRunning = $true }
-    Write-Host "Existing alpamon service detected (status: $($existingService.Status)). Stopping..."
-    Stop-Service -Name alpamon -Force -ErrorAction Stop
-    # Stop-Service returns before the SCM fully releases the binary
-    # handle; without the wait, the subsequent copy can still race.
-    # WaitForStatus refreshes the ServiceController's state internally,
-    # so reusing $existingService is safe.
-    $existingService.WaitForStatus('Stopped', '00:00:30')
+    if ($existingService.Status -eq 'Stopped') {
+        Write-Host "Existing alpamon service detected (status: Stopped); leaving as-is."
+    }
+    else {
+        Write-Host "Existing alpamon service detected (status: $($existingService.Status)). Stopping..."
+        # Skip Stop-Service if the SCM is already tearing the service
+        # down; the subsequent WaitForStatus will still block until the
+        # transition completes.
+        if ($existingService.Status -ne 'StopPending') {
+            Stop-Service -Name alpamon -Force -ErrorAction Stop
+        }
+        # Stop-Service returns before the SCM fully releases the binary
+        # handle; without the wait, the subsequent copy can still race.
+        # WaitForStatus refreshes the ServiceController's state internally,
+        # so reusing $existingService is safe.
+        $existingService.WaitForStatus('Stopped', '00:00:30')
+    }
 }
 
 if (-not $Version) {
@@ -199,4 +215,9 @@ catch {
 }
 finally {
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+}
+
+}  # end of outer try (ProgressPreference guard)
+finally {
+    $ProgressPreference = $previousProgressPreference
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,6 +65,10 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+# Suppress Invoke-WebRequest progress bar; on PS 5.1 the default
+# rendering slows downloads by one to two orders of magnitude, which
+# is painful in cloud-init / UserData runs.
+$ProgressPreference = "SilentlyContinue"
 
 if (-not $Url -or -not $Token) {
     throw "Url and Token are required (pass as parameters or set ALPAMON_URL / ALPAMON_TOKEN)."
@@ -74,6 +78,34 @@ $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIde
     [Security.Principal.WindowsBuiltInRole]::Administrator)
 if (-not $isAdmin) {
     throw "install.ps1 must be run from an elevated (Administrator) PowerShell."
+}
+
+# Force TLS 1.2+ before any Invoke-WebRequest / Invoke-RestMethod.
+# Older Server 2019 base images default to SSL3/TLS1.0, which fails
+# the GitHub API handshake. TLS 1.3 only exists on .NET Framework 4.8+,
+# so probe for the enum value rather than referencing the literal.
+$tls = [Net.SecurityProtocolType]::Tls12
+if ([Enum]::IsDefined([Net.SecurityProtocolType], 'Tls13')) {
+    $tls = $tls -bor [Net.SecurityProtocolType]'Tls13'
+}
+[Net.ServicePointManager]::SecurityProtocol = $tls
+
+# If an alpamon service already exists, stop it so `alpamon register`
+# can replace %ProgramFiles%\alpamon\alpamon.exe without hitting
+# ERROR_SHARING_VIOLATION. Track whether it was running so a failure
+# in the install block can put it back, matching Linux/macOS where a
+# failed register leaves the existing service untouched.
+$serviceWasRunning = $false
+$existingService = Get-Service -Name alpamon -ErrorAction SilentlyContinue
+if ($existingService) {
+    if ($existingService.Status -eq 'Running') { $serviceWasRunning = $true }
+    Write-Host "Existing alpamon service detected (status: $($existingService.Status)). Stopping..."
+    Stop-Service -Name alpamon -Force -ErrorAction Stop
+    # Stop-Service returns before the SCM fully releases the binary
+    # handle; without the wait, the subsequent copy can still race.
+    # WaitForStatus refreshes the ServiceController's state internally,
+    # so reusing $existingService is safe.
+    $existingService.WaitForStatus('Stopped', '00:00:30')
 }
 
 if (-not $Version) {
@@ -129,6 +161,9 @@ try {
 
     Write-Host "Extracting..."
     # tar.exe has shipped with Windows since 10 1803 / Server 2019.
+    if (-not (Get-Command tar.exe -ErrorAction SilentlyContinue)) {
+        throw "tar.exe not found on PATH. Windows 10 1803 / Server 2019 or newer is required."
+    }
     & tar.exe -xzf $archivePath -C $tempDir
     if ($LASTEXITCODE -ne 0) {
         throw "tar extraction failed (exit code $LASTEXITCODE). Windows 10 1803 / Server 2019 or newer required."
@@ -150,6 +185,17 @@ try {
 
     Write-Host ""
     Write-Host "Alpamon installed and registered."
+}
+catch {
+    # If we stopped a running service but then failed before register
+    # could bring it back up, restore the prior state on a best-effort
+    # basis. This mirrors Linux/macOS, where a failed `alpamon register`
+    # does not touch the existing service.
+    if ($serviceWasRunning) {
+        Write-Warning "Install failed; attempting to restart previously-running alpamon service."
+        Start-Service -Name alpamon -ErrorAction SilentlyContinue
+    }
+    throw
 }
 finally {
     Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -78,6 +78,11 @@ $ProgressPreference = "SilentlyContinue"
 # if a throw happens before the assignment points below.
 $serviceWasRunning = $false
 $tempDir = $null
+# SecurityProtocol is a process-wide setting, not script-scoped, so it
+# would persist in a caller that invoked the installer via `iwr | iex`.
+# Capture the prior value and restore it in the finally block for the
+# same reason $ProgressPreference is saved and restored above.
+$previousSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
 
 try {
     if (-not $Url -or -not $Token) {
@@ -221,5 +226,6 @@ finally {
     if ($tempDir -and (Test-Path $tempDir)) {
         Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
     }
+    [Net.ServicePointManager]::SecurityProtocol = $previousSecurityProtocol
     $ProgressPreference = $previousProgressPreference
 }


### PR DESCRIPTION
### Summary

- **install.ps1 hardening** (closes #287): the installer is now safe to re-run against a host with a running `alpamon` service, TLS 1.2 is forced for Server 2019 base images, failures roll back the service state, and several smaller robustness fixes land.
- **SHA-256 checksums alias** (unblocks alpacon-server #1963): every release now publishes `alpamon-checksums.sha256` as a byte-identical alias of the versioned checksums file, so `releases/latest/download/...` consumers no longer have to resolve a tag before verifying.

### Why

1. **Re-running `install.ps1` was broken in one concrete way and brittle in several others.** `alpamon register` copies itself into `%ProgramFiles%\alpamon\alpamon.exe`, which hits `ERROR_SHARING_VIOLATION` if a prior install left the service running. Stock Server 2019 images also default `SecurityProtocol` to SSL3/TLS1.0, so `api.github.com` handshakes fail before a download even starts. Both classes of failure leave the operator to debug PowerShell.
2. **alpacon-server's Windows install guide needs a version-independent checksum URL** (alpacon-server #1963). Today we only publish `alpamon-{version}-checksums.sha256`, which can't be fetched from the `releases/latest/download/...` path consumers want to use in their setup flow.

### What changed

#### `scripts/install.ps1`

- **Detect + stop an existing `alpamon` service** before the register step. After `Stop-Service`, wait on the `ServiceController` until the SCM reports `Stopped`, because `Stop-Service` returns before the binary handle is released.
- **Force TLS 1.2** via `ServicePointManager.SecurityProtocol`. TLS 1.3 is added only when `[Enum]::IsDefined` confirms the enum member exists, since `Tls13` is missing on .NET Framework < 4.8 and referencing it there throws at bind time.
- **Failure rollback**: if the installer fails after the service was stopped, the `catch` block best-effort restarts the previously-running service before re-throwing. This matches Linux/macOS, where a failed `alpamon register` never touches the existing service.
- **Fast IWR**: `$ProgressPreference = 'SilentlyContinue'` makes `Invoke-WebRequest` an order of magnitude faster on PS 5.1.
- **Preflight `tar.exe`** with a clearer error than the generic non-zero exit code.

#### `.github/workflows/release.yml`

- New step after the goreleaser job publishes a byte-identical `alpamon-checksums.sha256` alongside the existing `alpamon-{version}-checksums.sha256`. `gh release upload --clobber` lets the step be retried safely.
- Preflight check fails the release with a `::error` annotation if goreleaser didn't produce the versioned checksums file.
- `windows-smoke-test` now downloads the alias from the release and diffs it against the versioned file, guarded with `matrix.flavor == 'versioned'` so we don't pay the download twice. This is the regression guard: if a future edit silently breaks the upload step, the release fails before consumers see a broken alias.

#### `docs/windows.md`

- New **"Re-running `install.ps1`"** subsection documents the new behavior: safe stop-and-replace, `register`-refuses-on-already-registered (matching Linux/macOS, pointing operators at `alpamon upgrade` or Manual fallback for upgrades), automatic service restart on failure, forced TLS 1.2.
- Troubleshooting table: updated the existing `file in use` row (the script now handles it) and added a row for the new rollback warning.

### Acceptance criteria

#### Issue #287 (install.ps1)

- [x] `Get-Service alpamon` detected before extract / register; `Stop-Service -Force` if present.
- [x] `SecurityProtocol` set to `Tls12` (and `Tls13` when available) before any `Invoke-WebRequest` / `Invoke-RestMethod`.
- [x] Every `Invoke-WebRequest` / `tar.exe` / `alpamon.exe register` failure terminates the script with a non-zero exit (end-to-end: IWR throws under `ErrorActionPreference = Stop`; `tar.exe` and `alpamon.exe register` have explicit `$LASTEXITCODE` guards; the `try` block re-throws after rollback).
- [x] Administrator check and `try/finally` cleanup preserved.
- [x] Troubleshooting checklist added to `docs/windows.md`.

#### SHA-256 checksums alias issue

- [x] `alpamon-checksums.sha256` uploaded as an additional release asset on every release, byte-identical to `alpamon-{version}-checksums.sha256`.
- [x] Windows artifacts (versioned + stable alias) already built by `.goreleaser.yaml` on stable releases (prior work).
- [x] `curl -fIL .../releases/latest/download/alpamon-checksums.sha256` will return `200` after the next release promotion.
- [x] `curl -fIL .../releases/latest/download/alpamon-windows-amd64.zip` already returns `200`.
- [x] `gh api .../releases/latest --jq '.assets[].name'` will list both alias files after the next release.

### Test plan

CI:

- [x] `windows-smoke-test` matrix continues to verify both the versioned archive and the Windows alias archive end-to-end (download → SHA-256 → extract → `alpamon.exe --version`).
- [x] New step diffs the checksums alias against the versioned file; release fails fast if the upload step regresses.

Manual (on Server 2019 / 2022 VM):

- [ ] **Fresh install**: `.\install.ps1 -Url <u> -Token <t>` on a clean VM succeeds, service reaches Running. (Also exercises the TLS 1.2 probe on a base image.)
- [ ] **Re-run on registered host**: service was Running; installer detects it, stops it, `register` refuses with config-exists error (matches Linux/macOS), catch block restarts the service. Final state: service Running, installer exit non-zero.
- [ ] **Partial state**: install once, delete `%ProgramData%\alpamon\alpamon.conf`, re-run. Stop → register succeeds → service Running.
- [ ] **Simulated mid-install failure**: supply a bad token so `register` exits non-zero. Confirm the catch block restarts the previously-running service.
- [ ] **Checksums alias** (post-release): `curl -fIL https://github.com/alpacax/alpamon/releases/latest/download/alpamon-checksums.sha256` returns 200, `sha256sum` matches the versioned file bundled with the same release.

### Out of scope

- MSI installer, Authenticode signing of `install.ps1` / `alpamon.exe`, signed checksums file verification (each tracked separately).
- Auto-upgrade path inside `install.ps1` (decided: `install.ps1` mirrors Linux/macOS register semantics; upgrades go through `alpamon upgrade` or the documented Manual fallback).

### Linked issues

- Closes alpacax/alpamon#287
- Unblocks alpacon-server#1963 (Windows registration guide production rollout)