### PR TITLE
ci: install glibc-devel with --nobest on EL distros

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,13 +121,16 @@ jobs:
           apt-get update -o Acquire::Retries=3
           apt-get install -y -o Acquire::Retries=3 --no-install-recommends git curl gcc libc6-dev ca-certificates
 
+      # --nobest: glibc-devel (AppStream) pins glibc (BaseOS) to an exact NEVR, and
+      # the two repos can be served by mirrors at different sync points. Without it
+      # the newest glibc-devel is picked and its glibc match may not exist yet.
       - name: Install dependencies (yum)
         if: matrix.pkg_manager == 'yum'
-        run: yum install -y git curl gcc glibc-devel tar
+        run: yum install -y --nobest git curl gcc glibc-devel tar
 
       - name: Install dependencies (dnf)
         if: matrix.pkg_manager == 'dnf'
-        run: dnf install -y --allowerasing git curl gcc glibc-devel tar
+        run: dnf install -y --allowerasing --nobest git curl gcc glibc-devel tar
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Background

The `rocky-9` job in Build and Test fails before checkout, at the dependency install step:

```
dnf install -y --allowerasing git curl gcc glibc-devel tar
→ nothing provides glibc = 2.34-274.el9_8 needed by glibc-devel-2.34-274.el9_8.x86_64 from appstream
```

`glibc-devel` ships in AppStream and requires an exact NEVR match on `glibc`, which ships in BaseOS. A newer `glibc` does not satisfy it. dnf resolves a mirror per repository from the mirrorlist, so BaseOS and AppStream can be served from mirrors at different sync points. When AppStream carries a `glibc` build that the BaseOS mirror has not picked up yet, dnf selects the newest `glibc-devel` and then cannot resolve its `glibc` counterpart.

Evidence that this is repository skew rather than a workflow or code problem:

- Only `rocky-9` fails. `rocky-9-arm64` runs the same image and the same command and passes, as do `almalinux-9`, `rhel-9`, `oracle-9`, and the other 15 jobs.
- Runs were green through 2026-07-23 10:00Z and red from 2026-07-24 00:07Z, with no related code change in between.
- Running the exact failing command in `rockylinux:9` locally succeeds, because the mirror reached from there serves `glibc-2.34-274.el9_8` in BaseOS and `glibc-devel-2.34-274.el9_8` in AppStream as a matching pair.

Retrying does not clear it: the failure persisted across two runs 13 hours apart.

The failing log corroborates the skew from another angle. It reports `Package tar-2:1.34-6.el9_1.x86_64 is already installed.`, and that run had no `--nobest` — without the flag dnf upgrades an installed package to the newest available. So the BaseOS view the runner had did not carry `tar-1.34-11.el9`, which the mirrors reachable from the test machine do serve. `tar` and `glibc` both live in BaseOS, so the runner was reading a BaseOS snapshot that trails AppStream on more than just the one package.

## Changes

Pass `--nobest` to the dependency install steps in `.github/workflows/build-and-test.yml`. The resolver is then allowed to fall back to an older `glibc-devel` whose `glibc` counterpart exists in the BaseOS metadata it can see, instead of failing on the newest candidate.

Applied to the `yum` step as well. It installs the same package set on EL8 and carries the same cross-repo exposure, even though those jobs are currently green.

`--skip-broken`, the other flag the error message suggests, is not used: it would drop `glibc-devel` from the transaction entirely and break the cgo build.

A comment records why the flag is there, so it is not removed later as noise.

## Testing

Verified with Docker on `linux/amd64`:

| Image | Command | Result |
|---|---|---|
| `rockylinux:9` | `dnf install -y --allowerasing --nobest git curl gcc glibc-devel tar` | exit 0, installs `glibc-devel-2.34-274.el9_8`, `gcc`, `git`, `tar`, `curl` |
| `rockylinux:8` | `yum install -y --nobest git curl gcc glibc-devel tar` | exit 0, installs `glibc-devel-2.28-251.el8_10.40`, `gcc`, `git`, `tar` |

The workflow file parses as valid YAML and both `run` lines carry the intended flags.

### Side effect worth knowing about

`--nobest` also stops dnf from upgrading a package that is already installed and already satisfies the request. Across the images we use, that affects `tar` and nothing else:

| Image | Package | without `--nobest` | with `--nobest` |
|---|---|---|---|
| `rockylinux:9` | tar | 1.34-11.el9 | 1.34-6.el9_1 |
| `rockylinux:8` | tar | 1.30-11.el8_10 | 1.30-9.el8 |

`gcc`, `glibc-devel`, `git`, and `curl` resolve to the same versions either way, because they are not preinstalled and so are newly installed in both cases.

This was isolated rather than inferred. Within a single container `dnf list --showduplicates tar` reported `1.34-11.el9` available from BaseOS in both runs, so the differing outcome comes from the flag and not from mirror variation. The same result reproduces on a separate Linux docker daemon running native aarch64, which rules out the host platform and the amd64 emulation used for the other runs.

The practical cost looks small: `tar` here unpacks the Go toolchain, and both releases handle that. Stating the tradeoff plainly all the same, `--nobest` gives up some package freshness and some failure signal in exchange for resilience, since a genuine dependency conflict would now be resolved with an older candidate instead of failing loudly. That seemed acceptable for a toolchain install step, but it is a real change in behavior rather than a no-op.

Unlike `--skip-broken`, `--nobest` never drops a package from the transaction, so `glibc-devel` cannot go missing and silently break the cgo build.

### What this does not prove

The skewed mirror state could not be reproduced directly, since the mirrors reachable from the test machine serve a matching pair. The runs above confirm `--nobest` causes no regression when the pairing is intact, and the `tar` line in the failing log is consistent with the skew, but that the flag resolves it follows from dnf's documented `--nobest` semantics rather than from a reproduction. CI on this PR is the actual check.

## Checklist

- [x] Verified the install step on both EL8 and EL9 images
- [x] Isolated the `tar` side effect and confirmed it is caused by the flag, not the environment
- [x] Workflow YAML parses
- [ ] CI green on this PR, including `rocky-9`
