### PR TITLE
feat(plugin): add pkg/plugin host runtime for plugin agents

### DIFF
--- a/cmd/alpamon/command/setup/setup.go
+++ b/cmd/alpamon/command/setup/setup.go
@@ -33,6 +33,10 @@ func SetConfigPaths(serviceName string) {
 	name = serviceName
 	configTarget = filepath.Join(utils.ConfigDir(), fmt.Sprintf("%s.conf", name))
 	templateFilePath = filepath.Join(utils.ConfigDir(), fmt.Sprintf("%s.config.tmpl", name))
+	// Refresh the help string with the resolved service name. SetupCmd.Short
+	// is computed at package-init time, when `name` is still empty—without
+	// this refresh, `<binary> --help` would show "Setup and configure the ."
+	SetupCmd.Short = fmt.Sprintf("Setup and configure the %s.", name)
 }
 
 var SetupCmd = &cobra.Command{

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -11,7 +11,6 @@ package plugin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -107,9 +106,13 @@ type BuildResult struct {
 
 // NewRootCmd returns a Cobra command that runs the plugin and exposes the
 // shared `setup` subcommand. The returned command is suitable for use as the
-// plugin binary's root command. NewRootCmd panics if p fails validation, so
-// misconfigured plugins fail at process start rather than at first run.
+// plugin binary's root command. NewRootCmd panics if p is nil or fails
+// validation, so misconfigured plugins fail at process start rather than at
+// first run.
 func NewRootCmd(p *Plugin) *cobra.Command {
+	if p == nil {
+		panic("plugin: nil Plugin")
+	}
 	if err := p.validate(); err != nil {
 		panic(err)
 	}
@@ -265,6 +268,8 @@ func (p *Plugin) validate() error {
 	switch {
 	case p.Name == "":
 		return fmt.Errorf("plugin: Name is required")
+	case p.Version == "":
+		return fmt.Errorf("plugin: Version is required")
 	case p.WSPath == "":
 		return fmt.Errorf("plugin: WSPath is required")
 	case p.CheckServerURL == "":
@@ -291,21 +296,26 @@ func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) b
 			log.Error().Msg("Session check cancelled or timed out.")
 			return false
 		case <-time.After(timeout):
-			jsonData, _ := json.Marshal(map[string]string{"version": p.Version})
+			body := map[string]string{"version": p.Version}
 
-			_, statusCode, err := session.Patch(p.CheckServerURL, jsonData, 5)
+			_, statusCode, err := session.Patch(p.CheckServerURL, body, 5)
 			if err != nil || (statusCode != http.StatusOK && statusCode != http.StatusCreated) {
+				// Compute the next backoff before logging so the message
+				// reflects the actual delay (the previous version logged the
+				// stale value, which started at 0s on the first failure).
+				next := timeout
+				if next == 0 {
+					next = config.MinConnectInterval
+				}
+				next *= 2
+				if next > config.MaxConnectInterval {
+					next = config.MaxConnectInterval
+				}
 				log.Debug().Err(err).Msgf(
 					"Failed to connect to %s, will try again in %ds",
-					config.GlobalSettings.ServerURL, int(timeout.Seconds()),
+					config.GlobalSettings.ServerURL, int(next.Seconds()),
 				)
-				if timeout == 0 {
-					timeout = config.MinConnectInterval
-				}
-				timeout *= 2
-				if timeout > config.MaxConnectInterval {
-					timeout = config.MaxConnectInterval
-				}
+				timeout = next
 				continue
 			}
 			return true

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,7 +3,7 @@
 // It encapsulates the boilerplate that every plugin previously duplicated:
 // signal handling, pidfile management, config loading, session setup, the
 // initial server-side version handshake, and the websocket lifecycle
-// (graceful shutdown + in-place restart).
+// (graceful shutdown plus in-place restart).
 //
 // A plugin defines a Plugin value and either calls Plugin.Run directly or
 // embeds it under a Cobra root command via NewRootCmd.
@@ -34,6 +34,10 @@ import (
 // shutdownTimeout bounds how long the SDK waits for the worker pool to drain.
 const shutdownTimeout = 30 * time.Second
 
+// exitRestart is the internal sentinel exit code used by run to signal that
+// Run should exec the binary in place after deferred cleanup completes.
+const exitRestart = -1
+
 // Plugin describes a plugin agent. Name, Version, WSPath, CheckServerURL and
 // Build are required; the rest are optional.
 type Plugin struct {
@@ -62,7 +66,7 @@ type Plugin struct {
 	InitLogger func()
 
 	// PreConfigInit, if set, runs after config files are resolved but before
-	// LoadConfig. Used by plugins that need to validate / fix-up paths
+	// LoadConfig. Used by plugins that need to validate or fix-up paths
 	// referenced in their INI files (e.g. storage paths).
 	PreConfigInit func(configFiles []string)
 
@@ -73,6 +77,10 @@ type Plugin struct {
 	//
 	// The websocket client's lifecycle (Close, ShutDownChan, RestartChan)
 	// is owned by the SDK; plugins should not call Close on it themselves.
+	//
+	// The provided ctx is the plugin's lifecycle context: it is cancelled on
+	// shutdown or restart. Long-running goroutines started by Build should
+	// honor it.
 	Build func(ctx context.Context, host Host) (*BuildResult, error)
 }
 
@@ -99,8 +107,12 @@ type BuildResult struct {
 
 // NewRootCmd returns a Cobra command that runs the plugin and exposes the
 // shared `setup` subcommand. The returned command is suitable for use as the
-// plugin binary's root command.
+// plugin binary's root command. NewRootCmd panics if p fails validation, so
+// misconfigured plugins fail at process start rather than at first run.
 func NewRootCmd(p *Plugin) *cobra.Command {
+	if err := p.validate(); err != nil {
+		panic(err)
+	}
 	cmd := &cobra.Command{
 		Use:   p.Name,
 		Short: fmt.Sprintf("%s agent", p.Name),
@@ -120,9 +132,26 @@ func NewRootCmd(p *Plugin) *cobra.Command {
 // Run blocks until the agent stops. On a Restart signal it execs the current
 // binary in place and does not return.
 func (p *Plugin) Run() {
+	switch code := p.run(); code {
+	case 0:
+		return
+	case exitRestart:
+		// All deferred cleanups in run have completed; exec the new image.
+		p.restartAgent()
+		os.Exit(1) // only reached if syscall.Exec fails
+	default:
+		os.Exit(code)
+	}
+}
+
+// run drives the plugin lifecycle and returns an exit code (or exitRestart
+// to indicate the caller should exec the binary). Using a return value
+// instead of os.Exit lets deferred cleanups—pidfile removal, pool shutdown,
+// context manager shutdown—run on every exit path.
+func (p *Plugin) run() int {
 	if err := p.validate(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		return 1
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -142,15 +171,43 @@ func (p *Plugin) Run() {
 	if p.InitLogger != nil {
 		p.InitLogger()
 	}
-
 	utils.InitPlatform()
 
 	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(p.Name))
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "Failed to create PID file.", err.Error())
-		os.Exit(1)
+		return 1
 	}
-	defer func() { _ = os.Remove(pidFilePath) }()
+
+	// Single shutdown closure so the order matches the original per-plugin
+	// behavior: ws.Close first (stops incoming reads), then plugin Cleanup,
+	// then pool drain, then context manager, then pidfile removal. The
+	// captured pointers are nil until the corresponding step succeeds, so
+	// the closure is safe to register early.
+	var (
+		wsClient   *runner.WebsocketClient
+		ctxManager *agent.ContextManager
+		workerPool *pool.Pool
+		buildRes   *BuildResult
+	)
+	defer func() {
+		if wsClient != nil {
+			wsClient.Close()
+		}
+		if buildRes != nil && buildRes.Cleanup != nil {
+			buildRes.Cleanup()
+		}
+		if workerPool != nil {
+			if err := workerPool.Shutdown(shutdownTimeout); err != nil {
+				log.Warn().Err(err).Msg("Worker pool shutdown timed out.")
+			}
+		}
+		if ctxManager != nil {
+			ctxManager.Shutdown()
+		}
+		log.Debug().Msg("Bye.")
+		_ = os.Remove(pidFilePath)
+	}()
 
 	log.Info().Msgf("Starting %s... (version: %s)", p.Name, p.Version)
 
@@ -162,51 +219,45 @@ func (p *Plugin) Run() {
 	config.InitSettings(settings)
 
 	session := scheduler.InitSession()
-	p.checkSession(ctx, session)
+	if !p.checkSession(ctx, session) {
+		return 1
+	}
 
-	ctxManager := agent.NewContextManager()
-	workerPool := pool.NewPool(
+	ctxManager = agent.NewContextManager()
+	workerPool = pool.NewPool(
 		config.GlobalSettings.PoolMaxWorkers,
 		config.GlobalSettings.PoolQueueSize,
 	)
-	wsClient := runner.NewWebsocketClient(session, ctxManager, workerPool)
+	wsClient = runner.NewWebsocketClient(session, ctxManager, workerPool)
 
-	host := Host{
-		Session:  session,
-		WSClient: wsClient,
-	}
+	host := Host{Session: session, WSClient: wsClient}
 
 	log.Info().Msgf("%s initialized and running.", p.Name)
 
-	result, err := p.Build(ctx, host)
+	buildRes, err = p.Build(ctx, host)
 	if err != nil {
 		log.Error().Err(err).Msg("Plugin build failed.")
-		os.Exit(1)
+		return 1
 	}
-	if result == nil || result.Run == nil {
+	if buildRes == nil || buildRes.Run == nil {
 		log.Error().Msg("Plugin returned an invalid BuildResult.")
-		os.Exit(1)
+		return 1
 	}
 
-	go result.Run(ctx)
+	go buildRes.Run(ctx)
 
-	restart := false
 	select {
 	case <-ctx.Done():
 		log.Info().Msg("Received termination signal. Shutting down...")
+		return 0
 	case <-wsClient.ShutDownChan:
 		log.Info().Msg("Shutdown command received. Shutting down...")
 		cancel()
+		return 0
 	case <-wsClient.RestartChan:
 		log.Info().Msg("Restart command received. Restarting...")
 		cancel()
-		restart = true
-	}
-
-	p.gracefulShutdown(host, result, workerPool, ctxManager, pidFilePath)
-
-	if restart {
-		p.restartAgent()
+		return exitRestart
 	}
 }
 
@@ -226,8 +277,9 @@ func (p *Plugin) validate() error {
 
 // checkSession performs the initial version handshake against the server.
 // It retries with exponential backoff bounded by the scheduler limits and
-// exits the process if it cannot reach the server within MaxRetryTimeout.
-func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) {
+// returns false if it cannot reach the server within MaxRetryTimeout, so
+// the caller can return an error code through deferred cleanup.
+func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) bool {
 	log.Debug().Msg("Checking current session...")
 	timeout := time.Duration(0)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, scheduler.MaxRetryTimeout)
@@ -237,7 +289,7 @@ func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) {
 		select {
 		case <-ctxWithTimeout.Done():
 			log.Error().Msg("Session check cancelled or timed out.")
-			os.Exit(1)
+			return false
 		case <-time.After(timeout):
 			jsonData, _ := json.Marshal(map[string]string{"version": p.Version})
 
@@ -256,28 +308,9 @@ func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) {
 				}
 				continue
 			}
-			return
+			return true
 		}
 	}
-}
-
-func (p *Plugin) gracefulShutdown(host Host, result *BuildResult, workerPool *pool.Pool, ctxManager *agent.ContextManager, pidPath string) {
-	if host.WSClient != nil {
-		host.WSClient.Close()
-	}
-	if result != nil && result.Cleanup != nil {
-		result.Cleanup()
-	}
-	if workerPool != nil {
-		if err := workerPool.Shutdown(shutdownTimeout); err != nil {
-			log.Warn().Err(err).Msg("Worker pool shutdown timed out.")
-		}
-	}
-	if ctxManager != nil {
-		ctxManager.Shutdown()
-	}
-	log.Debug().Msg("Bye.")
-	_ = os.Remove(pidPath)
 }
 
 func (p *Plugin) restartAgent() {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,292 @@
+// Package plugin provides a shared host runtime for alpamon plugins.
+//
+// It encapsulates the boilerplate that every plugin previously duplicated:
+// signal handling, pidfile management, config loading, session setup, the
+// initial server-side version handshake, and the websocket lifecycle
+// (graceful shutdown + in-place restart).
+//
+// A plugin defines a Plugin value and either calls Plugin.Run directly or
+// embeds it under a Cobra root command via NewRootCmd.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/alpacax/alpamon/cmd/alpamon/command/setup"
+	"github.com/alpacax/alpamon/internal/pool"
+	"github.com/alpacax/alpamon/pkg/agent"
+	"github.com/alpacax/alpamon/pkg/config"
+	"github.com/alpacax/alpamon/pkg/pidfile"
+	"github.com/alpacax/alpamon/pkg/runner"
+	"github.com/alpacax/alpamon/pkg/scheduler"
+	"github.com/alpacax/alpamon/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// shutdownTimeout bounds how long the SDK waits for the worker pool to drain.
+const shutdownTimeout = 30 * time.Second
+
+// Plugin describes a plugin agent. Name, Version, WSPath, CheckServerURL and
+// Build are required; the rest are optional.
+type Plugin struct {
+	// Name is the plugin's binary/service name, e.g. "alpamon-dhcp-plugin".
+	// Used for the pidfile, logging, and config file lookup.
+	Name string
+
+	// Version is the plugin's version string (sent in the initial handshake).
+	Version string
+
+	// WSPath is the websocket route used for the main backhaul connection,
+	// e.g. "/ws/dhcp/backhaul/".
+	WSPath string
+
+	// ControlWSPath is the optional control-channel websocket route.
+	// Most plugins leave this empty.
+	ControlWSPath string
+
+	// CheckServerURL is the HTTP path PATCHed during the version handshake
+	// before opening the websocket, e.g. "/api/dhcp/-/".
+	CheckServerURL string
+
+	// InitLogger is called once at startup, before any other initialization,
+	// to configure the plugin's logger. Each plugin owns its own logger
+	// package, so the SDK delegates this step.
+	InitLogger func()
+
+	// PreConfigInit, if set, runs after config files are resolved but before
+	// LoadConfig. Used by plugins that need to validate / fix-up paths
+	// referenced in their INI files (e.g. storage paths).
+	PreConfigInit func(configFiles []string)
+
+	// Build is called after the session, worker pool, context manager and
+	// websocket client have all been initialized. It receives the host
+	// resources and returns the Run function that the SDK will spawn in a
+	// goroutine, plus an optional Cleanup that runs before exit/restart.
+	//
+	// The websocket client's lifecycle (Close, ShutDownChan, RestartChan)
+	// is owned by the SDK; plugins should not call Close on it themselves.
+	Build func(ctx context.Context, host Host) (*BuildResult, error)
+}
+
+// Host is the bundle of host-managed resources passed to Plugin.Build. The
+// websocket client is fully constructed and ready for the plugin to wire
+// into its domain types. The worker pool and context manager that back the
+// websocket client are owned by the SDK and intentionally not exposed.
+type Host struct {
+	Session  *scheduler.Session
+	WSClient *runner.WebsocketClient
+}
+
+// BuildResult is what Plugin.Build returns to the SDK.
+type BuildResult struct {
+	// Run is invoked in a goroutine by the SDK. Typically this is the
+	// plugin client's RunForever method.
+	Run func(ctx context.Context)
+
+	// Cleanup, if non-nil, runs once before the process exits or restarts.
+	// It is called after the websocket client is closed but before the pool
+	// and context manager are shut down.
+	Cleanup func()
+}
+
+// NewRootCmd returns a Cobra command that runs the plugin and exposes the
+// shared `setup` subcommand. The returned command is suitable for use as the
+// plugin binary's root command.
+func NewRootCmd(p *Plugin) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   p.Name,
+		Short: fmt.Sprintf("%s agent", p.Name),
+		Run: func(cmd *cobra.Command, args []string) {
+			p.Run()
+		},
+	}
+	setup.SetConfigPaths(p.Name)
+	cmd.AddCommand(setup.SetupCmd)
+	return cmd
+}
+
+// Run executes the plugin's full lifecycle: signal setup, logger / pidfile /
+// config / session initialization, the version handshake, websocket startup,
+// and graceful shutdown or in-place restart on the corresponding signals.
+//
+// Run blocks until the agent stops. On a Restart signal it execs the current
+// binary in place and does not return.
+func (p *Plugin) Run() {
+	if err := p.validate(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+	go func() {
+		select {
+		case <-sigChan:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	if p.InitLogger != nil {
+		p.InitLogger()
+	}
+
+	utils.InitPlatform()
+
+	pidFilePath, err := pidfile.WritePID(pidfile.FilePath(p.Name))
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Failed to create PID file.", err.Error())
+		os.Exit(1)
+	}
+	defer func() { _ = os.Remove(pidFilePath) }()
+
+	log.Info().Msgf("Starting %s... (version: %s)", p.Name, p.Version)
+
+	configFiles := config.Files(p.Name)
+	if p.PreConfigInit != nil {
+		p.PreConfigInit(configFiles)
+	}
+	settings := config.LoadConfig(configFiles, p.WSPath, p.ControlWSPath)
+	config.InitSettings(settings)
+
+	session := scheduler.InitSession()
+	p.checkSession(ctx, session)
+
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(
+		config.GlobalSettings.PoolMaxWorkers,
+		config.GlobalSettings.PoolQueueSize,
+	)
+	wsClient := runner.NewWebsocketClient(session, ctxManager, workerPool)
+
+	host := Host{
+		Session:  session,
+		WSClient: wsClient,
+	}
+
+	log.Info().Msgf("%s initialized and running.", p.Name)
+
+	result, err := p.Build(ctx, host)
+	if err != nil {
+		log.Error().Err(err).Msg("Plugin build failed.")
+		os.Exit(1)
+	}
+	if result == nil || result.Run == nil {
+		log.Error().Msg("Plugin returned an invalid BuildResult.")
+		os.Exit(1)
+	}
+
+	go result.Run(ctx)
+
+	restart := false
+	select {
+	case <-ctx.Done():
+		log.Info().Msg("Received termination signal. Shutting down...")
+	case <-wsClient.ShutDownChan:
+		log.Info().Msg("Shutdown command received. Shutting down...")
+		cancel()
+	case <-wsClient.RestartChan:
+		log.Info().Msg("Restart command received. Restarting...")
+		cancel()
+		restart = true
+	}
+
+	p.gracefulShutdown(host, result, workerPool, ctxManager, pidFilePath)
+
+	if restart {
+		p.restartAgent()
+	}
+}
+
+func (p *Plugin) validate() error {
+	switch {
+	case p.Name == "":
+		return fmt.Errorf("plugin: Name is required")
+	case p.WSPath == "":
+		return fmt.Errorf("plugin: WSPath is required")
+	case p.CheckServerURL == "":
+		return fmt.Errorf("plugin: CheckServerURL is required")
+	case p.Build == nil:
+		return fmt.Errorf("plugin: Build is required")
+	}
+	return nil
+}
+
+// checkSession performs the initial version handshake against the server.
+// It retries with exponential backoff bounded by the scheduler limits and
+// exits the process if it cannot reach the server within MaxRetryTimeout.
+func (p *Plugin) checkSession(ctx context.Context, session *scheduler.Session) {
+	log.Debug().Msg("Checking current session...")
+	timeout := time.Duration(0)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, scheduler.MaxRetryTimeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctxWithTimeout.Done():
+			log.Error().Msg("Session check cancelled or timed out.")
+			os.Exit(1)
+		case <-time.After(timeout):
+			jsonData, _ := json.Marshal(map[string]string{"version": p.Version})
+
+			_, statusCode, err := session.Patch(p.CheckServerURL, jsonData, 5)
+			if err != nil || (statusCode != http.StatusOK && statusCode != http.StatusCreated) {
+				log.Debug().Err(err).Msgf(
+					"Failed to connect to %s, will try again in %ds",
+					config.GlobalSettings.ServerURL, int(timeout.Seconds()),
+				)
+				if timeout == 0 {
+					timeout = config.MinConnectInterval
+				}
+				timeout *= 2
+				if timeout > config.MaxConnectInterval {
+					timeout = config.MaxConnectInterval
+				}
+				continue
+			}
+			return
+		}
+	}
+}
+
+func (p *Plugin) gracefulShutdown(host Host, result *BuildResult, workerPool *pool.Pool, ctxManager *agent.ContextManager, pidPath string) {
+	if host.WSClient != nil {
+		host.WSClient.Close()
+	}
+	if result != nil && result.Cleanup != nil {
+		result.Cleanup()
+	}
+	if workerPool != nil {
+		if err := workerPool.Shutdown(shutdownTimeout); err != nil {
+			log.Warn().Err(err).Msg("Worker pool shutdown timed out.")
+		}
+	}
+	if ctxManager != nil {
+		ctxManager.Shutdown()
+	}
+	log.Debug().Msg("Bye.")
+	_ = os.Remove(pidPath)
+}
+
+func (p *Plugin) restartAgent() {
+	executable, err := os.Executable()
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to restart the %s.", p.Name)
+		return
+	}
+	if err := syscall.Exec(executable, os.Args, os.Environ()); err != nil {
+		log.Error().Err(err).Msgf("Failed to restart the %s.", p.Name)
+	}
+}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -25,11 +25,12 @@ func TestValidate(t *testing.T) {
 		p    Plugin
 		want string
 	}{
-		{"missing name", Plugin{WSPath: "/x", CheckServerURL: "/y", Build: build}, "Name"},
-		{"missing wspath", Plugin{Name: "p", CheckServerURL: "/y", Build: build}, "WSPath"},
-		{"missing check url", Plugin{Name: "p", WSPath: "/x", Build: build}, "CheckServerURL"},
-		{"missing build", Plugin{Name: "p", WSPath: "/x", CheckServerURL: "/y"}, "Build"},
-		{"complete", Plugin{Name: "p", WSPath: "/x", CheckServerURL: "/y", Build: build}, ""},
+		{"missing name", Plugin{Version: "v1", WSPath: "/x", CheckServerURL: "/y", Build: build}, "Name"},
+		{"missing version", Plugin{Name: "p", WSPath: "/x", CheckServerURL: "/y", Build: build}, "Version"},
+		{"missing wspath", Plugin{Name: "p", Version: "v1", CheckServerURL: "/y", Build: build}, "WSPath"},
+		{"missing check url", Plugin{Name: "p", Version: "v1", WSPath: "/x", Build: build}, "CheckServerURL"},
+		{"missing build", Plugin{Name: "p", Version: "v1", WSPath: "/x", CheckServerURL: "/y"}, "Build"},
+		{"complete", Plugin{Name: "p", Version: "v1", WSPath: "/x", CheckServerURL: "/y", Build: build}, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,4 +83,18 @@ func TestNewRootCmdPanicsOnInvalidPlugin(t *testing.T) {
 		}
 	}()
 	NewRootCmd(&Plugin{}) // missing required fields
+}
+
+func TestNewRootCmdPanicsOnNilPlugin(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected NewRootCmd to panic on nil Plugin")
+		}
+		s, ok := r.(string)
+		if !ok || !strings.Contains(s, "nil Plugin") {
+			t.Fatalf("expected panic message mentioning nil Plugin, got %v", r)
+		}
+	}()
+	NewRootCmd(nil)
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	build := func(context.Context, Host) (*BuildResult, error) { return nil, nil }
+	tests := []struct {
+		name string
+		p    Plugin
+		want string
+	}{
+		{"missing name", Plugin{WSPath: "/x", CheckServerURL: "/y", Build: build}, "Name"},
+		{"missing wspath", Plugin{Name: "p", CheckServerURL: "/y", Build: build}, "WSPath"},
+		{"missing check url", Plugin{Name: "p", WSPath: "/x", Build: build}, "CheckServerURL"},
+		{"missing build", Plugin{Name: "p", WSPath: "/x", CheckServerURL: "/y"}, "Build"},
+		{"complete", Plugin{Name: "p", WSPath: "/x", CheckServerURL: "/y", Build: build}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.p.validate()
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+func validPlugin() Plugin {
+	return Plugin{
+		Name:           "alpamon-test-plugin",
+		Version:        "test",
+		WSPath:         "/ws/test/",
+		CheckServerURL: "/api/test/-/",
+		Build: func(context.Context, Host) (*BuildResult, error) {
+			return &BuildResult{Run: func(context.Context) {}}, nil
+		},
+	}
+}
+
 func TestValidate(t *testing.T) {
 	build := func(context.Context, Host) (*BuildResult, error) { return nil, nil }
 	tests := []struct {
@@ -33,4 +45,41 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewRootCmdValid(t *testing.T) {
+	p := validPlugin()
+	cmd := NewRootCmd(&p)
+	if cmd == nil {
+		t.Fatal("NewRootCmd returned nil")
+	}
+	if cmd.Use != p.Name {
+		t.Fatalf("cmd.Use = %q, want %q", cmd.Use, p.Name)
+	}
+	// The shared `setup` subcommand must be wired up so plugins can run
+	// `<binary> setup` for first-time configuration.
+	var hasSetup bool
+	for _, sub := range cmd.Commands() {
+		if sub.Use == "setup" {
+			hasSetup = true
+			break
+		}
+	}
+	if !hasSetup {
+		t.Fatal("expected `setup` subcommand to be registered")
+	}
+}
+
+func TestNewRootCmdPanicsOnInvalidPlugin(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected NewRootCmd to panic on invalid Plugin")
+		}
+		err, ok := r.(error)
+		if !ok || !strings.Contains(err.Error(), "Name") {
+			t.Fatalf("expected error mentioning Name, got %v", r)
+		}
+	}()
+	NewRootCmd(&Plugin{}) // missing required fields
 }


### PR DESCRIPTION
## Summary

Introduce `pkg/plugin`, a shared host runtime that encapsulates the boilerplate every alpamon plugin previously duplicated in its `cmd/.../command/root.go`:

- signal handling (SIGINT/SIGTERM)
- pidfile management
- config loading + `InitSettings`
- session setup
- initial server-side version handshake (`PATCH CheckServerURL`)
- websocket lifecycle (creates `WebsocketClient` with the `ContextManager` + `Pool` that v2 requires, manages `ShutDownChan` / `RestartChan`)
- graceful shutdown plus in-place restart (`syscall.Exec`)

Plugins describe themselves with a `Plugin` value (Name, Version, WSPath, CheckServerURL, Build, optional InitLogger / PreConfigInit / ControlWSPath) and either call `Plugin.Run` directly or embed it under a Cobra root command via `NewRootCmd`. With this in place, each of the six existing plugins drops ~150 lines of carbon-copy bootstrap.

## Why

- alpamon v2's `runner.NewWebsocketClient(session, ctxManager, pool)` requires resources that plugins should not have to know about (`internal/pool` is in fact unreachable from outside this module).
- The six plugin repos re-implement the same lifecycle, so any change—new graceful-shutdown logic, new config field, new handshake step—has to land in six places. A shared SDK collapses that.

## Design notes

- `Host` exposes only `Session` + `WSClient`; the worker pool and context manager that back the websocket client are owned by the SDK and intentionally not in the public API.
- The shared `setup` subcommand is wired up automatically via `NewRootCmd`.
- `NewRootCmd` validates the Plugin value and panics on missing required fields, so misconfigured plugins fail at process start instead of at first run.
- `Run` is a thin wrapper around an internal `run` helper that returns an exit code. All teardown (ws.Close → plugin Cleanup → pool.Shutdown(30s) → ctxManager.Shutdown → pidfile removal) lives in a single deferred closure so it fires on every exit path—including the ones that previously called `os.Exit` directly and leaked stale pidfiles to disk.
- An `exitRestart` sentinel lets `run` request `syscall.Exec` *after* deferred cleanup completes, preserving the legacy in-place-restart behavior.

## What's not in this PR

- Plugin migrations: those land as separate PRs in each plugin repo (one per repo, all sharing the same shape: bump alpamon to v2 + adopt `pkg/plugin`). Those PRs depend on this one being tagged as v2.2.0.
- No new external dependencies. `pkg/plugin` only reuses existing alpamon packages (`pkg/runner`, `pkg/scheduler`, `pkg/config`, `pkg/pidfile`, `pkg/utils`, `pkg/agent`, `internal/pool`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/plugin/...` — covers `validate()` (table-driven), `NewRootCmd` happy path (verifies setup subcommand is wired), and `NewRootCmd` panic-on-invalid-Plugin
- [x] `go test ./...` — full alpamon suite passes
- [x] Six downstream plugins build cleanly against this branch (verified locally via `replace` directive); will be verified end-to-end once their PRs open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)