### PR TITLE
Harden Unix process-tree cleanup against a Start/cancel race

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -352,8 +352,8 @@ func (e *Executor) runCommand(cmd *exec.Cmd, pidHook func(pid int), cw *chunkWri
 		}
 	}()
 	if err := cleanup.afterStart(cmd); err != nil {
-		// Windows afterStart may have already canceled on a Start/cancel race; the deferred cancel
-		// re-runs harmlessly (idempotent). Unix afterStart never errors here.
+		// afterStart may re-run cancel on a Start/cancel race (both platforms) and surface its error
+		// here; the deferred cancel then re-runs harmlessly (idempotent).
 		_ = cmd.Wait()
 		return finish(err)
 	}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -352,7 +352,7 @@ func (e *Executor) runCommand(cmd *exec.Cmd, pidHook func(pid int), cw *chunkWri
 		}
 	}()
 	if err := cleanup.afterStart(cmd); err != nil {
-		// afterStart may re-run cancel on a Start/cancel race (both platforms) and surface its error
+		// afterStart may re-run cancel on a Start/cancel race (unix-like and windows alike) and surface its error
 		// here; the deferred cancel then re-runs harmlessly (idempotent).
 		_ = cmd.Wait()
 		return finish(err)

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -6,13 +6,16 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
 )
 
 // commandCleanup mirrors the type in process_tree_windows.go; the commandCleaner assertion below pins
 // the shared afterStart/cancel/close method set across build tags. State differs per platform.
 type commandCleanup struct {
-	pgid int // process group to SIGKILL; 0 when the child does not lead its own group
+	mu       sync.Mutex // afterStart (main goroutine) writes pgid while cmd.Cancel's context watcher reads it
+	pgid     int        // process group to SIGKILL; 0 when the child does not lead its own group
+	canceled bool       // a cancel already fired; afterStart re-runs it once the group is recorded
 }
 
 var _ commandCleaner = (*commandCleanup)(nil)
@@ -41,10 +44,22 @@ func (c *commandCleanup) afterStart(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil && pgid == cmd.Process.Pid {
-		c.pgid = pgid
+	pgid := 0
+	if p, err := syscall.Getpgid(cmd.Process.Pid); err == nil && p == cmd.Process.Pid {
+		pgid = p
+	}
+	// A cancel that fired between Start and here read pgid==0 and hit only the leader; redo it with the group recorded.
+	if canceled := c.recordPgid(pgid); canceled {
+		return c.cancel(cmd)
 	}
 	return nil
+}
+
+func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pgid = pgid
+	return c.canceled
 }
 
 func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
@@ -52,8 +67,8 @@ func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
 		return os.ErrProcessDone
 	}
 	pid := cmd.Process.Pid
-	if c.pgid != 0 {
-		pid = -c.pgid
+	if pgid := c.markCanceled(); pgid != 0 {
+		pid = -pgid
 	}
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
@@ -62,6 +77,15 @@ func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
 		return err
 	}
 	return nil
