### PR TITLE
feat(updater): gate Windows self-update on a verified SCM restart path

### DIFF
--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -15,6 +15,9 @@ import (
 )
 
 const (
+	// Keep serviceName and the recovery values in sync with the copies in
+	// pkg/updater/guard_windows.go (the self-update preflight guard) and
+	// svcName in cmd/alpamon/command/svc_windows.go.
 	serviceName          = "alpamon"
 	serviceDisplayName   = "Alpamon Agent"
 	serviceDescription   = "Secure server agent for the Alpacon infrastructure access platform."

--- a/cmd/alpamon/command/register/service_windows.go
+++ b/cmd/alpamon/command/register/service_windows.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
@@ -15,14 +16,8 @@ import (
 )
 
 const (
-	// Keep serviceName and the recovery values in sync with the copies in
-	// pkg/updater/guard_windows.go (the self-update preflight guard) and
-	// svcName in cmd/alpamon/command/svc_windows.go.
-	serviceName          = "alpamon"
-	serviceDisplayName   = "Alpamon Agent"
-	serviceDescription   = "Secure server agent for the Alpacon infrastructure access platform."
-	recoveryResetSeconds = 60
-	recoveryRestartDelay = 5 * time.Second
+	serviceDisplayName = "Alpamon Agent"
+	serviceDescription = "Secure server agent for the Alpacon infrastructure access platform."
 
 	// serviceStopPoll* bound how long removeService waits for the SCM to report
 	// the service Stopped before deleting it (15s total).
@@ -67,13 +62,13 @@ func startService() error {
 	// Only treat ERROR_SERVICE_DOES_NOT_EXIST as "go create it"; any
 	// other OpenService failure (access denied, RPC issues) should
 	// surface so the operator can address it.
-	s, err := m.OpenService(serviceName)
+	s, err := m.OpenService(svcdef.ServiceName)
 	if err != nil {
 		if !isServiceNotExist(err) {
 			return fmt.Errorf("open service: %w%s", err, elevationHint(err))
 		}
 		s, err = m.CreateService(
-			serviceName,
+			svcdef.ServiceName,
 			serviceBinPath,
 			mgr.Config{
 				DisplayName:      serviceDisplayName,
@@ -134,12 +129,8 @@ func startService() error {
 
 	// Auto-restart on crash. Use conservative delays so a broken
 	// binary doesn't thrash SCM.
-	recoveryActions := []mgr.RecoveryAction{
-		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
-		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
-		{Type: mgr.NoAction},
-	}
-	if err := s.SetRecoveryActions(recoveryActions, recoveryResetSeconds); err != nil {
+	recoveryActions := svcdef.DefaultRecoveryActions()
+	if err := s.SetRecoveryActions(recoveryActions, svcdef.RecoveryResetSeconds); err != nil {
 		// Non-fatal; log and continue. The service will still start,
 		// just without automatic recovery.
 		fmt.Printf("Warning: failed to configure service recovery actions: %v\n", err)
@@ -171,7 +162,7 @@ func withService(fn func(*mgr.Service) error) error {
 	}
 	defer func() { _ = m.Disconnect() }()
 
-	s, err := m.OpenService(serviceName)
+	s, err := m.OpenService(svcdef.ServiceName)
 	if err != nil {
 		if isServiceNotExist(err) {
 			return nil

--- a/cmd/alpamon/command/svc_windows.go
+++ b/cmd/alpamon/command/svc_windows.go
@@ -3,13 +3,10 @@ package command
 import (
 	"sync"
 
+	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows/svc"
 )
-
-// svcName is the Windows Service name registered by `alpamon register`.
-// Must match what register creates.
-const svcName = "alpamon"
 
 // Shutdown hook bridge: runAgent installs its ContextManager.Shutdown
 // via setShutdownFunc, and the SCM handler below invokes it on Stop /
@@ -85,7 +82,7 @@ func runService() {
 	// error it encountered, if any; log it and exit normally so SCM
 	// doesn't reboot the service under a Recovery Action for a
 	// clean stop.
-	if err := svc.Run(svcName, handler); err != nil {
+	if err := svc.Run(svcdef.ServiceName, handler); err != nil {
 		log.Error().Err(err).Msg("Windows Service dispatcher returned an error.")
 	}
 }

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -198,6 +198,11 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 // selfUpdate downloads and replaces the binary from GitHub Releases, then triggers restart.
 func (h *SystemHandler) selfUpdate(ctx context.Context, latestVersion string) (int, string, error) {
 	if err := h.selfUpdateFn(ctx, latestVersion, updater.Options{}); err != nil {
+		if errors.Is(err, updater.ErrSelfUpdateInProgress) {
+			// Rejecting a duplicate is correct, not a failure; the run that owns
+			// the update handles its own restart, so don't schedule another.
+			return 0, "Self-update already in progress.", nil
+		}
 		return 1, fmt.Sprintf("Self-update failed: %v", err), err
 	}
 

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -209,6 +209,9 @@ func (h *SystemHandler) selfUpdate(ctx context.Context, latestVersion string) (i
 	if err := h.scheduleDelayedAction(1*time.Second, func(_ context.Context) {
 		h.wsClient.Restart()
 	}); err != nil {
+		// The update landed but no restart will fire, so drop the latch SelfUpdate
+		// holds on success—otherwise a manual retry would be rejected as a duplicate.
+		updater.ReleaseSelfUpdateLatch()
 		log.Error().Err(err).Msg("Failed to submit restart task after self-update. Manual restart required.")
 		return 1, fmt.Sprintf("Updated to %s, but automatic restart failed: %v. Please restart alpamon manually.", latestVersion, err), err
 	}

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -660,3 +660,38 @@ func TestSystemHandler_SelfUpdate_AlreadyInProgress(t *testing.T) {
 		t.Error("in-progress path must not schedule a restart")
 	}
 }
+
+// TestSystemHandler_SelfUpdate_RestartScheduleFails: a successful update whose restart
+// can't be scheduled reports a manual-restart failure and fires no restart. The latch
+// release on this branch is asserted in the updater package.
+func TestSystemHandler_SelfUpdate_RestartScheduleFails(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer ctxManager.Shutdown()
+	// Shut the pool down up front so scheduleDelayedAction's Submit fails.
+	if err := workerPool.Shutdown(1 * time.Second); err != nil {
+		t.Fatalf("failed to shut down pool: %v", err)
+	}
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{}, nil)
+	handler.selfUpdateFn = func(_ context.Context, _ string, _ updater.Options) error {
+		return nil // update succeeded
+	}
+
+	exitCode, output, err := handler.selfUpdate(context.Background(), "v9.9.9")
+
+	if err == nil {
+		t.Fatal("expected error when restart scheduling fails")
+	}
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+	if !strings.Contains(output, "manually") {
+		t.Errorf("expected manual-restart hint, got %q", output)
+	}
+	if mockWS.RestartCalled {
+		t.Error("restart must not fire when scheduling failed")
+	}
+}

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -630,3 +630,33 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 		})
 	}
 }
+
+// TestSystemHandler_SelfUpdate_AlreadyInProgress: a concurrent self-update is a benign no-op—exit 0, no error, no second restart.
+func TestSystemHandler_SelfUpdate_AlreadyInProgress(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{}, nil)
+	handler.selfUpdateFn = func(_ context.Context, _ string, _ updater.Options) error {
+		return updater.ErrSelfUpdateInProgress
+	}
+
+	exitCode, output, err := handler.selfUpdate(context.Background(), "v9.9.9")
+
+	if err != nil {
+		t.Fatalf("in-progress should not surface as an error, got: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "already in progress") {
+		t.Errorf("expected in-progress message, got %q", output)
+	}
+	if mockWS.RestartCalled {
+		t.Error("in-progress path must not schedule a restart")
+	}
+}

--- a/pkg/svcdef/svcdef_windows.go
+++ b/pkg/svcdef/svcdef_windows.go
@@ -1,0 +1,30 @@
+// Package svcdef holds the Windows service identity and recovery defaults shared by
+// 'alpamon register', the SCM handler, and the self-update guard, so they never drift.
+// Windows-only (every consumer is a _windows.go file); go build ./... skips it elsewhere.
+package svcdef
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// ServiceName is the Windows Service name registered by 'alpamon register'.
+const ServiceName = "alpamon"
+
+const (
+	// RecoveryResetSeconds is the SCM window after which the failure count resets.
+	RecoveryResetSeconds = 60
+	// RecoveryRestartDelay is how long SCM waits before each automatic restart.
+	RecoveryRestartDelay = 5 * time.Second
+)
+
+// DefaultRecoveryActions is the SCM policy 'alpamon register' installs and the
+// self-update guard restores; the trailing NoAction stops a broken binary thrashing SCM.
+func DefaultRecoveryActions() []mgr.RecoveryAction {
+	return []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: RecoveryRestartDelay},
+		{Type: mgr.ServiceRestart, Delay: RecoveryRestartDelay},
+		{Type: mgr.NoAction},
+	}
+}

--- a/pkg/updater/guard_unix.go
+++ b/pkg/updater/guard_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package updater
+
+// ensureSelfRestartable is a no-op on Unix. restartAgent execs in place,
+// so no external restarter is needed.
+func ensureSelfRestartable() error { return nil }

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -2,21 +2,11 @@ package updater
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
-)
-
-// scmServiceName duplicates register's serviceName and svc_windows.go's svcName;
-// pkg can't import cmd without inverting layering.
-const scmServiceName = "alpamon"
-
-// Recovery defaults from 'alpamon register', copied for the same layering reason.
-const (
-	recoveryResetSeconds = 60
-	recoveryRestartDelay = 5 * time.Second
 )
 
 // recoveryConfigurer is the subset of *mgr.Service ensureRecoveryRestart needs,
@@ -45,9 +35,9 @@ func ensureSelfRestartable() error {
 	}
 	defer func() { _ = m.Disconnect() }()
 
-	s, err := m.OpenService(scmServiceName)
+	s, err := m.OpenService(svcdef.ServiceName)
 	if err != nil {
-		return abortf("failed to open service %q: %w", scmServiceName, err)
+		return abortf("failed to open service %q: %w", svcdef.ServiceName, err)
 	}
 	defer func() { _ = s.Close() }()
 
@@ -68,12 +58,8 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 
 	// Not a new policy: register already applies exactly this configuration.
 	log.Warn().Msg("SCM recovery actions missing; restoring the defaults set by 'alpamon register'.")
-	defaults := []mgr.RecoveryAction{
-		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
-		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
-		{Type: mgr.NoAction},
-	}
-	if err := rc.SetRecoveryActions(defaults, recoveryResetSeconds); err != nil {
+	defaults := svcdef.DefaultRecoveryActions()
+	if err := rc.SetRecoveryActions(defaults, svcdef.RecoveryResetSeconds); err != nil {
 		return abortf("automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
 	}
 

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -61,8 +61,10 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 		return nil
 	}
 
-	// Not a new policy: register already applies exactly this configuration.
-	log.Warn().Msg("SCM recovery actions missing; restoring the defaults set by 'alpamon register'.")
+	// register already applies exactly this config, but SetRecoveryActions replaces
+	// the whole array—record what's lost, since this log is the only way back.
+	log.Warn().Strs("replaced", describeActions(actions)).
+		Msg("First SCM recovery action is not a restart; restoring the defaults set by 'alpamon register'.")
 	defaults := svcdef.DefaultRecoveryActions()
 	if err := rc.SetRecoveryActions(defaults, svcdef.RecoveryResetSeconds); err != nil {
 		return abortf("automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
@@ -82,6 +84,29 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 // abortf formats a fail-closed reason under the shared "self-update aborted" prefix.
 func abortf(format string, args ...any) error {
 	return fmt.Errorf("self-update aborted: "+format, args...)
+}
+
+// describeActions renders recovery actions for the overwrite log; mgr encodes
+// RecoveryAction.Type as a bare int that means nothing to a reader.
+func describeActions(actions []mgr.RecoveryAction) []string {
+	out := make([]string, len(actions))
+	for i, a := range actions {
+		var name string
+		switch a.Type {
+		case mgr.NoAction:
+			name = "none"
+		case mgr.ComputerReboot:
+			name = "reboot"
+		case mgr.ServiceRestart:
+			name = "restart"
+		case mgr.RunCommand:
+			name = "run-command"
+		default:
+			name = fmt.Sprintf("unknown(%d)", a.Type)
+		}
+		out[i] = fmt.Sprintf("%s after %s", name, a.Delay)
+	}
+	return out
 }
 
 // firstActionRestarts reports whether the first recovery action is a

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -14,8 +15,9 @@ import (
 // the self-update exit; a slower restart is healed to register's defaults, not trusted.
 const maxAcceptableRestartDelay = 60 * time.Second
 
-// recoveryConfigurer is the subset of *mgr.Service ensureRecoveryRestart needs,
-// an interface so the self-heal path is testable without a live SCM.
+// recoveryConfigurer is the RecoveryActions/SetRecoveryActions subset that
+// ensureRecoveryRestart needs—implemented by scmRecovery in production and a
+// fake in tests, so the self-heal path runs without a live SCM.
 type recoveryConfigurer interface {
 	RecoveryActions() ([]mgr.RecoveryAction, error)
 	SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error
@@ -39,19 +41,69 @@ func ensureSelfRestartable() error {
 		return nil
 	}
 
-	m, err := mgr.Connect()
+	// Open with least access; mgr.Connect/OpenService would demand *_ALL_ACCESS.
+	// scmRecovery escalates to write access only when a heal is required.
+	scm, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
 	if err != nil {
 		return abortf("failed to connect to service manager: %w", err)
 	}
-	defer func() { _ = m.Disconnect() }()
+	defer func() { _ = windows.CloseServiceHandle(scm) }()
 
-	s, err := m.OpenService(svcdef.ServiceName)
-	if err != nil {
+	rc := &scmRecovery{scm: scm, name: svcdef.ServiceName}
+	if err := rc.openQuery(); err != nil {
 		return abortf("failed to open service %q: %w", svcdef.ServiceName, err)
 	}
-	defer func() { _ = s.Close() }()
+	defer rc.close()
 
-	return ensureRecoveryRestart(s)
+	return ensureRecoveryRestart(rc)
+}
+
+// scmRecovery opens each SCM handle with the least access the call needs, so the
+// read path never demands SERVICE_CHANGE_CONFIG. It satisfies recoveryConfigurer.
+type scmRecovery struct {
+	scm   windows.Handle
+	name  string
+	query *mgr.Service // opened with SERVICE_QUERY_CONFIG
+}
+
+func (r *scmRecovery) openQuery() error {
+	h, err := r.openService(windows.SERVICE_QUERY_CONFIG)
+	if err != nil {
+		return err
+	}
+	r.query = &mgr.Service{Name: r.name, Handle: h}
+	return nil
+}
+
+func (r *scmRecovery) openService(access uint32) (windows.Handle, error) {
+	namePtr, err := windows.UTF16PtrFromString(r.name)
+	if err != nil {
+		return 0, err
+	}
+	return windows.OpenService(r.scm, namePtr, access)
+}
+
+func (r *scmRecovery) close() {
+	if r.query != nil {
+		_ = r.query.Close()
+	}
+}
+
+func (r *scmRecovery) RecoveryActions() ([]mgr.RecoveryAction, error) {
+	return r.query.RecoveryActions()
+}
+
+// SetRecoveryActions opens a dedicated write handle so the read path stays
+// query-only. SERVICE_START is required alongside SERVICE_CHANGE_CONFIG because
+// the restored policy sets an SC_ACTION_RESTART action.
+func (r *scmRecovery) SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error {
+	h, err := r.openService(windows.SERVICE_CHANGE_CONFIG | windows.SERVICE_START)
+	if err != nil {
+		return err
+	}
+	s := &mgr.Service{Name: r.name, Handle: h}
+	defer func() { _ = s.Close() }()
+	return s.SetRecoveryActions(actions, resetPeriod)
 }
 
 // ensureRecoveryRestart passes when rc's first recovery action is a prompt

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -9,31 +9,33 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
-// scmServiceName must match serviceName in cmd/alpamon/command/register;
-// copied because importing a cmd package from pkg would invert layering.
+// scmServiceName mirrors serviceName in cmd/alpamon/command/register; copied
+// because importing cmd from pkg would invert layering.
 const scmServiceName = "alpamon"
 
-// Recovery defaults applied by 'alpamon register'; copies for the same
-// layering reason as scmServiceName.
+// Recovery defaults from 'alpamon register', copied for the same layering reason.
 const (
 	recoveryResetSeconds = 60
 	recoveryRestartDelay = 5 * time.Second
 )
 
-// ensureSelfRestartable verifies something will relaunch alpamon after the
-// self-update exits: under SCM the first recovery action must be a restart,
-// or the replaced binary dies unrelaunched and a remote-only server goes
-// unreachable. A missing restart action is self-healed with register's
-// defaults, trusting only a confirming re-query; any failure aborts
-// (fail-closed). Preflight only: a later config change or a recent failure
-// streak (SCM steps to later actions) can still leave the service stopped.
+// recoveryConfigurer is the subset of *mgr.Service ensureRecoveryRestart needs,
+// an interface so the self-heal path is testable without a live SCM.
+type recoveryConfigurer interface {
+	RecoveryActions() ([]mgr.RecoveryAction, error)
+	SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error
+}
+
+// ensureSelfRestartable aborts the self-update unless a relaunch is guaranteed
+// afterward—otherwise the replaced binary stays dead and a remote-only server
+// goes unreachable. Preflight only: config drift or a failure streak past the
+// first action can still leave the service stopped.
 func ensureSelfRestartable() error {
 	isSvc, err := svc.IsWindowsService()
 	if err != nil {
 		return abortf("failed to determine service mode: %w", err)
 	}
 	if !isSvc {
-		// Interactive mode restarts itself via exec.Command (restartAgent).
 		return nil
 	}
 
@@ -50,13 +52,6 @@ func ensureSelfRestartable() error {
 	defer func() { _ = s.Close() }()
 
 	return ensureRecoveryRestart(s)
-}
-
-// recoveryConfigurer is the subset of *mgr.Service that ensureRecoveryRestart
-// needs; an interface so the self-heal path is unit-testable without a live SCM.
-type recoveryConfigurer interface {
-	RecoveryActions() ([]mgr.RecoveryAction, error)
-	SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error
 }
 
 // ensureRecoveryRestart passes when rc's first recovery action is a restart,

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -23,6 +23,9 @@ type recoveryConfigurer interface {
 func ensureSelfRestartable() error {
 	isSvc, err := svc.IsWindowsService()
 	if err != nil {
+		// Deliberately stricter than runningAsWindowsService(), which assumes
+		// interactive on this error: guessing interactive on a real service would
+		// skip the restart check and leave the replaced binary with nothing to relaunch it.
 		return abortf("failed to determine service mode: %w", err)
 	}
 	if !isSvc {

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -2,12 +2,17 @@ package updater
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
+
+// maxAcceptableRestartDelay bounds how long the server may stay unreachable after
+// the self-update exit; a slower restart is healed to register's defaults, not trusted.
+const maxAcceptableRestartDelay = 60 * time.Second
 
 // recoveryConfigurer is the subset of *mgr.Service ensureRecoveryRestart needs,
 // an interface so the self-heal path is testable without a live SCM.
@@ -49,8 +54,8 @@ func ensureSelfRestartable() error {
 	return ensureRecoveryRestart(s)
 }
 
-// ensureRecoveryRestart passes when rc's first recovery action is a restart,
-// otherwise self-heals register's defaults and trusts only a confirming
+// ensureRecoveryRestart passes when rc's first recovery action is a prompt
+// restart, otherwise self-heals register's defaults and trusts only a confirming
 // re-query. Any SCM error aborts (fail-closed).
 func ensureRecoveryRestart(rc recoveryConfigurer) error {
 	actions, err := rc.RecoveryActions()
@@ -64,10 +69,10 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 	// register already applies exactly this config, but SetRecoveryActions replaces
 	// the whole array—record what's lost, since this log is the only way back.
 	log.Warn().Strs("replaced", describeActions(actions)).
-		Msg("First SCM recovery action is not a restart; restoring the defaults set by 'alpamon register'.")
+		Msg("First SCM recovery action is not a prompt restart; restoring the defaults set by 'alpamon register'.")
 	defaults := svcdef.DefaultRecoveryActions()
 	if err := rc.SetRecoveryActions(defaults, svcdef.RecoveryResetSeconds); err != nil {
-		return abortf("automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
+		return abortf("a prompt automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
 	}
 
 	actions, err = rc.RecoveryActions()
@@ -75,7 +80,7 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 		return abortf("failed to verify restored recovery actions: %w", err)
 	}
 	if !firstActionRestarts(actions) {
-		return abortf("automatic restart is still not configured after restoring defaults; run 'alpamon register' to configure it")
+		return abortf("a prompt automatic restart is still not configured after restoring defaults; run 'alpamon register' to configure it")
 	}
 	log.Info().Msg("SCM recovery actions restored and verified.")
 	return nil
@@ -109,9 +114,11 @@ func describeActions(actions []mgr.RecoveryAction) []string {
 	return out
 }
 
-// firstActionRestarts reports whether the first recovery action is a
-// restart—SCM applies element [N-1] on the Nth failure, and the self-update
-// exit is failure 1 in steady state.
+// firstActionRestarts reports whether the first recovery action restarts the
+// service soon enough to count as a guarantee—SCM applies element [N-1] on the
+// Nth failure, and the self-update exit is failure 1 in steady state.
 func firstActionRestarts(actions []mgr.RecoveryAction) bool {
-	return len(actions) > 0 && actions[0].Type == mgr.ServiceRestart
+	return len(actions) > 0 &&
+		actions[0].Type == mgr.ServiceRestart &&
+		actions[0].Delay <= maxAcceptableRestartDelay
 }

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -19,7 +19,9 @@ type recoveryConfigurer interface {
 // ensureSelfRestartable aborts the self-update unless a relaunch is guaranteed
 // afterward—otherwise the replaced binary stays dead and a remote-only server
 // goes unreachable. Preflight only: config drift or a failure streak past the
-// first action can still leave the service stopped.
+// first action can still leave the service stopped—permanently so when the reset
+// period is INFINITE, since the failure count never ages out and the third update
+// lands on NoAction. Undetectable here: mgr.RecoveryActions() omits the reset period.
 func ensureSelfRestartable() error {
 	isSvc, err := svc.IsWindowsService()
 	if err != nil {
@@ -77,6 +79,7 @@ func ensureRecoveryRestart(rc recoveryConfigurer) error {
 	return nil
 }
 
+// abortf formats a fail-closed reason under the shared "self-update aborted" prefix.
 func abortf(format string, args ...any) error {
 	return fmt.Errorf("self-update aborted: "+format, args...)
 }

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -1,0 +1,91 @@
+package updater
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// scmServiceName must match serviceName in cmd/alpamon/command/register;
+// copied because importing a cmd package from pkg would invert layering.
+const scmServiceName = "alpamon"
+
+// Recovery defaults applied by 'alpamon register'; copies for the same
+// layering reason as scmServiceName.
+const (
+	recoveryResetSeconds = 60
+	recoveryRestartDelay = 5 * time.Second
+)
+
+// ensureSelfRestartable verifies something will relaunch alpamon after the
+// self-update exits: under SCM the first recovery action must be a restart,
+// or the replaced binary dies unrelaunched and a remote-only server goes
+// unreachable. A missing restart action is self-healed with register's
+// defaults, trusting only a confirming re-query; any failure aborts
+// (fail-closed). Preflight only: a later config change or a recent failure
+// streak (SCM steps to later actions) can still leave the service stopped.
+func ensureSelfRestartable() error {
+	isSvc, err := svc.IsWindowsService()
+	if err != nil {
+		return abortf("failed to determine service mode: %w", err)
+	}
+	if !isSvc {
+		// Interactive mode restarts itself via exec.Command (restartAgent).
+		return nil
+	}
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return abortf("failed to connect to service manager: %w", err)
+	}
+	defer func() { _ = m.Disconnect() }()
+
+	s, err := m.OpenService(scmServiceName)
+	if err != nil {
+		return abortf("failed to open service %q: %w", scmServiceName, err)
+	}
+	defer func() { _ = s.Close() }()
+
+	actions, err := s.RecoveryActions()
+	if err != nil {
+		return abortf("failed to query recovery actions: %w", err)
+	}
+	if firstActionRestarts(actions) {
+		return nil
+	}
+
+	// Not a new policy: register already applies exactly this configuration.
+	log.Warn().Msg("SCM recovery actions missing; restoring the defaults set by 'alpamon register'.")
+	defaults := []mgr.RecoveryAction{
+		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
+		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
+		{Type: mgr.NoAction},
+	}
+	if err := s.SetRecoveryActions(defaults, recoveryResetSeconds); err != nil {
+		return abortf("automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
+	}
+
+	actions, err = s.RecoveryActions()
+	if err != nil {
+		return abortf("failed to verify restored recovery actions: %w", err)
+	}
+	if !firstActionRestarts(actions) {
+		return abortf("automatic restart is still not configured after restoring defaults; run 'alpamon register' to configure it")
+	}
+	log.Info().Msg("SCM recovery actions restored and verified.")
+	return nil
+}
+
+func abortf(format string, args ...any) error {
+	return fmt.Errorf("self-update aborted: "+format, args...)
+}
+
+// firstActionRestarts reports whether the first recovery action is a
+// restart—SCM applies element [N-1] on the Nth failure, and the self-update
+// exit is failure 1 in steady state.
+func firstActionRestarts(actions []mgr.RecoveryAction) bool {
+	return len(actions) > 0 && actions[0].Type == mgr.ServiceRestart
+}

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
-// scmServiceName mirrors serviceName in cmd/alpamon/command/register; copied
-// because importing cmd from pkg would invert layering.
+// scmServiceName duplicates register's serviceName and svc_windows.go's svcName;
+// pkg can't import cmd without inverting layering.
 const scmServiceName = "alpamon"
 
 // Recovery defaults from 'alpamon register', copied for the same layering reason.

--- a/pkg/updater/guard_windows.go
+++ b/pkg/updater/guard_windows.go
@@ -49,7 +49,21 @@ func ensureSelfRestartable() error {
 	}
 	defer func() { _ = s.Close() }()
 
-	actions, err := s.RecoveryActions()
+	return ensureRecoveryRestart(s)
+}
+
+// recoveryConfigurer is the subset of *mgr.Service that ensureRecoveryRestart
+// needs; an interface so the self-heal path is unit-testable without a live SCM.
+type recoveryConfigurer interface {
+	RecoveryActions() ([]mgr.RecoveryAction, error)
+	SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error
+}
+
+// ensureRecoveryRestart passes when rc's first recovery action is a restart,
+// otherwise self-heals register's defaults and trusts only a confirming
+// re-query. Any SCM error aborts (fail-closed).
+func ensureRecoveryRestart(rc recoveryConfigurer) error {
+	actions, err := rc.RecoveryActions()
 	if err != nil {
 		return abortf("failed to query recovery actions: %w", err)
 	}
@@ -64,11 +78,11 @@ func ensureSelfRestartable() error {
 		{Type: mgr.ServiceRestart, Delay: recoveryRestartDelay},
 		{Type: mgr.NoAction},
 	}
-	if err := s.SetRecoveryActions(defaults, recoveryResetSeconds); err != nil {
+	if err := rc.SetRecoveryActions(defaults, recoveryResetSeconds); err != nil {
 		return abortf("automatic restart is not configured and restoring it failed: %w; run 'alpamon register' to configure it", err)
 	}
 
-	actions, err = s.RecoveryActions()
+	actions, err = rc.RecoveryActions()
 	if err != nil {
 		return abortf("failed to verify restored recovery actions: %w", err)
 	}

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -58,12 +58,13 @@ var restartDefaults = []mgr.RecoveryAction{{Type: mgr.ServiceRestart}}
 // fakeRecovery is a recoveryConfigurer whose RecoveryActions() returns each
 // queued result in turn (initial query, then the post-heal re-query).
 type fakeRecovery struct {
-	queries   [][]mgr.RecoveryAction
-	queryErrs []error
-	queryIdx  int
-	setErr    error
-	setCalled bool
-	setReset  uint32
+	queries    [][]mgr.RecoveryAction
+	queryErrs  []error
+	queryIdx   int
+	setErr     error
+	setCalled  bool
+	setActions []mgr.RecoveryAction
+	setReset   uint32
 }
 
 func (f *fakeRecovery) RecoveryActions() ([]mgr.RecoveryAction, error) {
@@ -80,6 +81,7 @@ func (f *fakeRecovery) RecoveryActions() ([]mgr.RecoveryAction, error) {
 
 func (f *fakeRecovery) SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error {
 	f.setCalled = true
+	f.setActions = actions
 	f.setReset = resetPeriod
 	return f.setErr
 }
@@ -87,11 +89,10 @@ func (f *fakeRecovery) SetRecoveryActions(actions []mgr.RecoveryAction, resetPer
 func TestEnsureRecoveryRestart(t *testing.T) {
 	noAction := []mgr.RecoveryAction{{Type: mgr.NoAction}}
 	tests := []struct {
-		name      string
-		fake      fakeRecovery
-		wantErr   bool
-		wantSet   bool
-		wantReset uint32
+		name    string
+		fake    fakeRecovery
+		wantErr bool
+		wantSet bool
 	}{
 		{
 			name:    "first action already restarts: pass without healing",
@@ -100,11 +101,10 @@ func TestEnsureRecoveryRestart(t *testing.T) {
 			wantSet: false,
 		},
 		{
-			name:      "missing: heal then re-query confirms restart",
-			fake:      fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, restartDefaults}},
-			wantErr:   false,
-			wantSet:   true,
-			wantReset: svcdef.RecoveryResetSeconds,
+			name:    "missing: heal then re-query confirms restart",
+			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, restartDefaults}},
+			wantErr: false,
+			wantSet: true,
 		},
 		{
 			name:    "missing: SetRecoveryActions fails aborts",
@@ -141,8 +141,16 @@ func TestEnsureRecoveryRestart(t *testing.T) {
 			if f.setCalled != tt.wantSet {
 				t.Errorf("SetRecoveryActions called = %v, want %v", f.setCalled, tt.wantSet)
 			}
-			if tt.wantReset != 0 && f.setReset != tt.wantReset {
-				t.Errorf("SetRecoveryActions reset = %d, want %d", f.setReset, tt.wantReset)
+			if !tt.wantSet {
+				return
+			}
+			// A heal must write register's defaults verbatim—the guard's actual output.
+			// Without this, a regression to NoAction or a dropped Delay passes every case.
+			if want := svcdef.DefaultRecoveryActions(); !slices.Equal(f.setActions, want) {
+				t.Errorf("SetRecoveryActions actions = %v, want %v", f.setActions, want)
+			}
+			if f.setReset != svcdef.RecoveryResetSeconds {
+				t.Errorf("SetRecoveryActions reset = %d, want %d", f.setReset, svcdef.RecoveryResetSeconds)
 			}
 		})
 	}

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"golang.org/x/sys/windows/svc/mgr"
 )
 
@@ -81,7 +82,7 @@ func TestEnsureRecoveryRestart(t *testing.T) {
 			fake:      fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, restartDefaults}},
 			wantErr:   false,
 			wantSet:   true,
-			wantReset: recoveryResetSeconds,
+			wantReset: svcdef.RecoveryResetSeconds,
 		},
 		{
 			name:    "missing: SetRecoveryActions fails aborts",

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -2,7 +2,9 @@ package updater
 
 import (
 	"errors"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/svcdef"
 	"golang.org/x/sys/windows/svc/mgr"
@@ -28,6 +30,26 @@ func TestFirstActionRestarts(t *testing.T) {
 				t.Errorf("firstActionRestarts() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDescribeActions(t *testing.T) {
+	got := describeActions([]mgr.RecoveryAction{
+		{Type: mgr.RunCommand, Delay: 0},
+		{Type: mgr.ServiceRestart, Delay: 5 * time.Second},
+		{Type: mgr.ComputerReboot, Delay: time.Minute},
+		{Type: mgr.NoAction},
+		{Type: 99},
+	})
+	want := []string{
+		"run-command after 0s",
+		"restart after 5s",
+		"reboot after 1m0s",
+		"none after 0s",
+		"unknown(99) after 0s",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("describeActions() = %v, want %v", got, want)
 	}
 }
 

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -23,6 +23,18 @@ func TestFirstActionRestarts(t *testing.T) {
 		{"noaction first, restart later", []mgr.RecoveryAction{
 			{Type: mgr.NoAction}, {Type: mgr.ServiceRestart},
 		}, false},
+		{"register's own delay is accepted", []mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart, Delay: svcdef.RecoveryRestartDelay},
+		}, true},
+		{"delay exactly at the bound", []mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart, Delay: maxAcceptableRestartDelay},
+		}, true},
+		{"delay past the bound is no guarantee", []mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart, Delay: maxAcceptableRestartDelay + time.Second},
+		}, false},
+		{"restart six hours out leaves the server unreachable", []mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart, Delay: 6 * time.Hour},
+		}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -103,6 +115,15 @@ func TestEnsureRecoveryRestart(t *testing.T) {
 		{
 			name:    "missing: heal then re-query confirms restart",
 			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, restartDefaults}},
+			wantErr: false,
+			wantSet: true,
+		},
+		{
+			name: "restart delayed past the bound heals like a missing restart",
+			fake: fakeRecovery{queries: [][]mgr.RecoveryAction{
+				{{Type: mgr.ServiceRestart, Delay: 6 * time.Hour}},
+				restartDefaults,
+			}},
 			wantErr: false,
 			wantSet: true,
 		},

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -1,0 +1,30 @@
+package updater
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+func TestFirstActionRestarts(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []mgr.RecoveryAction
+		want    bool
+	}{
+		{"no actions configured", nil, false},
+		{"register default: restart first", []mgr.RecoveryAction{
+			{Type: mgr.ServiceRestart}, {Type: mgr.ServiceRestart}, {Type: mgr.NoAction},
+		}, true},
+		{"noaction first, restart later", []mgr.RecoveryAction{
+			{Type: mgr.NoAction}, {Type: mgr.ServiceRestart},
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstActionRestarts(tt.actions); got != tt.want {
+				t.Errorf("firstActionRestarts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/updater/guard_windows_test.go
+++ b/pkg/updater/guard_windows_test.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"errors"
 	"testing"
 
 	"golang.org/x/sys/windows/svc/mgr"
@@ -24,6 +25,101 @@ func TestFirstActionRestarts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := firstActionRestarts(tt.actions); got != tt.want {
 				t.Errorf("firstActionRestarts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var restartDefaults = []mgr.RecoveryAction{{Type: mgr.ServiceRestart}}
+
+// fakeRecovery is a recoveryConfigurer whose RecoveryActions() returns each
+// queued result in turn (initial query, then the post-heal re-query).
+type fakeRecovery struct {
+	queries   [][]mgr.RecoveryAction
+	queryErrs []error
+	queryIdx  int
+	setErr    error
+	setCalled bool
+	setReset  uint32
+}
+
+func (f *fakeRecovery) RecoveryActions() ([]mgr.RecoveryAction, error) {
+	i := f.queryIdx
+	f.queryIdx++
+	if i < len(f.queryErrs) && f.queryErrs[i] != nil {
+		return nil, f.queryErrs[i]
+	}
+	if i < len(f.queries) {
+		return f.queries[i], nil
+	}
+	return nil, nil
+}
+
+func (f *fakeRecovery) SetRecoveryActions(actions []mgr.RecoveryAction, resetPeriod uint32) error {
+	f.setCalled = true
+	f.setReset = resetPeriod
+	return f.setErr
+}
+
+func TestEnsureRecoveryRestart(t *testing.T) {
+	noAction := []mgr.RecoveryAction{{Type: mgr.NoAction}}
+	tests := []struct {
+		name      string
+		fake      fakeRecovery
+		wantErr   bool
+		wantSet   bool
+		wantReset uint32
+	}{
+		{
+			name:    "first action already restarts: pass without healing",
+			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{restartDefaults}},
+			wantErr: false,
+			wantSet: false,
+		},
+		{
+			name:      "missing: heal then re-query confirms restart",
+			fake:      fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, restartDefaults}},
+			wantErr:   false,
+			wantSet:   true,
+			wantReset: recoveryResetSeconds,
+		},
+		{
+			name:    "missing: SetRecoveryActions fails aborts",
+			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{noAction}, setErr: errors.New("access denied")},
+			wantErr: true,
+			wantSet: true,
+		},
+		{
+			name:    "missing: re-query still not restart aborts",
+			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{noAction, noAction}},
+			wantErr: true,
+			wantSet: true,
+		},
+		{
+			name:    "missing: re-query errors aborts",
+			fake:    fakeRecovery{queries: [][]mgr.RecoveryAction{noAction}, queryErrs: []error{nil, errors.New("query failed")}},
+			wantErr: true,
+			wantSet: true,
+		},
+		{
+			name:    "initial query errors aborts before healing",
+			fake:    fakeRecovery{queryErrs: []error{errors.New("query failed")}},
+			wantErr: true,
+			wantSet: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.fake
+			err := ensureRecoveryRestart(&f)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ensureRecoveryRestart() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if f.setCalled != tt.wantSet {
+				t.Errorf("SetRecoveryActions called = %v, want %v", f.setCalled, tt.wantSet)
+			}
+			if tt.wantReset != 0 && f.setReset != tt.wantReset {
+				t.Errorf("SetRecoveryActions reset = %d, want %d", f.setReset, tt.wantReset)
 			}
 		})
 	}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -35,6 +35,13 @@ const (
 
 var versionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[\w.]+)?$`)
 
+// selfUpdateInFlight serializes SelfUpdate: concurrent runs race on the same
+// staging paths and can delete each other's files mid-replace, killing the agent.
+var selfUpdateInFlight atomic.Bool
+
+// SelfUpdateFunc is the signature of SelfUpdate, held as a field so tests can inject a fake.
+type SelfUpdateFunc func(ctx context.Context, latestVersion string, opts Options) error
+
 // Options configures the self-update behavior. Use defaults for production.
 type Options struct {
 	BaseURL string // Override release base URL (for testing)
@@ -46,13 +53,6 @@ func (o Options) baseURL() string {
 	}
 	return defaultReleaseBaseURL
 }
-
-// SelfUpdateFunc is the signature of SelfUpdate, held as a field so tests can inject a fake.
-type SelfUpdateFunc func(ctx context.Context, latestVersion string, opts Options) error
-
-// selfUpdateInFlight serializes SelfUpdate: concurrent runs race on the same
-// staging paths and can delete each other's files mid-replace, killing the agent.
-var selfUpdateInFlight atomic.Bool
 
 // SelfUpdate downloads the latest binary from GitHub Releases,
 // verifies its checksum, and replaces the current binary.

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -48,9 +50,18 @@ func (o Options) baseURL() string {
 // SelfUpdateFunc is the signature of SelfUpdate, held as a field so tests can inject a fake.
 type SelfUpdateFunc func(ctx context.Context, latestVersion string, opts Options) error
 
+// selfUpdateInFlight serializes SelfUpdate: concurrent runs race on the same
+// staging paths and can delete each other's files mid-replace, killing the agent.
+var selfUpdateInFlight atomic.Bool
+
 // SelfUpdate downloads the latest binary from GitHub Releases,
 // verifies its checksum, and replaces the current binary.
 func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
+	if !selfUpdateInFlight.CompareAndSwap(false, true) {
+		return errors.New("self-update already in progress")
+	}
+	defer selfUpdateInFlight.Store(false)
+
 	if !versionRe.MatchString(latestVersion) {
 		return fmt.Errorf("invalid version format: %q", latestVersion)
 	}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -35,8 +35,10 @@ const (
 
 var versionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[\w.]+)?$`)
 
-// selfUpdateInFlight serializes SelfUpdate: concurrent runs race on the same
-// staging paths and can delete each other's files mid-replace, killing the agent.
+// selfUpdateInFlight serializes SelfUpdate: concurrent runs race on the same staging
+// paths and can delete each other's files mid-replace, killing the agent. Process-local,
+// so it does not guard against a second alpamon process. Held through a successful run
+// (the expected restart resets it), released on failure or via ReleaseSelfUpdateLatch.
 var selfUpdateInFlight atomic.Bool
 
 // ErrSelfUpdateInProgress is returned when a self-update is already running.
@@ -58,13 +60,27 @@ func (o Options) baseURL() string {
 	return defaultReleaseBaseURL
 }
 
+// ReleaseSelfUpdateLatch clears the latch SelfUpdate keeps set after a successful
+// run. Call it only when the expected post-update restart could not be triggered.
+func ReleaseSelfUpdateLatch() {
+	selfUpdateInFlight.Store(false)
+}
+
 // SelfUpdate downloads the latest binary from GitHub Releases,
 // verifies its checksum, and replaces the current binary.
 func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 	if !selfUpdateInFlight.CompareAndSwap(false, true) {
 		return ErrSelfUpdateInProgress
 	}
-	defer selfUpdateInFlight.Store(false)
+	// Release only on failure: on success the pending restart resets it, and holding
+	// it blocks a duplicate upgrade in that window—which on Windows fails in
+	// replaceBinary after a wasted download.
+	success := false
+	defer func() {
+		if !success {
+			selfUpdateInFlight.Store(false)
+		}
+	}()
 
 	if !versionRe.MatchString(latestVersion) {
 		return fmt.Errorf("invalid version format: %q", latestVersion)
@@ -138,6 +154,7 @@ func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 	}
 
 	log.Info().Str("version", latestVersion).Msg("Self-update completed.")
+	success = true
 	return nil
 }
 

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -55,6 +55,11 @@ func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 		return fmt.Errorf("invalid version format: %q", latestVersion)
 	}
 
+	// Abort before touching anything if nothing would restart us afterward.
+	if err := ensureSelfRestartable(); err != nil {
+		return err
+	}
+
 	// On Windows, clear any ".old" binary left behind by a prior update
 	// before we stage a new one, otherwise MoveFileEx will collide.
 	// No-op on Unix.

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -39,6 +39,10 @@ var versionRe = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[\w.]+)?$`)
 // staging paths and can delete each other's files mid-replace, killing the agent.
 var selfUpdateInFlight atomic.Bool
 
+// ErrSelfUpdateInProgress is returned when a self-update is already running.
+// Callers should treat it as a benign no-op, not a failure.
+var ErrSelfUpdateInProgress = errors.New("self-update already in progress")
+
 // SelfUpdateFunc is the signature of SelfUpdate, held as a field so tests can inject a fake.
 type SelfUpdateFunc func(ctx context.Context, latestVersion string, opts Options) error
 
@@ -58,7 +62,7 @@ func (o Options) baseURL() string {
 // verifies its checksum, and replaces the current binary.
 func SelfUpdate(ctx context.Context, latestVersion string, opts Options) error {
 	if !selfUpdateInFlight.CompareAndSwap(false, true) {
-		return errors.New("self-update already in progress")
+		return ErrSelfUpdateInProgress
 	}
 	defer selfUpdateInFlight.Store(false)
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -331,6 +331,28 @@ func TestSelfUpdate_InvalidVersion(t *testing.T) {
 	}
 }
 
+func TestSelfUpdate_AlreadyInProgress(t *testing.T) {
+	if !selfUpdateInFlight.CompareAndSwap(false, true) {
+		t.Fatal("in-flight flag unexpectedly set before test")
+	}
+	defer selfUpdateInFlight.Store(false)
+
+	err := SelfUpdate(context.Background(), "v1.0.0", Options{})
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("expected in-progress error, got: %v", err)
+	}
+}
+
+func TestSelfUpdate_InFlightFlagResets(t *testing.T) {
+	// A failed run (invalid version) must clear the flag for the next call.
+	if err := SelfUpdate(context.Background(), "not-a-version", Options{}); err == nil {
+		t.Fatal("expected error for invalid version")
+	}
+	if selfUpdateInFlight.Load() {
+		t.Fatal("in-flight flag not reset after SelfUpdate returned")
+	}
+}
+
 func TestDownloadFile_Oversize(t *testing.T) {
 	// Server streams more than maxArchiveSize without Content-Length
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -350,7 +350,19 @@ func TestSelfUpdate_InFlightFlagResets(t *testing.T) {
 		t.Fatal("expected error for invalid version")
 	}
 	if selfUpdateInFlight.Load() {
-		t.Fatal("in-flight flag not reset after SelfUpdate returned")
+		t.Fatal("in-flight flag not reset after failed SelfUpdate returned")
+	}
+}
+
+func TestReleaseSelfUpdateLatch(t *testing.T) {
+	if !selfUpdateInFlight.CompareAndSwap(false, true) {
+		t.Fatal("in-flight flag unexpectedly set before test")
+	}
+	defer selfUpdateInFlight.Store(false)
+
+	ReleaseSelfUpdateLatch()
+	if selfUpdateInFlight.Load() {
+		t.Fatal("ReleaseSelfUpdateLatch did not clear the latch")
 	}
 }
 

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -338,8 +339,8 @@ func TestSelfUpdate_AlreadyInProgress(t *testing.T) {
 	defer selfUpdateInFlight.Store(false)
 
 	err := SelfUpdate(context.Background(), "v1.0.0", Options{})
-	if err == nil || !strings.Contains(err.Error(), "already in progress") {
-		t.Fatalf("expected in-progress error, got: %v", err)
+	if !errors.Is(err, ErrSelfUpdateInProgress) {
+		t.Fatalf("expected ErrSelfUpdateInProgress, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Background

Windows self-update replaces the running `alpamon.exe` via a rename-aside sequence and then exits the process. In service mode, SCM Recovery Actions must relaunch the process right after it exits for the new binary to start. If no prompt restart is configured (an operator disabled it, or the service predates `register`), the replaced binary stays dead and a server reachable only over its outbound WebSocket becomes unreachable. Starting a self-update without a guaranteed restart is itself the hazard.

The worker pool can also dispatch two upgrade commands concurrently. Self-update uses fixed staging paths (`.new`/`.old`), so concurrent runs can delete each other's files mid-replace and kill the agent.

## Changes

Add a preflight guard `ensureSelfRestartable()` that runs before self-update touches anything (`pkg/updater/guard_windows.go`).

- Interactive (non-service) mode returns immediately: `restartAgent` re-execs itself via `exec.Command`.
- Service mode queries SCM Recovery Actions and checks whether the first action is a prompt restart. SCM applies element `[N-1]` on the Nth failure, so relaunching after the self-update exit (failure 1 in steady state) requires `[0]` to be a restart. A restart scheduled beyond `maxAcceptableRestartDelay` (60s) is not a guarantee and is treated like a missing restart, so the server cannot be left unreachable for minutes or hours after the exit.
- If the first action is not a prompt restart, it restores the defaults `register` uses (`Restart 5s` / `Restart 5s` / `NoAction`, reset 60s), logs the replaced actions so an overwritten operator config can be reconstructed, re-queries to confirm the change took effect, and only then proceeds. Any failure to restore or re-query aborts the self-update (fail-closed).

The guard opens the SCM with least privilege: `SC_MANAGER_CONNECT` + `SERVICE_QUERY_CONFIG` for the read path, escalating to a dedicated `SERVICE_CHANGE_CONFIG | SERVICE_START` handle only when a heal is actually needed. The `svc/mgr` wrapper hardcodes `*_ALL_ACCESS`, so the guard uses the raw `windows.OpenSCManager`/`OpenService` and wraps the handle in `mgr.Service` to reuse `RecoveryActions()`/`SetRecoveryActions()`. This keeps a hardened deployment from being permanently blocked on the common read-only path.

Unix is a no-op (`pkg/updater/guard_unix.go`): `restartAgent` execs in place via `syscall.Exec`.

Concurrent runs are serialized with a process-local `atomic.Bool` CAS (`pkg/updater/updater.go`), exposed as `ErrSelfUpdateInProgress` so a caller can treat a rejected duplicate as a benign no-op rather than a failure. The latch is held through a successful run (the pending restart resets it) and released only on failure, closing the window where a second upgrade could re-run mid-restart; the system handler releases it explicitly if it cannot schedule the restart.

The shared Windows service identity and recovery defaults (service name, reset period, restart delay, default recovery actions) now live in a single `pkg/svcdef` package that `register`, the SCM handler, and the guard all import, replacing the three duplicated copies and their sync comments.

## Safety

- Fail-closed: if a prompt restart is not guaranteed, the guard aborts before touching the binary.
- Least privilege: the read path never requires write access, so tightening the service DACL cannot block a self-update whose recovery config is already correct.
- The self-heal restores the exact values `register` writes at install time, not a new policy. It does overwrite a deliberately-disabled setting (a tradeoff over letting the server die unrelaunched) and logs the replaced actions so they can be reconstructed.
- Preflight limits: it cannot cover a config change after the query, or a failure streak that has advanced SCM to a later action — permanent only when the reset period is INFINITE, which `mgr.RecoveryActions()` cannot report. Documented in the `ensureSelfRestartable` comment.
- Concurrent self-updates are serialized via the process-local CAS.

## Testing

- `guard_windows_test.go`: `firstActionRestarts` including delay-bound cases (register's 5s, exactly 60s, past the bound, 6h), `describeActions`, and `TestEnsureRecoveryRestart` through a `recoveryConfigurer` seam, now asserting the healed values against `svcdef.DefaultRecoveryActions()` and the reset period in every heal case. These run in the Windows CI job.
- `updater_test.go`: a rejected concurrent run returns `ErrSelfUpdateInProgress`, a failed run clears the latch, and `ReleaseSelfUpdateLatch` clears it. `system_test.go`: an in-progress run is a benign no-op (exit 0), and a failed restart schedule releases the latch.
- `go test ./... -p 1` passes; gofmt/lint clean; `GOOS=windows` build/vet/test-compile clean.
- Real-server E2E (Windows Server 2022, LocalSystem): installed a dev build, set the first recovery action to a 6h-delay restart (`sc.exe failure alpamon reset= 60 actions= restart/21600000`), then triggered a console upgrade. The guard rejected the 6h delay as non-prompt and self-healed the `register` defaults via the `SERVICE_CHANGE_CONFIG | SERVICE_START` write handle; the binary was replaced (dev to 2.3.2) and SCM restarted the process, which reconnected. `sc.exe qfailure alpamon` then showed `RESET_PERIOD 60` / `RESTART 5000ms` x2 restored. The least-privilege read path and the write heal are both confirmed on real hardware; a hardened non-LocalSystem logon account is not yet covered.

## Checklist

- [x] Fail-closed guard before the binary is touched
- [x] Least-privilege SCM access, escalating only to heal
- [x] Restart-delay upper bound enforced
- [x] Concurrency serialized (process-local)
- [x] Windows CI unit tests + real-server E2E