+}
+
+// markCanceled records that a cancel fired and returns the recorded group; afterStart uses the flag to
+// redo a kill that raced ahead of the group being recorded.
+func (c *commandCleanup) markCanceled() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.canceled = true
+	return c.pgid
 }
 
 func (c *commandCleanup) close() error {

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -48,9 +48,13 @@ func (c *commandCleanup) afterStart(cmd *exec.Cmd) error {
 	if p, err := syscall.Getpgid(cmd.Process.Pid); err == nil && p == cmd.Process.Pid {
 		pgid = p
 	}
-	// A cancel that fired between Start and here read pgid==0 and hit only the leader; redo it with the group recorded.
+	// A cancel that fired between Start and here read pgid==0 and hit only the leader; redo it with the
+	// group recorded. An already-gone group (ErrProcessDone) is the expected benign outcome, so let the
+	// normal Wait path report the real termination status rather than surfacing it as an afterStart failure.
 	if canceled := c.recordPgid(pgid); canceled {
-		return c.cancel(cmd)
+		if err := c.cancel(cmd); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -59,13 +59,6 @@ func (c *commandCleanup) afterStart(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.pgid = pgid
-	return c.canceled
-}
-
 func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
@@ -83,6 +76,17 @@ func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
 	return nil
 }
 
+func (c *commandCleanup) close() error {
+	return nil
+}
+
+func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pgid = pgid
+	return c.canceled
+}
+
 // markCanceled records that a cancel fired and returns the recorded group; afterStart uses the flag to
 // redo a kill that raced ahead of the group being recorded.
 func (c *commandCleanup) markCanceled() int {
@@ -90,8 +94,4 @@ func (c *commandCleanup) markCanceled() int {
 	defer c.mu.Unlock()
 	c.canceled = true
 	return c.pgid
-}
-
-func (c *commandCleanup) close() error {
-	return nil
 }

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -13,10 +13,11 @@ import (
 // commandCleanup mirrors the type in process_tree_windows.go; the commandCleaner assertion below pins
 // the shared afterStart/cancel/close method set across build tags. State differs per platform.
 type commandCleanup struct {
-	mu         sync.Mutex // afterStart (main goroutine) writes pgid while cmd.Cancel's context watcher reads it
-	leadsGroup bool       // configure requested setsid/setpgid(0,0), so PGID == PID by construction
-	pgid       int        // process group to SIGKILL; 0 when the child does not lead its own group
-	canceled   bool       // a cancel already fired; afterStart re-runs it once the group is recorded
+	leadsGroup bool // immutable after configure: setsid/setpgid(0,0) was requested, so PGID == PID
+
+	mu       sync.Mutex // afterStart (main goroutine) writes pgid while cmd.Cancel's context watcher reads it
+	pgid     int        // process group to SIGKILL; 0 when the child does not lead its own group
+	canceled bool       // a cancel already fired; afterStart re-runs it once the group is recorded
 }
 
 var _ commandCleaner = (*commandCleanup)(nil)

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -95,8 +95,9 @@ func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
 	return c.canceled
 }
 
-// Mirrors the Windows sibling: records that a cancel fired and hands back the group, so cancel's SIGKILL
-// runs lock-free. afterStart uses the flag to redo a kill that raced ahead of the group being recorded.
+// takeForCancel records that a cancel fired and hands back the group, so cancel's SIGKILL runs lock-free;
+// it mirrors the Windows sibling of the same name. afterStart uses the flag to redo a kill that raced
+// ahead of the group being recorded.
 func (c *commandCleanup) takeForCancel() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -13,9 +13,10 @@ import (
 // commandCleanup mirrors the type in process_tree_windows.go; the commandCleaner assertion below pins
 // the shared afterStart/cancel/close method set across build tags. State differs per platform.
 type commandCleanup struct {
-	mu       sync.Mutex // afterStart (main goroutine) writes pgid while cmd.Cancel's context watcher reads it
-	pgid     int        // process group to SIGKILL; 0 when the child does not lead its own group
-	canceled bool       // a cancel already fired; afterStart re-runs it once the group is recorded
+	mu         sync.Mutex // afterStart (main goroutine) writes pgid while cmd.Cancel's context watcher reads it
+	leadsGroup bool       // configure requested setsid/setpgid(0,0), so PGID == PID by construction
+	pgid       int        // process group to SIGKILL; 0 when the child does not lead its own group
+	canceled   bool       // a cancel already fired; afterStart re-runs it once the group is recorded
 }
 
 var _ commandCleaner = (*commandCleanup)(nil)
@@ -34,18 +35,23 @@ func configureProcessTreeCleanup(cmd *exec.Cmd, sessionLeader bool) (*commandCle
 		cmd.SysProcAttr.Setpgid = true
 	}
 
-	return &commandCleanup{}, nil
+	sysAttr := cmd.SysProcAttr
+	return &commandCleanup{leadsGroup: sysAttr.Setsid || (sysAttr.Setpgid && sysAttr.Pgid == 0)}, nil
 }
 
-// afterStart captures the process group while the leader is alive: getpgid fails with ESRCH once Wait
-// reaps it, yet -pgid stays killable while a descendant holds the group open (the post-reap leak path).
-// Recorded only when the child leads its own group (PGID == PID), so -pgid can't hit an unrelated group.
+// afterStart records the process group cancel should target: -pgid stays killable while a descendant holds
+// the group open even after Wait reaps the leader (the post-reap leak path). Recorded only when the child
+// leads its own group (PGID == PID), so -pgid can't hit an unrelated group.
 func (c *commandCleanup) afterStart(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
 	pgid := 0
-	if p, err := syscall.Getpgid(cmd.Process.Pid); err == nil && p == cmd.Process.Pid {
+	if c.leadsGroup {
+		// Don't ask getpgid: on darwin it returns ESRCH for a signalled-but-unreaped leader, which would
+		// drop the group in exactly the raced cancel handled below.
+		pgid = cmd.Process.Pid
+	} else if p, err := syscall.Getpgid(cmd.Process.Pid); err == nil && p == cmd.Process.Pid {
 		pgid = p
 	}
 	// A cancel that fired between Start and here read pgid==0 and hit only the leader; redo it with the

--- a/pkg/executor/process_tree_unix.go
+++ b/pkg/executor/process_tree_unix.go
@@ -70,7 +70,7 @@ func (c *commandCleanup) cancel(cmd *exec.Cmd) error {
 		return os.ErrProcessDone
 	}
 	pid := cmd.Process.Pid
-	if pgid := c.markCanceled(); pgid != 0 {
+	if pgid := c.takeForCancel(); pgid != 0 {
 		pid = -pgid
 	}
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
@@ -86,6 +86,8 @@ func (c *commandCleanup) close() error {
 	return nil
 }
 
+// recordPgid stores the group cancel should target and reports whether a cancel already fired, which is
+// what tells afterStart to redo the kill.
 func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -93,9 +95,9 @@ func (c *commandCleanup) recordPgid(pgid int) (canceled bool) {
 	return c.canceled
 }
 
-// markCanceled records that a cancel fired and returns the recorded group; afterStart uses the flag to
-// redo a kill that raced ahead of the group being recorded.
-func (c *commandCleanup) markCanceled() int {
+// Mirrors the Windows sibling: records that a cancel fired and hands back the group, so cancel's SIGKILL
+// runs lock-free. afterStart uses the flag to redo a kill that raced ahead of the group being recorded.
+func (c *commandCleanup) takeForCancel() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.canceled = true

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -85,7 +85,7 @@ func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
 // the whole group, so a backgrounded grandchild holding the pipe open dies too.
 func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	cmd := exec.Command("/bin/sh", "-c", "sleep 600 & echo $! > \"$1\"; wait", "sh", pidFile)
+	cmd := exec.Command("/bin/sh", "-c", `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`, "sh", pidFile)
 	cleanup, err := configureProcessTreeCleanup(cmd, false)
 	if err != nil {
 		t.Fatalf("configureProcessTreeCleanup: %v", err)
@@ -127,7 +127,7 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pidFile := filepath.Join(t.TempDir(), "child.pid")
-			script := "sleep 600 & echo $! > \"$1\"; wait"
+			script := `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`
 
 			type result struct {
 				exitCode int
@@ -178,7 +178,7 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 // timeout means no Cancel, and Wait returns ExitError not ErrWaitDelay, so only the unconditional cancel covers it.
 func TestExecutor_CleansDescendantWhenCommandExitsNonZero(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	script := "sleep 600 & echo $! > \"$1\"; exit 3"
+	script := `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; exit 3`
 
 	type result struct {
 		exitCode int

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -81,10 +81,11 @@ func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
 	}
 }
 
-// When a cancel races ahead of the process group being recorded, afterStart redoes the kill. An
-// already-gone group is the benign expected outcome, so the redo must not surface os.ErrProcessDone
-// as an afterStart failure—otherwise Execute reports exit 1 instead of the real termination status.
-func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
+// When a cancel races ahead of the process group being recorded, afterStart redoes the kill. runCommand
+// always runs afterStart before Wait, so the redo targets a still-unreaped process—never a reaped pid the
+// OS could have handed to an unrelated process. Exercise that exact order: the redo must complete without
+// surfacing an error, so Execute reports the real termination status rather than exit 1. Reap only after.
+func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "exit 0")
 	cleanup, err := configureProcessTreeCleanup(cmd, false)
 	if err != nil {
@@ -93,13 +94,13 @@ func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("cmd.Start: %v", err)
 	}
-	// Simulate a cancel that fired between Start and afterStart, then reap so the redo hits ESRCH.
+	// Cancel before the group is recorded: pgid is still 0, so only the leader is targeted.
 	_ = cleanup.cancel(cmd)
-	_ = cmd.Wait()
-
+	// Redo while the process is still unreaped, matching runCommand's afterStart-before-Wait order.
 	if err := cleanup.afterStart(cmd); err != nil {
-		t.Fatalf("afterStart redo surfaced %v, want nil for an already-gone group", err)
+		t.Fatalf("afterStart redo surfaced %v, want nil after a raced cancel", err)
 	}
+	_ = cmd.Wait()
 }
 
 // White-box counterpart to the Windows job-object test: configure -> Start -> cancel must SIGKILL

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -81,6 +81,27 @@ func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
 	}
 }
 
+// When a cancel races ahead of the process group being recorded, afterStart redoes the kill. An
+// already-gone group is the benign expected outcome, so the redo must not surface os.ErrProcessDone
+// as an afterStart failure—otherwise Execute reports exit 1 instead of the real termination status.
+func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cleanup, err := configureProcessTreeCleanup(cmd, false)
+	if err != nil {
+		t.Fatalf("configureProcessTreeCleanup: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	// Simulate a cancel that fired between Start and afterStart, then reap so the redo hits ESRCH.
+	_ = cleanup.cancel(cmd)
+	_ = cmd.Wait()
+
+	if err := cleanup.afterStart(cmd); err != nil {
+		t.Fatalf("afterStart redo surfaced %v, want nil for an already-gone group", err)
+	}
+}
+
 // White-box counterpart to the Windows job-object test: configure -> Start -> cancel must SIGKILL
 // the whole group, so a backgrounded grandchild holding the pipe open dies too.
 func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -94,13 +94,16 @@ func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("cmd.Start: %v", err)
 	}
+	// Reap last—after afterStart, and even when an assertion below fails early.
+	t.Cleanup(func() { _ = cmd.Wait() })
 	// Cancel before the group is recorded: pgid is still 0, so only the leader is targeted.
-	_ = cleanup.cancel(cmd)
+	if err := cleanup.cancel(cmd); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("cancel: %v", err)
+	}
 	// Redo while the process is still unreaped, matching runCommand's afterStart-before-Wait order.
 	if err := cleanup.afterStart(cmd); err != nil {
 		t.Fatalf("afterStart redo surfaced %v, want nil after a raced cancel", err)
 	}
-	_ = cmd.Wait()
 }
 
 // White-box counterpart to the Windows job-object test: configure -> Start -> cancel must SIGKILL
@@ -115,6 +118,12 @@ func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("cmd.Start: %v", err)
 	}
+	// Kill and reap the leader even when an assertion below fails before cancel runs; the in-body
+	// cancel makes this a no-op on the happy path.
+	t.Cleanup(func() {
+		_ = cleanup.cancel(cmd)
+		_ = cmd.Wait()
+	})
 	if err := cleanup.afterStart(cmd); err != nil {
 		t.Fatalf("afterStart: %v", err)
 	}
@@ -125,7 +134,6 @@ func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
 	if err := cleanup.cancel(cmd); err != nil {
 		t.Fatalf("cancel: %v", err)
 	}
-	go func() { _ = cmd.Wait() }()
 
 	if !waitForExecutorTimeoutChildExit(childPID, 3*time.Second) {
 		t.Fatalf("grandchild %d survived the group kill", childPID)

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -20,7 +20,8 @@ import (
 func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 	t.Run("non_session_leader_sets_pgid", func(t *testing.T) {
 		cmd := &exec.Cmd{}
-		if _, err := configureProcessTreeCleanup(cmd, false); err != nil {
+		cleanup, err := configureProcessTreeCleanup(cmd, false)
+		if err != nil {
 			t.Fatalf("configureProcessTreeCleanup: %v", err)
 		}
 		if cmd.SysProcAttr == nil {
@@ -32,11 +33,15 @@ func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 		if cmd.SysProcAttr.Setsid {
 			t.Error("Setsid: got true, want false")
 		}
+		if !cleanup.leadsGroup {
+			t.Error("leadsGroup: got false, want true for setpgid(0,0)")
+		}
 	})
 
 	t.Run("session_leader_sets_sid_not_pgid", func(t *testing.T) {
 		cmd := &exec.Cmd{}
-		if _, err := configureProcessTreeCleanup(cmd, true); err != nil {
+		cleanup, err := configureProcessTreeCleanup(cmd, true)
+		if err != nil {
 			t.Fatalf("configureProcessTreeCleanup: %v", err)
 		}
 		if !cmd.SysProcAttr.Setsid {
@@ -45,16 +50,35 @@ func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 		if cmd.SysProcAttr.Setpgid {
 			t.Error("Setpgid: got true, want false (setpgid on a setsid session leader is EPERM, fails Start)")
 		}
+		if !cleanup.leadsGroup {
+			t.Error("leadsGroup: got false, want true for setsid")
+		}
 	})
 
 	// A caller that already asked for setsid must not also get Setpgid forced on.
 	t.Run("preexisting_setsid_not_overridden", func(t *testing.T) {
 		cmd := &exec.Cmd{SysProcAttr: &syscall.SysProcAttr{Setsid: true}}
-		if _, err := configureProcessTreeCleanup(cmd, false); err != nil {
+		cleanup, err := configureProcessTreeCleanup(cmd, false)
+		if err != nil {
 			t.Fatalf("configureProcessTreeCleanup: %v", err)
 		}
 		if cmd.SysProcAttr.Setpgid {
 			t.Error("Setpgid was forced on despite preexisting Setsid")
+		}
+		if !cleanup.leadsGroup {
+			t.Error("leadsGroup: got false, want true for preexisting setsid")
+		}
+	})
+
+	// Joining an existing group means PGID != PID, so afterStart must fall back to the getpgid guard.
+	t.Run("preexisting_pgid_is_not_own_group_leader", func(t *testing.T) {
+		cmd := &exec.Cmd{SysProcAttr: &syscall.SysProcAttr{Setpgid: true, Pgid: 1234}}
+		cleanup, err := configureProcessTreeCleanup(cmd, false)
+		if err != nil {
+			t.Fatalf("configureProcessTreeCleanup: %v", err)
+		}
+		if cleanup.leadsGroup {
+			t.Error("leadsGroup: got true, want false for a child joining an existing group")
 		}
 	})
 
@@ -62,7 +86,8 @@ func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 	t.Run("preserves_existing_credential", func(t *testing.T) {
 		cred := &syscall.Credential{Uid: 1000, Gid: 1000}
 		cmd := &exec.Cmd{SysProcAttr: &syscall.SysProcAttr{Credential: cred}}
-		if _, err := configureProcessTreeCleanup(cmd, false); err != nil {
+		cleanup, err := configureProcessTreeCleanup(cmd, false)
+		if err != nil {
 			t.Fatalf("configureProcessTreeCleanup: %v", err)
 		}
 		if cmd.SysProcAttr.Credential != cred {
@@ -70,6 +95,9 @@ func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 		}
 		if !cmd.SysProcAttr.Setpgid {
 			t.Error("Setpgid was not set alongside the preserved credential")
+		}
+		if !cleanup.leadsGroup {
+			t.Error("leadsGroup: got false, want true alongside the preserved credential")
 		}
 	})
 }

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -83,10 +83,11 @@ func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
 
 // When a cancel races ahead of the process group being recorded, afterStart redoes the kill. runCommand
 // always runs afterStart before Wait, so the redo targets a still-unreaped process—never a reaped pid the
-// OS could have handed to an unrelated process. Exercise that exact order: the redo must complete without
-// surfacing an error, so Execute reports the real termination status rather than exit 1. Reap only after.
+// OS could have handed to an unrelated process. Exercise that exact order and assert the redo reached the
+// whole group: a backgrounded grandchild that survived the raced cancel must die. Reap only after.
 func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
-	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	cmd := exec.Command("/bin/sh", "-c", `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`, "sh", pidFile)
 	cleanup, err := configureProcessTreeCleanup(cmd, false)
 	if err != nil {
 		t.Fatalf("configureProcessTreeCleanup: %v", err)
@@ -96,13 +97,57 @@ func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	}
 	// Reap last—after afterStart, and even when an assertion below fails early.
 	t.Cleanup(func() { _ = cmd.Wait() })
+
+	childPID := readExecutorTimeoutChildPID(t, pidFile)
+	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
+
 	// Cancel before the group is recorded: pgid is still 0, so only the leader is targeted.
 	if err := cleanup.cancel(cmd); err != nil && !errors.Is(err, os.ErrProcessDone) {
 		t.Fatalf("cancel: %v", err)
 	}
+	// Let the SIGKILL land before the redo: an unreaped-zombie leader is the state that used to defeat
+	// getpgid, and the redo must cope with it. The raced cancel reaches only the leader, so the grandchild
+	// must still be alive—otherwise the assertion below cannot tell a working redo from a no-op one.
+	if !waitForLeaderStopped(cmd.Process.Pid, 3*time.Second) {
+		t.Fatalf("leader %d still running after the raced cancel", cmd.Process.Pid)
+	}
+	if processGone(childPID) {
+		t.Fatalf("grandchild %d died with the raced cancel; the redo is not exercised", childPID)
+	}
+
 	// Redo while the process is still unreaped, matching runCommand's afterStart-before-Wait order.
 	if err := cleanup.afterStart(cmd); err != nil {
 		t.Fatalf("afterStart redo surfaced %v, want nil after a raced cancel", err)
+	}
+	if !waitForExecutorTimeoutChildExit(childPID, 3*time.Second) {
+		t.Fatalf("grandchild %d survived the afterStart redo", childPID)
+	}
+}
+
+// afterStart swallows os.ErrProcessDone from its redo so Wait reports the real termination status instead
+// of exit 1 with "os: process already finished". runCommand can't reach it—afterStart always precedes
+// Wait, so the group still holds the unreaped leader—so pin the branch white-box on a reaped cmd.
+func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cleanup, err := configureProcessTreeCleanup(cmd, false)
+	if err != nil {
+		t.Fatalf("configureProcessTreeCleanup: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cmd.Start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("cmd.Wait: %v", err)
+	}
+	// Reaped, so the group must be empty; skip rather than signal a group the OS already handed out.
+	if !errors.Is(syscall.Kill(-pid, 0), syscall.ESRCH) {
+		t.Skipf("pgid %d was reused, cannot exercise an already-gone group", pid)
+	}
+
+	cleanup.markCanceled() // a cancel raced ahead, so afterStart redoes the kill
+	if err := cleanup.afterStart(cmd); err != nil {
+		t.Fatalf("afterStart: got %v, want nil for an already-gone group", err)
 	}
 }
 
@@ -272,6 +317,23 @@ func waitForExecutorTimeoutChildExit(pid int, timeout time.Duration) bool {
 		time.Sleep(20 * time.Millisecond)
 	}
 	return processGone(pid)
+}
+
+// waitForLeaderStopped waits until the SIGKILL landed but Wait has not reaped the leader yet. Detection is
+// split because the platforms disagree about zombies: on linux processGone reads the Z state from /proc,
+// while on darwin getpgid is what stops seeing the leader (proc_find skips SZOMB).
+func waitForLeaderStopped(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if processGone(pid) {
+			return true
+		}
+		if _, err := syscall.Getpgid(pid); errors.Is(err, syscall.ESRCH) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
 }
 
 // processGone also accepts a zombie as gone: kill(pid, 0) still succeeds for one, and in a CI container with no init process to reap the orphaned grandchild it stays a zombie indefinitely.

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -87,7 +87,7 @@ func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
 // whole group: a backgrounded grandchild that survived the raced cancel must die. Reap only after.
 func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	cmd := exec.Command("/bin/sh", "-c", `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`, "sh", pidFile)
+	cmd := exec.Command("/bin/sh", "-c", bgChildScript("wait"), "sh", pidFile)
 	cleanup, err := configureProcessTreeCleanup(cmd, false)
 	if err != nil {
 		t.Fatalf("configureProcessTreeCleanup: %v", err)
@@ -145,7 +145,7 @@ func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
 		t.Skipf("pgid %d was reused, cannot exercise an already-gone group", pid)
 	}
 
-	cleanup.markCanceled() // a cancel raced ahead, so afterStart redoes the kill
+	cleanup.takeForCancel() // a cancel raced ahead, so afterStart redoes the kill
 	if err := cleanup.afterStart(cmd); err != nil {
 		t.Fatalf("afterStart: got %v, want nil for an already-gone group", err)
 	}
@@ -155,7 +155,7 @@ func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
 // the whole group, so a backgrounded grandchild holding the pipe open dies too.
 func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	cmd := exec.Command("/bin/sh", "-c", `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`, "sh", pidFile)
+	cmd := exec.Command("/bin/sh", "-c", bgChildScript("wait"), "sh", pidFile)
 	cleanup, err := configureProcessTreeCleanup(cmd, false)
 	if err != nil {
 		t.Fatalf("configureProcessTreeCleanup: %v", err)
@@ -202,7 +202,7 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pidFile := filepath.Join(t.TempDir(), "child.pid")
-			script := `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; wait`
+			script := bgChildScript("wait")
 
 			type result struct {
 				exitCode int
@@ -253,7 +253,7 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 // timeout means no Cancel, and Wait returns ExitError not ErrWaitDelay, so only the unconditional cancel covers it.
 func TestExecutor_CleansDescendantWhenCommandExitsNonZero(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	script := `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; exit 3`
+	script := bgChildScript("exit 3")
 
 	type result struct {
 		exitCode int
@@ -317,6 +317,12 @@ func waitForExecutorTimeoutChildExit(pid int, timeout time.Duration) bool {
 		time.Sleep(20 * time.Millisecond)
 	}
 	return processGone(pid)
+}
+
+// bgChildScript backgrounds a long sleeper and publishes its pid atomically: echo truncate-opens the
+// target, so write to a temp file and rename it in (a same-directory rename(2) is atomic).
+func bgChildScript(tail string) string {
+	return `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; ` + tail
 }
 
 // waitForLeaderStopped waits until the SIGKILL landed but Wait has not reaped the leader yet. Detection is

--- a/pkg/executor/process_tree_unix_test.go
+++ b/pkg/executor/process_tree_unix_test.go
@@ -74,13 +74,6 @@ func TestConfigureProcessTreeCleanup_FlagMatrix(t *testing.T) {
 	})
 }
 
-func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
-	var cleanup commandCleanup
-	if err := cleanup.cancel(&exec.Cmd{}); !errors.Is(err, os.ErrProcessDone) {
-		t.Fatalf("cancel: got %v, want os.ErrProcessDone", err)
-	}
-}
-
 // When a cancel races ahead of the process group being recorded, afterStart redoes the kill. runCommand
 // always runs afterStart before Wait, so the redo targets a still-unreaped process—never a reaped pid the
 // OS could have handed to an unrelated process. Exercise that exact order and assert the redo reached the
@@ -98,7 +91,7 @@ func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	// Reap last—after afterStart, and even when an assertion below fails early.
 	t.Cleanup(func() { _ = cmd.Wait() })
 
-	childPID := readExecutorTimeoutChildPID(t, pidFile)
+	childPID := readChildPID(t, pidFile)
 	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
 
 	// Cancel before the group is recorded: pgid is still 0, so only the leader is targeted.
@@ -119,7 +112,7 @@ func TestCommandCleanup_AfterStartRedoAfterRacedCancel(t *testing.T) {
 	if err := cleanup.afterStart(cmd); err != nil {
 		t.Fatalf("afterStart redo surfaced %v, want nil after a raced cancel", err)
 	}
-	if !waitForExecutorTimeoutChildExit(childPID, 3*time.Second) {
+	if !waitForProcessGone(childPID, 3*time.Second) {
 		t.Fatalf("grandchild %d survived the afterStart redo", childPID)
 	}
 }
@@ -151,6 +144,13 @@ func TestCommandCleanup_AfterStartRedoSwallowsProcessDone(t *testing.T) {
 	}
 }
 
+func TestCommandCleanup_CancelNilProcessReturnsProcessDone(t *testing.T) {
+	var cleanup commandCleanup
+	if err := cleanup.cancel(&exec.Cmd{}); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("cancel: got %v, want os.ErrProcessDone", err)
+	}
+}
+
 // White-box counterpart to the Windows job-object test: configure -> Start -> cancel must SIGKILL
 // the whole group, so a backgrounded grandchild holding the pipe open dies too.
 func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
@@ -173,14 +173,14 @@ func TestCommandCleanup_CancelKillsProcessGroup(t *testing.T) {
 		t.Fatalf("afterStart: %v", err)
 	}
 
-	childPID := readExecutorTimeoutChildPID(t, pidFile)
+	childPID := readChildPID(t, pidFile)
 	t.Cleanup(func() { _ = syscall.Kill(childPID, syscall.SIGKILL) })
 
 	if err := cleanup.cancel(cmd); err != nil {
 		t.Fatalf("cancel: %v", err)
 	}
 
-	if !waitForExecutorTimeoutChildExit(childPID, 3*time.Second) {
+	if !waitForProcessGone(childPID, 3*time.Second) {
 		t.Fatalf("grandchild %d survived the group kill", childPID)
 	}
 }
@@ -223,7 +223,7 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 			select {
 			case res = <-done:
 			case <-time.After(5 * time.Second):
-				pid := readExecutorTimeoutChildPID(t, pidFile)
+				pid := readChildPID(t, pidFile)
 				_ = syscall.Kill(pid, syscall.SIGKILL)
 				t.Fatalf("executor did not return after timeout; leaked child pid %d", pid)
 			}
@@ -238,11 +238,11 @@ func TestExecutor_TimeoutCleansProcessTreeWhenChildKeepsPipeOpen(t *testing.T) {
 				t.Fatalf("expected timeout banner, got %q", res.output)
 			}
 
-			pid := readExecutorTimeoutChildPID(t, pidFile)
+			pid := readChildPID(t, pidFile)
 			t.Cleanup(func() {
 				_ = syscall.Kill(pid, syscall.SIGKILL)
 			})
-			if !waitForExecutorTimeoutChildExit(pid, 3*time.Second) {
+			if !waitForProcessGone(pid, 3*time.Second) {
 				t.Fatalf("child process %d was still alive after executor timeout cleanup", pid)
 			}
 		})
@@ -271,7 +271,7 @@ func TestExecutor_CleansDescendantWhenCommandExitsNonZero(t *testing.T) {
 	select {
 	case res = <-done:
 	case <-time.After(10 * time.Second):
-		pid := readExecutorTimeoutChildPID(t, pidFile)
+		pid := readChildPID(t, pidFile)
 		_ = syscall.Kill(pid, syscall.SIGKILL)
 		t.Fatalf("executor did not return; leaked child pid %d", pid)
 	}
@@ -280,14 +280,20 @@ func TestExecutor_CleansDescendantWhenCommandExitsNonZero(t *testing.T) {
 		t.Fatalf("exit code: got %d, want 3; err=%v", res.exitCode, res.err)
 	}
 
-	pid := readExecutorTimeoutChildPID(t, pidFile)
+	pid := readChildPID(t, pidFile)
 	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
-	if !waitForExecutorTimeoutChildExit(pid, 3*time.Second) {
+	if !waitForProcessGone(pid, 3*time.Second) {
 		t.Fatalf("descendant %d survived after a non-zero command exit", pid)
 	}
 }
 
-func readExecutorTimeoutChildPID(t *testing.T, path string) int {
+// bgChildScript backgrounds a long sleeper and publishes its pid atomically: echo truncate-opens the
+// target, so write to a temp file and rename it in (a same-directory rename(2) is atomic).
+func bgChildScript(tail string) string {
+	return `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; ` + tail
+}
+
+func readChildPID(t *testing.T, path string) int {
 	t.Helper()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -308,38 +314,35 @@ func readExecutorTimeoutChildPID(t *testing.T, path string) int {
 	return 0
 }
 
-func waitForExecutorTimeoutChildExit(pid int, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if processGone(pid) {
-			return true
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	return processGone(pid)
-}
-
-// bgChildScript backgrounds a long sleeper and publishes its pid atomically: echo truncate-opens the
-// target, so write to a temp file and rename it in (a same-directory rename(2) is atomic).
-func bgChildScript(tail string) string {
-	return `sleep 600 & echo $! > "$1.tmp"; mv "$1.tmp" "$1"; ` + tail
+func waitForProcessGone(pid int, timeout time.Duration) bool {
+	return waitFor(timeout, func() bool { return processGone(pid) })
 }
 
 // waitForLeaderStopped waits until the SIGKILL landed but Wait has not reaped the leader yet. Detection is
 // split because the platforms disagree about zombies: on linux processGone reads the Z state from /proc,
 // while on darwin getpgid is what stops seeing the leader (proc_find skips SZOMB).
 func waitForLeaderStopped(pid int, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	return waitFor(timeout, func() bool {
 		if processGone(pid) {
 			return true
 		}
-		if _, err := syscall.Getpgid(pid); errors.Is(err, syscall.ESRCH) {
+		_, err := syscall.Getpgid(pid)
+		return errors.Is(err, syscall.ESRCH)
+	})
+}
+
+// waitFor polls cond every 20ms until it reports true or timeout elapses.
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
 			return true
+		}
+		if time.Now().After(deadline) {
+			return false
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	return false
 }
 
 // processGone also accepts a zombie as gone: kill(pid, 0) still succeeds for one, and in a CI container with no init process to reap the orphaned grandchild it stays a zombie indefinitely.


### PR DESCRIPTION
## Background

While looking into an intermittent CI failure in the `executor` package, a couple of small timing-related rough edges surfaced around the Unix process-tree cleanup path. None of them affect the happy path, but they are worth smoothing out so the behavior is predictable under load and during shutdown.

The CI failure itself came from a test helper occasionally reading a half-written pid file. Alongside that, the race detector pointed at unsynchronized access to the cleanup state, and review found that the fix for the resulting early-cancel window was a no-op on darwin.

## Changes

Guard the process-group state against a Start/cancel race. `commandCleanup.pgid` was written by `afterStart` on the main goroutine and read by `cancel` from the context-watcher goroutine that `os/exec` invokes via `cmd.Cancel`, with no synchronization between them. Both fields are now serialized behind a mutex through small `recordPgid`/`takeForCancel` helpers, keeping the lock scoped to the field access so the `SIGKILL` itself stays lock-free. This mirrors the locking discipline already used in the Windows sibling.

Close the narrow early-cancel window the synchronization exposes. If a cancel fires before the group is recorded, it can only reach the leader; `afterStart` now redoes the kill once the group is known.

Record the process group by construction rather than by lookup. `afterStart` used to ask `syscall.Getpgid` for the group, which is unreliable exactly when the redo needs it: on a signalled-but-unreaped leader it succeeds on Linux but returns `ESRCH` on darwin, where XNU's `proc_find` skips `SZOMB`. The redo then recorded `pgid` as 0, targeted the already-killed leader instead of the group, and let backgrounded descendants survive—silently, since `kill` on the zombie returns `nil`. Since `configureProcessTreeCleanup` requests `setsid` or `setpgid(0,0)` itself, PGID == PID is guaranteed by construction, so that is recorded as `leadsGroup` and used directly. The `Getpgid == pid` guard remains for the only case it protects: a caller that pre-set `Pgid` to an existing group. This also keeps the unconditional deferred cancel from targeting a reaped pid, and removes one syscall per command execution.

Report the real termination status when the redo meets an already-gone group. Previously the redo could surface `os.ErrProcessDone` as an `afterStart` failure, which led `Execute` to report exit 1 with `os: process already finished` under a non-timeout cancellation such as a graceful shutdown. An already-gone group is treated as the benign outcome it is—consistent with the unconditional deferred cancel—so the normal `Wait` path reports the actual status; only a genuine kill error still surfaces.

Make the test pid file publish atomically. The affected test scripts wrote the backgrounded child pid with `echo $! > "$1"`, which truncate-opens the file before writing, leaving a brief window where a reader sees it empty. They now write to a temp file and rename it into place; a same-directory `rename(2)` is atomic, so the reader sees the file either absent or fully written.

## Safety

The changes are confined to the Unix cleanup path and its tests. The `Getpgid == pid` guard that keeps `-pgid` from targeting an unrelated group is unchanged in the case it applies to, and the redo remains idempotent alongside the existing deferred cancel. The pid file change is test-only.

## Testing

- `go test -race ./pkg/executor` across repeated runs, including the process-group and timeout cleanup tests, with no race reports.
- The original flaky read no longer reproduces without the race detector over many iterations.
- `TestCommandCleanup_AfterStartRedoAfterRacedCancel` asserts the redo reaches the whole group: it waits for the leader to reach the signalled-but-unreaped state, checks the backgrounded grandchild survived the raced cancel, and then requires the redo to kill it. Verified on darwin that the test fails when the `leadsGroup` branch is disabled and passes with it.
- `TestCommandCleanup_AfterStartRedoSwallowsProcessDone` pins the `os.ErrProcessDone` branch, which `runCommand` cannot reach because `afterStart` always precedes `Wait`.
- `gofmt -l`, `go vet` on linux and darwin, and a Windows cross-build all pass.

## Checklist

- [x] `go vet` clean
- [x] Tests pass, including `-race`
- [x] Windows cross-build verified
- [x] No changes outside the Unix cleanup path and its tests
