### PR TITLE
fix(platform): classify openSUSE/SLES instead of crash-looping on it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,6 +100,11 @@ jobs:
             container: amazonlinux:2023
             pkg_manager: dnf
             runner: ubuntu-latest
+          # SUSE (amd64)
+          - distro: opensuse-leap-15
+            container: opensuse/leap:15
+            pkg_manager: zypper
+            runner: ubuntu-latest
           # ARM64
           - distro: ubuntu-24.04-arm64
             container: ubuntu:24.04
@@ -128,6 +133,12 @@ jobs:
       - name: Install dependencies (dnf)
         if: matrix.pkg_manager == 'dnf'
         run: dnf install -y --allowerasing git curl gcc glibc-devel tar
+
+      # gzip is explicit here because the Leap base image ships neither tar
+      # nor gzip, and actions/setup-go extracts its tarball with `tar xz`.
+      - name: Install dependencies (zypper)
+        if: matrix.pkg_manager == 'zypper'
+        run: zypper --non-interactive install git curl gcc glibc-devel tar gzip
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,9 +136,14 @@ jobs:
 
       # gzip is explicit here because the Leap base image ships neither tar
       # nor gzip, and actions/setup-go extracts its tarball with `tar xz`.
+      # PATH goes to GITHUB_ENV because the Leap image config defines no PATH
+      # (alone in this matrix); once setup-go calls addPath, the runner rebuilds
+      # PATH from the image value, and an empty base loses /usr/bin.
       - name: Install dependencies (zypper)
         if: matrix.pkg_manager == 'zypper'
-        run: zypper --non-interactive install git curl gcc glibc-devel tar gzip
+        run: |
+          zypper --non-interactive install git curl gcc glibc-devel tar gzip
+          echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$GITHUB_ENV"
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,15 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.distro }})
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container }}
+    # PATH is pinned in the container env because opensuse/leap:15 is the only
+    # matrix image whose config defines no PATH; the runner rebuilds each exec
+    # PATH as "prepended dirs + container config PATH", so once setup-go
+    # prepends its toolchain an empty base loses /usr/bin. The other images
+    # already define exactly this value.
+    container:
+      image: ${{ matrix.container }}
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     strategy:
       fail-fast: false
       matrix:
@@ -136,14 +144,9 @@ jobs:
 
       # gzip is explicit here because the Leap base image ships neither tar
       # nor gzip, and actions/setup-go extracts its tarball with `tar xz`.
-      # PATH goes to GITHUB_ENV because the Leap image config defines no PATH
-      # (alone in this matrix); once setup-go calls addPath, the runner rebuilds
-      # PATH from the image value, and an empty base loses /usr/bin.
       - name: Install dependencies (zypper)
         if: matrix.pkg_manager == 'zypper'
-        run: |
-          zypper --non-interactive install git curl gcc glibc-devel tar gzip
-          echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$GITHUB_ENV"
+        run: zypper --non-interactive install git curl gcc glibc-devel tar gzip
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Dockerfiles/build.sh
+++ b/Dockerfiles/build.sh
@@ -31,3 +31,5 @@ docker build -t alpamon:redhat-8 -f Dockerfiles/redhat/8/Dockerfile .
 docker build -t alpamon:redhat-9 -f Dockerfiles/redhat/9/Dockerfile .
 
 docker build -t alpamon:centos-7 -f Dockerfiles/centos/7/Dockerfile .
+
+docker build -t alpamon:opensuse-15 -f Dockerfiles/opensuse/15/Dockerfile .

--- a/Dockerfiles/opensuse/15/Dockerfile
+++ b/Dockerfiles/opensuse/15/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.25 AS builder
+
+# Automatically set GOARCH to the build-time architecture
+ARG TARGETARCH
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=${TARGETARCH:-amd64}
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go build -o alpamon ./cmd/alpamon/main.go
+
+FROM opensuse/leap:15
+
+WORKDIR /usr/local/alpamon
+
+COPY --from=builder /build/alpamon ./alpamon
+
+COPY Dockerfiles/opensuse/15/entrypoint.sh /usr/local/alpamon/entrypoint.sh
+
+RUN chmod +x /usr/local/alpamon/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/alpamon/entrypoint.sh"]

--- a/Dockerfiles/opensuse/15/entrypoint.sh
+++ b/Dockerfiles/opensuse/15/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"f4592c6d-cb9a-4b33-af1c-bd67b675b16f"}
+PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
+
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
+
+cat > /etc/alpamon/alpamon.conf <<EOL
+[server]
+url = $ALPACON_URL
+id = $PLUGIN_ID
+key = $PLUGIN_KEY
+
+[logging]
+debug = true
+EOL
+
+echo -e "\nThe following configuration file is being used:\n"
+cat /etc/alpamon/alpamon.conf
+
+exec /usr/local/alpamon/alpamon

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Installed on each managed server, Alpamon establishes an outbound-only connectio
 | Platform | Minimum version | Arch |
 | --- | --- | --- |
 | Linux | Ubuntu 18.04+, Debian 11+, RHEL / Rocky / AlmaLinux 8+, Oracle Linux 8+, Amazon Linux 2 / 2023, Fedora (current or previous) | amd64, arm64 |
+| Linux (best-effort) | openSUSE Leap 15+, SLES 15+ | amd64, arm64 |
 | macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
 | Windows | Windows 10 (1803+) / Windows 11, Windows Server 2019 or later | amd64 |
 
@@ -33,6 +34,44 @@ curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.rpm.
 sudo yum install alpamon
 sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```
+
+**openSUSE / SLES** (best-effort)
+
+openSUSE and SLES report `platform=rhel` to Alpacon: they share RHEL's rpm
+packaging, `wheel` sudo group, and shadow-utils account tooling. The agent
+runs `zypper` locally.
+
+The repository URL below is unverified: see issue #348.
+
+```bash
+# The PackageCloud one-liner writes a yum repo file; add the repo to zypper directly.
+sudo zypper addrepo -f \
+  'https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch' alpamon
+sudo zypper --gpg-auto-import-keys refresh
+sudo zypper install alpamon
+sudo alpamon register --url https://<workspace> --token <TOKEN>
+```
+
+**Sudoers prerequisite**: openSUSE ships `/etc/sudoers` with `Defaults targetpw`
+set and `%wheel` commented out, so `wheel` membership alone does not grant
+sudo. Add a drop-in before granting admin access:
+
+```bash
+echo '%wheel ALL=(ALL) ALL' | sudo tee /etc/sudoers.d/alpacon-wheel
+sudo chmod 0440 /etc/sudoers.d/alpacon-wheel
+```
+
+**Known limitation**: because the host reports `rhel`, console-driven package
+operations that the server composes still emit `yum` commands and fail on a
+SUSE host: Alpacon plugin install/upgrade and the automatic `alpamon-pam`
+install. The agent's own upgrade, uninstall, and system-update paths do use
+`zypper`. Install `alpamon-pam` and plugins manually with `zypper` until the
+server side is zypper-aware.
+
+**Already-registered hosts**: a host that registered before this fix carries a
+wrong `platform` value on the server. That field is write-once, so the host
+must re-register (`sudo alpamon register --force ...`) to pick up the correct
+value.
 
 ### macOS
 
@@ -90,6 +129,8 @@ The optional `alpamon-pam` package provides PAM integration for Alpacon-managed 
 sudo apt-get install alpamon-pam
 # RHEL / CentOS
 sudo yum install alpamon-pam
+# openSUSE / SLES
+sudo zypper install alpamon-pam
 ```
 
 After install, add to `/etc/pam.d/sudo`:
@@ -206,7 +247,7 @@ docker run \
     alpamon:latest
 ```
 
-Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.
+Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9, openSUSE Leap 15. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.
 
 ### Run locally
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 set and `%wheel` commented out, so `wheel` membership alone does not grant
 sudo. Add a drop-in before granting admin access:
 
+Stage it under a name containing a dot, which sudo ignores when reading the
+include directory, so a typo cannot lock you out before `visudo -cf` has passed:
+
 ```bash
-echo '%wheel ALL=(ALL) ALL' | sudo tee /etc/sudoers.d/alpacon-wheel
-sudo chmod 0440 /etc/sudoers.d/alpacon-wheel
+echo '%wheel ALL=(ALL) ALL' | sudo tee /etc/sudoers.d/alpacon-wheel.stage >/dev/null
+sudo visudo -cf /etc/sudoers.d/alpacon-wheel.stage &&
+  sudo install -m 0440 -o root -g root \
+    /etc/sudoers.d/alpacon-wheel.stage /etc/sudoers.d/alpacon-wheel
+sudo rm -f /etc/sudoers.d/alpacon-wheel.stage
 ```
 
 **Known limitation**: because the host reports `rhel`, console-driven package

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ docker run \
     -e ALPACON_URL="https://<workspace>" \
     -e PLUGIN_ID="<plugin_id>" \
     -e PLUGIN_KEY="<plugin_key>" \
-    alpamon:latest
+    alpamon:opensuse-15
 ```
 
 Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9, openSUSE Leap 15. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -99,7 +99,7 @@ func init() {
 	Cmd.Flags().StringVar(&apiToken, "token", "", "Registration token issued by the target workspace (required)")
 	Cmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
 	Cmd.Flags().StringVar(&platform, "platform", "",
-		"Platform (debian/rhel). Auto-detected when omitted.\n"+
+		"Platform (debian/rhel/darwin/windows). Auto-detected when omitted.\n"+
 			"Affects the target workspace's server record only; the agent still\n"+
 			"refuses to start on an unsupported distribution.")
 	Cmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -403,12 +403,9 @@ func normalizeHostname(h string) string {
 	return h
 }
 
-// detectPlatform classifies this host for the migration's registration
-// payload on the target workspace.
-//
-// It returns an error rather than a default for a distribution it cannot
-// classify: alpacon-server persists this value write-once, so a wrong guess
-// on workspace B is only fixable by re-registering.
+// detectPlatform returns an error rather than a default for a distribution it
+// cannot classify: the target workspace persists this value write-once, so a
+// wrong guess is only fixable by re-registering there.
 func detectPlatform() (string, error) {
 	var raw string
 	if runtime.GOOS == "linux" {
@@ -424,8 +421,8 @@ func detectPlatform() (string, error) {
 	return detectPlatformFor(runtime.GOOS, raw)
 }
 
-// detectPlatformFor is the pure half of detectPlatform, split out so the
-// mapping and its error text can be tested without a host.
+// detectPlatformFor is detectPlatform's pure half, so the mapping and its
+// error text are testable without a host.
 func detectPlatformFor(goos, raw string) (string, error) {
 	like, _, ok := utils.ResolvePlatform(goos, raw)
 	if !ok {

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -98,7 +98,10 @@ func init() {
 	Cmd.Flags().StringVar(&newURL, "url", "", "Target Alpacon workspace URL (required)")
 	Cmd.Flags().StringVar(&apiToken, "token", "", "Registration token issued by the target workspace (required)")
 	Cmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
-	Cmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel/darwin/windows, auto-detected when omitted)")
+	Cmd.Flags().StringVar(&platform, "platform", "",
+		"Platform (debian/rhel). Auto-detected when omitted.\n"+
+			"Affects the target workspace's server record only; the agent still\n"+
+			"refuses to start on an unsupported distribution.")
 	Cmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	Cmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	Cmd.Flags().DurationVar(&rollbackTimeout, "rollback-timeout", migrate.DefaultRollbackTimeout,
@@ -139,7 +142,11 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 	}
 
 	if platform == "" {
-		platform = detectPlatform()
+		detected, err := detectPlatform()
+		if err != nil {
+			return err
+		}
+		platform = detected
 	}
 
 	current, err := config.ReadServer(configPath)
@@ -396,29 +403,35 @@ func normalizeHostname(h string) string {
 	return h
 }
 
-func detectPlatform() string {
-	if runtime.GOOS == "windows" {
-		return "windows"
+// detectPlatform classifies this host for the migration's registration
+// payload on the target workspace.
+//
+// It returns an error rather than a default for a distribution it cannot
+// classify: alpacon-server persists this value write-once, so a wrong guess
+// on workspace B is only fixable by re-registering.
+func detectPlatform() (string, error) {
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			return "", fmt.Errorf("failed to detect the host platform: %w", err)
+		}
+		raw = info.Platform
 	}
-	info, err := host.Info()
-	if err != nil {
-		return "debian"
+	return detectPlatformFor(runtime.GOOS, raw)
+}
+
+// detectPlatformFor is the pure half of detectPlatform, split out so the
+// mapping and its error text can be tested without a host.
+func detectPlatformFor(goos, raw string) (string, error) {
+	like, _, ok := utils.ResolvePlatform(goos, raw)
+	if !ok {
+		return "", fmt.Errorf(
+			"unrecognized Linux distribution %q.\n"+
+				"alpamon supports debian- and rhel-family distributions, "+
+				"including openSUSE/SLES.\n"+
+				"Pass --platform debian|rhel to override if you know the host is compatible",
+			raw)
 	}
-	switch info.Platform {
-	case "darwin":
-		return "darwin"
-	case "ubuntu", "debian", "raspbian":
-		return "debian"
-	case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-		return "rhel"
-	}
-	p := strings.ToLower(info.Platform)
-	switch {
-	case strings.Contains(p, "ubuntu"), strings.Contains(p, "debian"):
-		return "debian"
-	case strings.Contains(p, "centos"), strings.Contains(p, "rhel"),
-		strings.Contains(p, "fedora"), strings.Contains(p, "rocky"):
-		return "rhel"
-	}
-	return "debian"
+	return like, nil
 }

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -414,7 +414,10 @@ func detectPlatform() (string, error) {
 	if runtime.GOOS == "linux" {
 		info, err := host.Info()
 		if err != nil {
-			return "", fmt.Errorf("failed to detect the host platform: %w", err)
+			return "", fmt.Errorf(
+				"failed to detect the host platform: %w.\n"+
+					"Pass --platform debian|rhel to skip detection if you know the host is compatible",
+				err)
 		}
 		raw = info.Platform
 	}

--- a/cmd/alpamon/command/migrate/migrate_test.go
+++ b/cmd/alpamon/command/migrate/migrate_test.go
@@ -227,3 +227,31 @@ func TestCleanupTargetRegistration_CallsUnregisterEndpoint(t *testing.T) {
 		t.Fatalf("expected unregister endpoint to be hit")
 	}
 }
+
+// migrate carries its own detectPlatform copy; assert it agrees with the
+// shared table rather than trusting the two copies stayed in sync.
+func TestDetectPlatform_SuseMapsToRhel(t *testing.T) {
+	got, err := detectPlatformFor("linux", "opensuse-leap")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "rhel" {
+		t.Errorf("platform = %q, want rhel", got)
+	}
+}
+
+// detectPlatform must not invent a platform for a distribution it cannot
+// classify. The target workspace persists the value write-once with no admin
+// edit path, so a silent "debian" default is unrecoverable.
+func TestDetectPlatform_UnsupportedReturnsError(t *testing.T) {
+	_, err := detectPlatformFor("linux", "arch")
+	if err == nil {
+		t.Fatal("expected an error for an unclassifiable distribution")
+	}
+	if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "--platform") {
+		t.Errorf("error must tell the operator about the override, got %q", err)
+	}
+}

--- a/cmd/alpamon/command/migrate/migrate_test.go
+++ b/cmd/alpamon/command/migrate/migrate_test.go
@@ -240,9 +240,8 @@ func TestDetectPlatform_SuseMapsToRhel(t *testing.T) {
 	}
 }
 
-// detectPlatform must not invent a platform for a distribution it cannot
-// classify. The target workspace persists the value write-once with no admin
-// edit path, so a silent "debian" default is unrecoverable.
+// A silent "debian" default is unrecoverable: the target workspace persists
+// the value write-once with no admin edit path.
 func TestDetectPlatform_UnsupportedReturnsError(t *testing.T) {
 	_, err := detectPlatformFor("linux", "arch")
 	if err == nil {

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -54,14 +54,16 @@ var (
 	// Test seams: indirections over the side-effecting steps so registration
 	// logic (within-run rollback, --force ordering) can be exercised without
 	// touching the real filesystem, OS service manager, or relying on platform
-	// service behavior. They default to the production implementations, mirroring
-	// the detectCloud seam above.
+	// service behavior. detectPlatformFn is the exception: it has no side effect
+	// and exists so a detection failure can be injected on any host. They default
+	// to the production implementations, mirroring the detectCloud seam above.
 	ensureInstalledFn   = ensureInstalled
 	writeConfigFileFn   = writeConfigFile
 	ensureDirectoriesFn = ensureDirectories
 	startServiceFn      = startService
 	stopServiceFn       = stopService
 	removeServiceFn     = removeService
+	detectPlatformFn    = detectPlatform
 )
 
 // registerCloudDetectTimeout caps the synchronous cloud probe at register time
@@ -115,7 +117,7 @@ Options:
   --url             Alpacon server URL (required)
   --token           API token (servers:register scope required)
   --name            Server name (optional, defaults to hostname)
-  --platform        Platform (debian/rhel, auto-detect if omitted)
+  --platform        Platform (debian/rhel, auto-detected if omitted; server record only)
   --ssl-verify      SSL certificate verification (default: true)
   --ca-cert         CA certificate path
   --tag             Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")
@@ -129,7 +131,10 @@ func init() {
 	RegisterCmd.Flags().StringVar(&serverURL, "url", "", "Alpacon server URL (required)")
 	RegisterCmd.Flags().StringVar(&apiToken, "token", "", "API token (servers:register scope required)")
 	RegisterCmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
-	RegisterCmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel, auto-detect)")
+	RegisterCmd.Flags().StringVar(&platform, "platform", "",
+		"Platform (debian/rhel). Auto-detected when omitted.\n"+
+			"Affects the server-side record only; the agent still\n"+
+			"refuses to start on an unsupported distribution.")
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
@@ -330,7 +335,11 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 	}
 
 	if platform == "" {
-		platform = detectPlatform()
+		detected, err := detectPlatformFn()
+		if err != nil {
+			return RegisterRequest{}, err
+		}
+		platform = detected
 		fmt.Printf("Platform auto-detected: %s\n", platform)
 	}
 
@@ -471,39 +480,36 @@ func normalizeServerName(value string) string {
 	return strings.TrimRight(n, "-")
 }
 
-func detectPlatform() string {
-	hostInfo, err := host.Info()
-	if err != nil {
-		fmt.Println("Warning: Failed to detect platform, defaulting to debian")
-		return "debian"
-	}
-
-	if runtime.GOOS == "windows" {
-		return "windows"
-	}
-
-	switch hostInfo.Platform {
-	case "darwin":
-		return "darwin"
-	case "ubuntu", "debian", "raspbian":
-		return "debian"
-	case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-		return "rhel"
-	default:
-		// Check if platform name contains known keywords
-		platformLower := strings.ToLower(hostInfo.Platform)
-		if strings.Contains(platformLower, "ubuntu") ||
-			strings.Contains(platformLower, "debian") {
-			return "debian"
+// detectPlatform classifies this host for the registration payload.
+//
+// It returns an error rather than a default for a distribution it cannot
+// classify. alpacon-server persists this value write-once with no admin edit
+// path, so a wrong guess is only fixable by re-registering the host.
+func detectPlatform() (string, error) {
+	var raw string
+	if runtime.GOOS == "linux" {
+		hostInfo, err := host.Info()
+		if err != nil {
+			return "", fmt.Errorf("failed to detect the host platform: %w", err)
 		}
-		if strings.Contains(platformLower, "centos") ||
-			strings.Contains(platformLower, "rhel") ||
-			strings.Contains(platformLower, "fedora") ||
-			strings.Contains(platformLower, "rocky") {
-			return "rhel"
-		}
-		return "debian" // default fallback
+		raw = hostInfo.Platform
 	}
+	return detectPlatformFor(runtime.GOOS, raw)
+}
+
+// detectPlatformFor is the pure half of detectPlatform, split out so the
+// mapping and its error text can be tested without a host.
+func detectPlatformFor(goos, raw string) (string, error) {
+	like, _, ok := utils.ResolvePlatform(goos, raw)
+	if !ok {
+		return "", fmt.Errorf(
+			"unrecognized Linux distribution %q.\n"+
+				"alpamon supports debian- and rhel-family distributions, "+
+				"including openSUSE/SLES.\n"+
+				"Pass --platform debian|rhel to override if you know the host is compatible",
+			raw)
+	}
+	return like, nil
 }
 
 func sendRegisterRequest(req RegisterRequest) (*RegisterResponse, error) {

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -117,7 +117,7 @@ Options:
   --url             Alpacon server URL (required)
   --token           API token (servers:register scope required)
   --name            Server name (optional, defaults to hostname)
-  --platform        Platform (debian/rhel, auto-detected if omitted; server record only)
+  --platform        Platform (debian/rhel/darwin/windows, auto-detected if omitted; server record only)
   --ssl-verify      SSL certificate verification (default: true)
   --ca-cert         CA certificate path
   --tag             Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")
@@ -132,7 +132,7 @@ func init() {
 	RegisterCmd.Flags().StringVar(&apiToken, "token", "", "API token (servers:register scope required)")
 	RegisterCmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
 	RegisterCmd.Flags().StringVar(&platform, "platform", "",
-		"Platform (debian/rhel). Auto-detected when omitted.\n"+
+		"Platform (debian/rhel/darwin/windows). Auto-detected when omitted.\n"+
 			"Affects the server-side record only; the agent still\n"+
 			"refuses to start on an unsupported distribution.")
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -490,7 +490,10 @@ func detectPlatform() (string, error) {
 	if runtime.GOOS == "linux" {
 		hostInfo, err := host.Info()
 		if err != nil {
-			return "", fmt.Errorf("failed to detect the host platform: %w", err)
+			return "", fmt.Errorf(
+				"failed to detect the host platform: %w.\n"+
+					"Pass --platform debian|rhel to skip detection if you know the host is compatible",
+				err)
 		}
 		raw = hostInfo.Platform
 	}

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -55,8 +55,7 @@ var (
 	// logic (within-run rollback, --force ordering) can be exercised without
 	// touching the real filesystem, OS service manager, or relying on platform
 	// service behavior. detectPlatformFn is the exception: it has no side effect
-	// and exists so a detection failure can be injected on any host. They default
-	// to the production implementations, mirroring the detectCloud seam above.
+	// and exists so a detection failure can be injected on any host.
 	ensureInstalledFn   = ensureInstalled
 	writeConfigFileFn   = writeConfigFile
 	ensureDirectoriesFn = ensureDirectories
@@ -480,11 +479,9 @@ func normalizeServerName(value string) string {
 	return strings.TrimRight(n, "-")
 }
 
-// detectPlatform classifies this host for the registration payload.
-//
-// It returns an error rather than a default for a distribution it cannot
-// classify. alpacon-server persists this value write-once with no admin edit
-// path, so a wrong guess is only fixable by re-registering the host.
+// detectPlatform returns an error rather than a default for a distribution it
+// cannot classify: alpacon-server persists this value write-once with no admin
+// edit path, so a wrong guess is only fixable by re-registering the host.
 func detectPlatform() (string, error) {
 	var raw string
 	if runtime.GOOS == "linux" {
@@ -500,8 +497,8 @@ func detectPlatform() (string, error) {
 	return detectPlatformFor(runtime.GOOS, raw)
 }
 
-// detectPlatformFor is the pure half of detectPlatform, split out so the
-// mapping and its error text can be tested without a host.
+// detectPlatformFor is detectPlatform's pure half, so the mapping and its
+// error text are testable without a host.
 func detectPlatformFor(goos, raw string) (string, error) {
 	like, _, ok := utils.ResolvePlatform(goos, raw)
 	if !ok {

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/cloud"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -427,5 +428,60 @@ func TestTagFlagParsing(t *testing.T) {
 				assert.Equal(t, tt.expectedTags, parsedTags)
 			}
 		})
+	}
+}
+
+// register carries its own detectPlatform copy; assert it agrees with the
+// shared table rather than trusting the two copies stayed in sync.
+func TestDetectPlatform_SuseMapsToRhel(t *testing.T) {
+	got, err := detectPlatformFor("linux", "opensuse-leap")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "rhel" {
+		t.Errorf("platform = %q, want rhel", got)
+	}
+}
+
+// detectPlatform must not invent a platform for a distribution it cannot
+// classify. The server persists the registration value write-once with no
+// admin edit path, so a silent "debian" default is unrecoverable.
+func TestDetectPlatform_UnsupportedReturnsError(t *testing.T) {
+	_, err := detectPlatformFor("linux", "arch")
+	if err == nil {
+		t.Fatal("expected an error for an unclassifiable distribution")
+	}
+	if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "--platform") {
+		t.Errorf("error must tell the operator about the override, got %q", err)
+	}
+}
+
+// buildRegisterRequest surfaces the detection failure instead of registering
+// with a guessed platform.
+func TestBuildRegisterRequest_PlatformDetectionFailurePropagates(t *testing.T) {
+	origPlatform := platform
+	origName := serverName
+	t.Cleanup(func() { platform = origPlatform; serverName = origName })
+
+	platform = ""
+	serverName = "test-host"
+
+	orig := detectPlatformFn
+	detectPlatformFn = func() (string, error) {
+		return "", errors.New("unrecognized Linux distribution \"arch\"")
+	}
+	t.Cleanup(func() { detectPlatformFn = orig })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	_, err := buildRegisterRequest(cmd)
+	if err == nil {
+		t.Fatal("expected buildRegisterRequest to fail when platform detection fails")
+	}
+	if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
 	}
 }

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -443,9 +443,8 @@ func TestDetectPlatform_SuseMapsToRhel(t *testing.T) {
 	}
 }
 
-// detectPlatform must not invent a platform for a distribution it cannot
-// classify. The server persists the registration value write-once with no
-// admin edit path, so a silent "debian" default is unrecoverable.
+// A silent "debian" default is unrecoverable: the server persists the
+// registration value write-once with no admin edit path.
 func TestDetectPlatform_UnsupportedReturnsError(t *testing.T) {
 	_, err := detectPlatformFor("linux", "arch")
 	if err == nil {
@@ -459,8 +458,6 @@ func TestDetectPlatform_UnsupportedReturnsError(t *testing.T) {
 	}
 }
 
-// buildRegisterRequest surfaces the detection failure instead of registering
-// with a guessed platform.
 func TestBuildRegisterRequest_PlatformDetectionFailurePropagates(t *testing.T) {
 	origPlatform := platform
 	origName := serverName

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -174,17 +174,21 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	pkgList := strings.Join(packages, " ")
 
 	var cmd string
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
-	case "rhel":
+	case utils.PkgYum:
 		cmd = fmt.Sprintf("yum update -y %s", pkgList)
-	case "darwin", "windows":
-		// needAlpamon is always true here: needPam is always false on non-linux
-		// (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
+	case utils.PkgZypper:
+		cmd = fmt.Sprintf("zypper --non-interactive update %s", pkgList)
+	case utils.PkgBrew, "":
+		// darwin/windows have no package channel for alpamon, so the binary
+		// replaces itself. needAlpamon is always true here: needPam is always
+		// false on non-linux (pam unsupported; see pkg/utils/pam.go) and the
+		// switch is reached only when needAlpamon||needPam.
 		return h.selfUpdate(ctx, latestVersion)
 	default:
-		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
+		return 1, fmt.Sprintf("Platform '%s' (package manager %q) not supported.", utils.PlatformLike, utils.PackageManager), nil
 	}
 
 	log.Debug().Msgf("Upgrading %s...", pkgList)
@@ -323,20 +327,21 @@ func (h *SystemHandler) executeUninstall() {
 
 	var cmd string
 
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		// Use purge to remove package and config files
 		cmd = "apt-get purge alpamon -y && apt-get autoremove -y"
-	case "rhel":
-		// Remove package using yum
+	case utils.PkgYum:
 		cmd = "yum remove alpamon -y"
-	case "darwin":
+	case utils.PkgZypper:
+		cmd = "zypper --non-interactive remove alpamon"
+	case utils.PkgBrew:
 		// For macOS development environment, just shutdown
 		log.Warn().Msgf("Platform '%s' does not support full uninstall. Shutting down instead.", utils.PlatformLike)
 		h.wsClient.ShutDown()
 		return
 	default:
-		log.Error().Msgf("Platform '%s' not supported for uninstall.", utils.PlatformLike)
+		log.Error().Msgf("Platform '%s' (package manager %q) not supported for uninstall.", utils.PlatformLike, utils.PackageManager)
 		h.wsClient.ShutDown()
 		return
 	}
@@ -415,15 +420,24 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 	log.Info().Msg("Upgrade system requested.")
 
 	var cmd string
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		cmd = "apt-get update -o Acquire::Retries=3 && apt-get upgrade -y -o Acquire::Retries=3 && apt-get autoremove -y"
-	case "rhel":
+	case utils.PkgYum:
 		cmd = "yum update -y"
-	case "darwin":
+	case utils.PkgZypper:
+		// Tumbleweed is a rolling release: `zypper update` cannot perform the
+		// vendor changes a distribution upgrade needs. Leap/SLES must NOT use
+		// dup — it would jump to the next service pack.
+		if utils.IsTumbleweed(utils.PlatformID) {
+			cmd = "zypper --non-interactive dup"
+		} else {
+			cmd = "zypper --non-interactive update"
+		}
+	case utils.PkgBrew:
 		cmd = "brew upgrade"
 	default:
-		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
+		return 1, fmt.Sprintf("Platform '%s' (package manager %q) not supported.", utils.PlatformLike, utils.PackageManager), nil
 	}
 
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -428,7 +428,7 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 	case utils.PkgZypper:
 		// Tumbleweed is a rolling release: `zypper update` cannot perform the
 		// vendor changes a distribution upgrade needs. Leap/SLES must NOT use
-		// dup — it would jump to the next service pack.
+		// dup: it would jump to the next service pack.
 		if utils.IsTumbleweed(utils.PlatformID) {
 			cmd = "zypper --non-interactive dup"
 		} else {

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -581,9 +581,8 @@ func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
 	}
 }
 
-// TestSystemHandler_Upgrade_SelfUpdate: darwin and windows route handleUpgrade
-// through selfUpdateFn instead of returning "not supported". Both axes are set
-// explicitly — leaving PackageManager at its zero value would pass by accident.
+// Both axes are set explicitly: leaving PackageManager at its zero value would
+// pass by accident.
 func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 	for _, tc := range []struct {
 		platformLike   string
@@ -705,8 +704,6 @@ func TestSystemHandler_SelfUpdate_RestartScheduleFails(t *testing.T) {
 	}
 }
 
-// setPackageManagerAndID sets both local-command axes for one test and restores
-// them: PackageManager selects the command, PlatformID resolves the Tumbleweed guard.
 func setPackageManagerAndID(t *testing.T, pkgManager, platformID string) {
 	t.Helper()
 	origPM := utils.PackageManager
@@ -719,8 +716,8 @@ func setPackageManagerAndID(t *testing.T, pkgManager, platformID string) {
 	})
 }
 
-// openSUSE/SLES report platform_like=rhel to the server but must run zypper
-// locally, which is exactly why PackageManager is a separate axis.
+// openSUSE/SLES report platform_like=rhel but must run zypper locally, which is
+// why PackageManager is a separate axis.
 func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}
@@ -757,9 +754,7 @@ func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
 	}
 }
 
-// Tumbleweed is a rolling release: `zypper update` cannot perform the vendor
-// changes a distribution upgrade needs. Leap/SLES must NOT use dup — it would
-// jump to the next service pack.
+// Leap/SLES must NOT use dup: it would jump to the next service pack.
 func TestSystemHandler_SystemUpdate_ZypperDupOnlyOnTumbleweed(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -805,10 +800,9 @@ func TestSystemHandler_SystemUpdate_ZypperDupOnlyOnTumbleweed(t *testing.T) {
 	}
 }
 
-// executeUninstall is the third PackageManager switch; the other two already have
-// zypper coverage. Asserts against every captured command because the uninstall is
-// scheduled through systemd-run where systemd exists and a deferred subshell where
-// it does not, so the zypper string lands in different argv positions per host.
+// Asserts against every captured command: the uninstall is scheduled through
+// systemd-run where systemd exists and a deferred subshell where it does not, so
+// the zypper string lands in different argv positions per host.
 func TestSystemHandler_Uninstall_UsesZypper(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -581,10 +581,18 @@ func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
 	}
 }
 
-// TestSystemHandler_Upgrade_SelfUpdate: darwin and windows route handleUpgrade through selfUpdateFn instead of returning "not supported".
+// TestSystemHandler_Upgrade_SelfUpdate: darwin and windows route handleUpgrade
+// through selfUpdateFn instead of returning "not supported". Both axes are set
+// explicitly — leaving PackageManager at its zero value would pass by accident.
 func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
-	for _, platform := range []string{"darwin", "windows"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, tc := range []struct {
+		platformLike   string
+		packageManager string
+	}{
+		{"darwin", utils.PkgBrew},
+		{"windows", ""},
+	} {
+		t.Run(tc.platformLike, func(t *testing.T) {
 			mockExec := common.NewMockCommandExecutor(t)
 			mockWS := &MockWSClient{}
 			ctxManager := agent.NewContextManager()
@@ -607,8 +615,9 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 			}
 
 			originalPlatformLike := utils.PlatformLike
-			utils.SetPlatformLike(platform)
+			utils.SetPlatformLike(tc.platformLike)
 			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+			setPackageManagerAndID(t, tc.packageManager, "")
 
 			exitCode, output, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
 
@@ -616,7 +625,7 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !called {
-				t.Errorf("expected selfUpdateFn to be called on %s", platform)
+				t.Errorf("expected selfUpdateFn to be called on %s", tc.platformLike)
 			}
 			if gotVersion != "v9.9.9" {
 				t.Errorf("expected self-update version v9.9.9, got %q", gotVersion)
@@ -625,7 +634,7 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 				t.Errorf("expected exit code 0, got %d", exitCode)
 			}
 			if strings.Contains(output, "not supported") {
-				t.Errorf("%s should route to self-update, got %q", platform, output)
+				t.Errorf("%s should route to self-update, got %q", tc.platformLike, output)
 			}
 		})
 	}
@@ -693,5 +702,137 @@ func TestSystemHandler_SelfUpdate_RestartScheduleFails(t *testing.T) {
 	}
 	if mockWS.RestartCalled {
 		t.Error("restart must not fire when scheduling failed")
+	}
+}
+
+// setPackageManagerAndID sets both local-command axes for one test and restores
+// them: PackageManager selects the command, PlatformID resolves the Tumbleweed guard.
+func setPackageManagerAndID(t *testing.T, pkgManager, platformID string) {
+	t.Helper()
+	origPM := utils.PackageManager
+	origID := utils.PlatformID
+	utils.SetPackageManager(pkgManager)
+	utils.SetPlatformID(platformID)
+	t.Cleanup(func() {
+		utils.SetPackageManager(origPM)
+		utils.SetPlatformID(origID)
+	})
+}
+
+// openSUSE/SLES report platform_like=rhel to the server but must run zypper
+// locally, which is exactly why PackageManager is a separate axis.
+func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	var found bool
+	for _, c := range mockExec.GetExecutedCommands() {
+		joined := strings.Join(c.Args, " ")
+		if strings.Contains(joined, "zypper --non-interactive update alpamon") {
+			found = true
+		}
+		if strings.Contains(joined, "yum ") || strings.Contains(joined, "apt-get ") {
+			t.Errorf("zypper host must not run yum/apt: %q", joined)
+		}
+	}
+	if !found {
+		t.Errorf("expected a zypper update command, got %+v", mockExec.GetExecutedCommands())
+	}
+}
+
+// Tumbleweed is a rolling release: `zypper update` cannot perform the vendor
+// changes a distribution upgrade needs. Leap/SLES must NOT use dup — it would
+// jump to the next service pack.
+func TestSystemHandler_SystemUpdate_ZypperDupOnlyOnTumbleweed(t *testing.T) {
+	tests := []struct {
+		name       string
+		platformID string
+		wantCmd    string
+		rejectCmd  string
+	}{
+		{"tumbleweed", "opensuse-tumbleweed", "zypper --non-interactive dup", "zypper --non-interactive update"},
+		{"leap", "opensuse-leap", "zypper --non-interactive update", "zypper --non-interactive dup"},
+		{"sles", "sles", "zypper --non-interactive update", "zypper --non-interactive dup"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{}, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, tt.platformID)
+
+			if _, _, err := handler.Execute(context.Background(), common.Update.String(), &common.CommandArgs{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var found bool
+			for _, c := range mockExec.GetExecutedCommands() {
+				joined := strings.Join(c.Args, " ")
+				if strings.Contains(joined, tt.rejectCmd) {
+					t.Fatalf("%s must not run %q", tt.name, tt.rejectCmd)
+				}
+				if strings.Contains(joined, tt.wantCmd) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected %q, got %+v", tt.wantCmd, mockExec.GetExecutedCommands())
+			}
+		})
+	}
+}
+
+// executeUninstall is the third PackageManager switch; the other two already have
+// zypper coverage. Asserts against every captured command because the uninstall is
+// scheduled through systemd-run where systemd exists and a deferred subshell where
+// it does not, so the zypper string lands in different argv positions per host.
+func TestSystemHandler_Uninstall_UsesZypper(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+	handler.executeUninstall()
+
+	var found bool
+	for _, c := range mockExec.GetExecutedCommands() {
+		joined := strings.Join(c.Args, " ")
+		if strings.Contains(joined, "zypper --non-interactive remove alpamon") {
+			found = true
+		}
+		if strings.Contains(joined, "yum remove") || strings.Contains(joined, "apt-get purge") {
+			t.Errorf("zypper host must not run yum/apt: %q", joined)
+		}
+	}
+	if !found {
+		t.Errorf("expected a zypper remove command, got %+v", mockExec.GetExecutedCommands())
 	}
 }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -17,7 +17,7 @@ import (
 //     one of debian/rhel/darwin/windows and nothing else. SUSE reports rhel:
 //     the three things the server gates on (rpm, wheel, useradd) answer
 //     identically for both families.
-//   - PackageManager picks the local command. This is where SUSE diverges —
+//   - PackageManager picks the local command. This is where SUSE diverges:
 //     zypper, not yum.
 //   - PlatformID is the raw os-release id, kept for the one place a
 //     distro-level distinction is unavoidable (Tumbleweed).
@@ -30,7 +30,7 @@ var (
 // platformAliases mirrors alpacon-server servers/constants.py
 // PLATFORM_ALIASES. Server.platform is write-once with no admin edit path,
 // so a value the two sides disagree on corrupts feature gating permanently.
-// Keep the two tables 1:1 — do not add ids the server does not know.
+// Keep the two tables 1:1: do not add ids the server does not know.
 var platformAliases = map[string]string{
 	"debian":    "debian",
 	"ubuntu":    "debian",
@@ -68,9 +68,8 @@ const (
 	PkgBrew   = "brew"
 )
 
-// ResolvePlatform maps a raw gopsutil platform id onto the alpacon-server
-// contract value and the local package manager. Pure: callers pass
-// host.Info() output so the table is testable without a host.
+// ResolvePlatform is pure: callers pass host.Info() output so the table is
+// testable without a host.
 //
 // ok is false for a distribution neither table knows. Callers must not
 // substitute a default (see platformAliases for why).
@@ -134,25 +133,23 @@ func InitPlatform() {
 	PlatformID = raw
 }
 
-// SetPlatformLike allows setting PlatformLike for testing purposes.
+// SetPlatformLike sets PlatformLike for tests.
 func SetPlatformLike(platform string) {
 	PlatformLike = platform
 }
 
-// SetPackageManager allows setting PackageManager for testing purposes.
+// SetPackageManager sets PackageManager for tests.
 func SetPackageManager(pm string) {
 	PackageManager = pm
 }
 
-// SetPlatformID allows setting PlatformID for testing purposes.
+// SetPlatformID sets PlatformID for tests.
 func SetPlatformID(id string) {
 	PlatformID = id
 }
 
-// IsTumbleweed reports whether id names an openSUSE Tumbleweed variant.
-//
-// Lives beside susePrefixes so both SUSE id decisions normalize case the same
-// way. Why the caller cares is documented at the call site.
+// IsTumbleweed lives beside susePrefixes so both SUSE id decisions normalize
+// case the same way. Why the caller cares is documented at the call site.
 func IsTumbleweed(id string) bool {
 	return strings.Contains(strings.ToLower(id), "tumbleweed")
 }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -1,0 +1,158 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+// Platform classification, split across three axes because a single value
+// cannot serve both consumers on SUSE:
+//
+//   - PlatformLike is the alpacon-server contract value. The register
+//     endpoint gates it with a ChoiceField over SERVER_PLATFORMS, so it is
+//     one of debian/rhel/darwin/windows and nothing else. SUSE reports rhel:
+//     the three things the server gates on (rpm, wheel, useradd) answer
+//     identically for both families.
+//   - PackageManager picks the local command. This is where SUSE diverges —
+//     zypper, not yum.
+//   - PlatformID is the raw os-release id, kept for the one place a
+//     distro-level distinction is unavoidable (Tumbleweed).
+var (
+	PlatformLike   string
+	PackageManager string
+	PlatformID     string
+)
+
+// platformAliases mirrors alpacon-server servers/constants.py
+// PLATFORM_ALIASES. Server.platform is write-once with no admin edit path,
+// so a value the two sides disagree on corrupts feature gating permanently.
+// Keep the two tables 1:1 — do not add ids the server does not know.
+var platformAliases = map[string]string{
+	"debian":    "debian",
+	"ubuntu":    "debian",
+	"raspbian":  "debian",
+	"rhel":      "rhel",
+	"centos":    "rhel",
+	"redhat":    "rhel",
+	"amazon":    "rhel",
+	"amzn":      "rhel",
+	"fedora":    "rhel",
+	"rocky":     "rhel",
+	"almalinux": "rhel",
+	"oracle":    "rhel",
+	"ol":        "rhel",
+}
+
+// susePrefixes mirrors alpacon-server SUSE_PLATFORM_PREFIXES. SUSE matches by
+// prefix rather than exact id because the os-release ids proliferate
+// (opensuse-leap, opensuse-tumbleweed, opensuse-microos, sles, sled,
+// sle-micro, sle_hpc, ...). gopsutil's own PlatformFamily is exact-match and
+// returns "" for several of these, so it cannot be the mapping source.
+var susePrefixes = []string{"opensuse", "sle", "suse"}
+
+// Local package managers. Windows has none: it self-updates the binary
+// instead of going through a package channel.
+//
+// Exported because PackageManager is a cross-package contract: produced here,
+// consumed by the switches in pkg/executor/handlers/system. A mistyped case
+// label there falls through to default and silently reports the platform as
+// unsupported, so the agreement needs to be compiler-enforced.
+const (
+	PkgApt    = "apt"
+	PkgYum    = "yum"
+	PkgZypper = "zypper"
+	PkgBrew   = "brew"
+)
+
+// ResolvePlatform maps a raw gopsutil platform id onto the alpacon-server
+// contract value and the local package manager. Pure: callers pass
+// host.Info() output so the table is testable without a host.
+//
+// ok is false for a distribution neither table knows. Callers must not
+// substitute a default (see platformAliases for why).
+func ResolvePlatform(goos, rawPlatform string) (like, pkgManager string, ok bool) {
+	switch goos {
+	case "darwin":
+		return "darwin", PkgBrew, true
+	case "windows":
+		return "windows", "", true
+	case "linux":
+		// fall through
+	default:
+		return "", "", false
+	}
+
+	id := strings.ToLower(strings.TrimSpace(rawPlatform))
+	if id == "" {
+		return "", "", false
+	}
+
+	for _, prefix := range susePrefixes {
+		if strings.HasPrefix(id, prefix) {
+			return "rhel", PkgZypper, true
+		}
+	}
+
+	switch platformAliases[id] {
+	case "debian":
+		return "debian", PkgApt, true
+	case "rhel":
+		return "rhel", PkgYum, true
+	}
+	return "", "", false
+}
+
+// InitPlatform classifies the host once at startup. An unclassifiable
+// distribution is fatal: every downstream handler switches on these values,
+// and guessing would send a wrong platform to the server (see platformAliases).
+func InitPlatform() {
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to retrieve platform information.")
+			os.Exit(1)
+		}
+		raw = info.Platform
+	}
+
+	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
+	if !ok {
+		log.Fatal().Msgf(
+			"Unsupported platform: os=%s distribution=%q. "+
+				"alpamon supports debian- and rhel-family Linux distributions "+
+				"(including openSUSE/SLES), macOS, and Windows.",
+			runtime.GOOS, raw)
+	}
+
+	PlatformLike = like
+	PackageManager = pkgManager
+	PlatformID = raw
+}
+
+// SetPlatformLike allows setting PlatformLike for testing purposes.
+func SetPlatformLike(platform string) {
+	PlatformLike = platform
+}
+
+// SetPackageManager allows setting PackageManager for testing purposes.
+func SetPackageManager(pm string) {
+	PackageManager = pm
+}
+
+// SetPlatformID allows setting PlatformID for testing purposes.
+func SetPlatformID(id string) {
+	PlatformID = id
+}
+
+// IsTumbleweed reports whether id names an openSUSE Tumbleweed variant.
+//
+// Lives beside susePrefixes so both SUSE id decisions normalize case the same
+// way. Why the caller cares is documented at the call site.
+func IsTumbleweed(id string) bool {
+	return strings.Contains(strings.ToLower(id), "tumbleweed")
+}

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import "testing"
+
+// Vectors deliberately mirror alpacon-server servers/test_utils.py:68-96. The
+// 1:1 correspondence between the two tables is the contract, and Server.platform
+// is write-once, so a divergence breaks feature gating permanently.
+func TestResolvePlatform(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		raw        string
+		wantLike   string
+		wantPkgMgr string
+	}{
+		// debian family
+		{"debian", "linux", "debian", "debian", "apt"},
+		{"ubuntu", "linux", "ubuntu", "debian", "apt"},
+		{"raspbian", "linux", "raspbian", "debian", "apt"},
+
+		// rhel family
+		{"rhel", "linux", "rhel", "rhel", "yum"},
+		{"centos", "linux", "centos", "rhel", "yum"},
+		{"redhat", "linux", "redhat", "rhel", "yum"},
+		{"amazon", "linux", "amazon", "rhel", "yum"},
+		{"amzn", "linux", "amzn", "rhel", "yum"},
+		{"fedora", "linux", "fedora", "rhel", "yum"},
+		{"rocky", "linux", "rocky", "rhel", "yum"},
+		{"almalinux", "linux", "almalinux", "rhel", "yum"},
+		{"oracle", "linux", "oracle", "rhel", "yum"},
+		{"ol", "linux", "ol", "rhel", "yum"},
+
+		// suse family: prefix match, because the os-release ids keep multiplying
+		{"suse", "linux", "suse", "rhel", "zypper"},
+		{"opensuse", "linux", "opensuse", "rhel", "zypper"},
+		{"opensuse-leap", "linux", "opensuse-leap", "rhel", "zypper"},
+		{"opensuse-tumbleweed", "linux", "opensuse-tumbleweed", "rhel", "zypper"},
+		{"opensuse-microos", "linux", "opensuse-microos", "rhel", "zypper"},
+		{"sles", "linux", "sles", "rhel", "zypper"},
+		{"sled", "linux", "sled", "rhel", "zypper"},
+		{"sle-micro", "linux", "sle-micro", "rhel", "zypper"},
+		{"sle_hpc", "linux", "sle_hpc", "rhel", "zypper"},
+
+		// case and whitespace normalization
+		{"uppercase", "linux", "SLES", "rhel", "zypper"},
+		{"padded", "linux", "  sles ", "rhel", "zypper"},
+
+		// non-linux: raw platform is ignored
+		{"darwin", "darwin", "darwin", "darwin", "brew"},
+		{"windows", "windows", "Microsoft Windows Server 2025 Datacenter", "windows", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			like, pkgMgr, ok := ResolvePlatform(tt.goos, tt.raw)
+			if !ok {
+				t.Fatalf("ResolvePlatform(%q, %q) = not ok, want ok", tt.goos, tt.raw)
+			}
+			if like != tt.wantLike {
+				t.Errorf("platformLike = %q, want %q", like, tt.wantLike)
+			}
+			if pkgMgr != tt.wantPkgMgr {
+				t.Errorf("packageManager = %q, want %q", pkgMgr, tt.wantPkgMgr)
+			}
+		})
+	}
+}
+
+// alpamon must not accept an id the alpacon-server table rejects. Accepting a
+// wider set splits the two tables, and the value pinned at registration cannot
+// be taken back.
+func TestResolvePlatform_Unsupported(t *testing.T) {
+	for _, raw := range []string{
+		"arch", "alpine", "gentoo",
+		// slackware also guards against the "sle" prefix overmatching.
+		"slackware",
+		"linuxmint", "cloudlinux", "uos",
+		"", "   ",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			like, pkgMgr, ok := ResolvePlatform("linux", raw)
+			if ok {
+				t.Fatalf("ResolvePlatform(linux, %q) = (%q, %q, ok), want not ok", raw, like, pkgMgr)
+			}
+			if like != "" || pkgMgr != "" {
+				t.Errorf("unsupported input must return empty values, got (%q, %q)", like, pkgMgr)
+			}
+		})
+	}
+}
+
+// Lock both directions: a false negative skips a needed dup, a false positive
+// runs a destructive one.
+func TestIsTumbleweed(t *testing.T) {
+	for _, tt := range []struct {
+		id   string
+		want bool
+	}{
+		{"opensuse-tumbleweed", true},
+		{"opensuse-tumbleweed-kubic", true},
+		{"openSUSE-Tumbleweed", true},
+		{"opensuse-leap", false},
+		{"sles", false},
+		{"sle-micro", false},
+		{"rhel", false},
+		{"", false},
+	} {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := IsTumbleweed(tt.id); got != tt.want {
+				t.Errorf("IsTumbleweed(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -13,12 +13,10 @@ func TestResolvePlatform(t *testing.T) {
 		wantLike   string
 		wantPkgMgr string
 	}{
-		// debian family
 		{"debian", "linux", "debian", "debian", "apt"},
 		{"ubuntu", "linux", "ubuntu", "debian", "apt"},
 		{"raspbian", "linux", "raspbian", "debian", "apt"},
 
-		// rhel family
 		{"rhel", "linux", "rhel", "rhel", "yum"},
 		{"centos", "linux", "centos", "rhel", "yum"},
 		{"redhat", "linux", "redhat", "rhel", "yum"},
@@ -30,7 +28,7 @@ func TestResolvePlatform(t *testing.T) {
 		{"oracle", "linux", "oracle", "rhel", "yum"},
 		{"ol", "linux", "ol", "rhel", "yum"},
 
-		// suse family: prefix match, because the os-release ids keep multiplying
+		// suse family: every row matches by prefix, not by exact id
 		{"suse", "linux", "suse", "rhel", "zypper"},
 		{"opensuse", "linux", "opensuse", "rhel", "zypper"},
 		{"opensuse-leap", "linux", "opensuse-leap", "rhel", "zypper"},
@@ -41,7 +39,6 @@ func TestResolvePlatform(t *testing.T) {
 		{"sle-micro", "linux", "sle-micro", "rhel", "zypper"},
 		{"sle_hpc", "linux", "sle_hpc", "rhel", "zypper"},
 
-		// case and whitespace normalization
 		{"uppercase", "linux", "SLES", "rhel", "zypper"},
 		{"padded", "linux", "  sles ", "rhel", "zypper"},
 

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,6 +1,12 @@
 package utils
 
-import "testing"
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/host"
+)
 
 // Vectors deliberately mirror alpacon-server servers/test_utils.py:68-96. The
 // 1:1 correspondence between the two tables is the contract, and Server.platform
@@ -84,6 +90,32 @@ func TestResolvePlatform_Unsupported(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolvePlatform_CIHost feeds ResolvePlatform the same input
+// InitPlatform reads (host.Info() on linux), so every CI matrix row verifies
+// that its own distro classifies. The vectors above cannot catch the #348
+// class of bug: a distro present in CI but absent from the tables. Gated on
+// CI so a contributor on an unsupported distro keeps a green local run.
+func TestResolvePlatform_CIHost(t *testing.T) {
+	if os.Getenv("CI") == "" {
+		t.Skip("CI-matrix guard: host distros are only pinned supported on CI runners")
+	}
+
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			t.Fatalf("host.Info() failed: %v", err)
+		}
+		raw = info.Platform
+	}
+
+	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
+	if !ok {
+		t.Fatalf("CI host not classified: os=%s distribution=%q", runtime.GOOS, raw)
+	}
+	t.Logf("os=%s distribution=%q -> like=%s pkgManager=%s", runtime.GOOS, raw, like, pkgManager)
 }
 
 // Lock both directions: a false negative skips a needed dup, a false positive

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,56 +10,17 @@ import (
 	"os"
 	"os/user"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/version"
 	"github.com/rs/zerolog/log"
-	"github.com/shirou/gopsutil/v4/host"
 )
 
 var (
-	PlatformLike string
-	pattern      = regexp.MustCompile(`[^\w@%+=:,./-]`)
+	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 )
-
-func InitPlatform() {
-	getPlatformLike()
-}
-
-func getPlatformLike() {
-	system := runtime.GOOS
-
-	switch system {
-	case "darwin":
-		PlatformLike = system
-	case "linux":
-		platformInfo, err := host.Info()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to retrieve platform information.")
-			os.Exit(1)
-		}
-		switch platformInfo.Platform {
-		case "ubuntu", "debian", "raspbian":
-			PlatformLike = "debian"
-		case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-			PlatformLike = "rhel"
-		default:
-			log.Fatal().Msgf("Platform %s not supported.", platformInfo.Platform)
-		}
-	case "windows":
-		PlatformLike = "windows"
-	default:
-		log.Fatal().Msgf("Unsupported os: %s.", runtime.GOOS)
-	}
-}
-
-// SetPlatformLike allows setting PlatformLike for testing purposes.
-func SetPlatformLike(platform string) {
-	PlatformLike = platform
-}
 
 func JoinPath(base string, paths ...string) string {
 	fullURL, err := url.JoinPath(base, paths...)


### PR DESCRIPTION
## Background

Alpamon dies at startup on openSUSE/SLES. `getPlatformLike` had no branch for `opensuse-leap`, `opensuse-tumbleweed`, or `sles`, so those ids fell to the default and `log.Fatal`'d the agent. AlmaLinux died the same way despite README listing it as supported.

`register` failed the other direction: `detectPlatform` returned `"debian"` whenever it could not classify the host, both on a `host.Info()` error and as the trailing default. That is not a safe default. alpacon-server persists it to `Server.platform`, which is write-once with no admin edit path, so a wrong value can only be corrected by re-registering the host. On openSUSE it also made the server pick the `sudo` group, which does not exist there, silently leaving admin users without sudo.

So: silently wrong at registration, loudly dead at runtime.

## What changed

One overloaded `utils.PlatformLike` becomes three variables, because on SUSE the value we report and the command we run disagree:

| Variable | Values | Purpose |
| --- | --- | --- |
| `PlatformLike` | debian / rhel / darwin / windows | what we report to the server |
| `PackageManager` | apt / yum / zypper / brew / "" | what we run locally |
| `PlatformID` | raw os-release id | the one distro-level branch (Tumbleweed) |

`pkg/utils/platform.go` is the single detection source. `ResolvePlatform` is pure, so the table is testable without a host. SUSE matches by prefix rather than exact id because the os-release names keep multiplying (`opensuse-microos`, `sle-micro`, `sle_hpc`); gopsutil's `PlatformFamily` is exact-match and returns `""` for several of them, so it cannot be the source.

`platformAliases` and `susePrefixes` mirror alpacon-server `servers/constants.py` (`PLATFORM_ALIASES` + `SUSE_PLATFORM_PREFIXES`) entry for entry, and the test vectors are deliberately the same ones as `servers/test_utils.py:68-96`. Ids the server table lacks (`linuxmint`, `cloudlinux`, `uos`) are rejected: a wider set on our side splits the two tables.

Reporting SUSE as `rhel` is a behavior bucket, not a genealogy claim. The server gates only rpm packaging, the `wheel` sudo group, and shadow-utils account tooling on `platform`, and all three are identical for SUSE and RHEL. The real distro name is preserved in `OsVersion.name`. Recorded in alpacon-server#2414 and commit `02e341c6d`.

Three package-manager sites in `pkg/executor/handlers/system/system.go` move onto the `PackageManager` axis and gain a zypper arm: `handleUpgrade` (`zypper --non-interactive update`), `executeUninstall` (`remove alpamon`), and `handleSystemUpdate` (`dup`, Tumbleweed only). `user.go` and `group.go` are deliberately untouched: they pick `useradd`/`groupadd` from `PlatformLike`, and those are shadow-utils on SUSE exactly as on RHEL.

`detectPlatform` in `register` and `migrate` now returns an error naming the distribution and pointing at `--platform`, and `host.Info()` is called only on linux. This is not a regression for Arch/Alpine/Gentoo: those hosts already registered and then crash-looped, since the runtime path always `log.Fatal`'d. They now fail earlier, at register time, with a message that says what to do.

## Safety

`zypper dup` is hard to undo: on Leap or SLES it advances the service pack. The Tumbleweed guard goes through `utils.IsTumbleweed` so it normalizes case the same way the prefix table does, and it is tested in both directions. Never widen it.

`Server.platform` being write-once means reintroducing a default is permanent damage, so `be3017f` carries a propagation test that fails if someone does.

## Testing

`go test ./... -p 1` passes. New coverage: `pkg/utils/platform_test.go` (43 vectors), `system_test.go` (three zypper paths, Tumbleweed both ways), `register_test.go` and `migrate_test.go` (error propagation and the real error text).

The build matrix in `.github/workflows/build-and-test.yml` covered apt-get, yum and dnf only, so no CI job had ever run on a zypper host and the new tests would have passed identically on every existing container. It gains an `opensuse-leap-15` row on `opensuse/leap:15`, the tag `Dockerfiles/opensuse/15/Dockerfile` already pins, so the job and the smoke image cannot drift onto different Leap releases; it resolves to 15.6 and reports `ID="opensuse-leap"`. Its install step names `gzip` explicitly because, unlike the RHEL-family images, the Leap base ships neither `tar` nor `gzip`, and `actions/setup-go` extracts its toolchain tarball with `tar xz`. Verified by running the job's steps inside the container on linux/amd64: `zypper install`, Go 1.25.12, `go generate ./pkg/db/ent`, `go build`, and `go test ./... -p 1` all pass, 45 packages ok and no failures.

The matrix rows are not just build environments: `TestResolvePlatform_CIHost` feeds `ResolvePlatform` the same input `InitPlatform` reads (`host.Info()` on linux), so every row verifies that the distro it runs on classifies. This is the check the pure vectors cannot do, and it is the guard against the #348 class of bug recurring: a distro present in CI but absent from the tables fails its own row. It skips when the `CI` env var is unset, so a contributor on an unsupported distribution keeps a green local run. Proven in three containers with `CI=true`: `golang:1.25` (`ID=debian`) passes with apt, `opensuse/leap:15` (`ID=opensuse-leap`) passes with zypper, and `golang:1.25-alpine` (`ID=alpine`) fails with the unclassified error, which is the guard working. On GitHub's runners the job then surfaced a runner-level quirk the container simulation cannot reproduce: `opensuse/leap:15` is the only image in the matrix whose config defines no `PATH`, and the runner rebuilds each container step's `PATH` as "prepended dirs + container config `PATH`", so after `setup-go` the rebuilt value lost `/usr/bin` and the composite action's `shell: bash` step died with `exec: "bash": executable file not found`. Writing `PATH` from a step via `GITHUB_ENV` does not help, because the runner overrides step-level `PATH` with that rebuilt value (verified against `actions/runner` source and a failing run). The fix pins the standard `PATH` in the job's `container.env`, which lands in `docker create` and feeds the rebuild; the other thirteen images already define exactly that value in their image config, so nothing changes for them. With that in place the full matrix is green, and the job log shows the detection test running on the real runner: `distribution="opensuse-leap" -> like=rhel pkgManager=zypper`.

Each of the fifteen commits was checked out in its own worktree: all report `build:OK failing-tests:0`, so any midpoint bisects.

`-race` fails, but not because of this branch. The cause is `TestSystemHandler_Uninstall` (`system_test.go:470`) dispatching through the worker pool so the task outlives the test. Over five runs of `go test -race -count=1 ./pkg/executor/handlers/system/... -p 1`, merge-base `ebf316a` reports 2 data races every time; the branch reports 2 on four runs and 3 on one. This change widened the set of globals the leaked goroutine can race on from one to three, which is why the count moves. It did not create the leak.

## Known limitations

alpacon-server still composes `yum` commands for `platform == 'rhel'`, so console-driven plugin install/upgrade and the automatic `alpamon-pam` install fail on a SUSE host. Fixing that means `plugins/models.py`, `workspaces/tasks.py`, and seven `install.rhel.sh` templates on the server side. README documents it and points at manual `zypper`. The agent's own upgrade, uninstall, and system-update paths do use `zypper`.

Still unverified, needing a real hosted rpm package: whether zypper passes `$1=2` to rpm scriptlets on upgrade, and what `zypper update` returns for a package no repo carries. The repository URL in the README install block is unverified too, and says so above the command.

## Follow-up from review

Ten Copilot findings across five rounds. Eight are fixed here. Two were Dockerfile issues that turned out not to belong in this PR and were backed out of it (details under Builder image). Each was treated as a class rather than a line: the sweep for other instances found more than the review flagged every time except one.

Help text. `--platform` said `debian/rhel` while `ResolvePlatform` also returns `darwin` and `windows`. Fixed at all three sites, including the `RegisterCmd.Long` Options block the review did not flag. Separately, the `host.Info()` failure path returned a bare error while its sibling branch named the `--platform` escape hatch: same dead end, half the message, since `buildRegisterRequest` skips detection entirely when the flag is set. Two places keep narrower text on purpose: the `detectPlatformFor` errors, reachable only on Linux for an unclassifiable distribution, where naming `darwin` would be wrong advice; and `utils.InitPlatform`, which runs at agent startup where `--platform` has no effect at all.

Builder image. Copilot raised two things here and neither survived into this branch as a repo-wide change. The floating `FROM golang:1.25` tag was pinned and then reverted: the build failure reported in support of it came from a stale local image (a `golang:1.25` layer cached 2026-05-08, carrying go1.25.10). A fresh pull gives go1.25.12 and the unmodified Dockerfile builds clean under `docker build --no-cache`. The `GOARCH=amd64` hardcoding is real: it is in seven of the eight Dockerfiles that predate this branch, and still seven of nine after it, since the file added here does not repeat it. On an arm64 host it produces a binary that only runs under emulation. It predates this branch, and none of this PR's claims depend on it, since platform detection behaves the same either way. Both belong in their own PR, alongside the `ARG GO_VERSION` and Dockerfile-building-CI work that would keep them from silently regressing; `.github/workflows/` never touches `Dockerfiles/` today.

What did stay is one line in the file this branch creates: `Dockerfiles/opensuse/15` follows `ubuntu/22.04`'s `ARG TARGETARCH` form rather than copying `redhat/9`'s hardcoded amd64. Measured on an arm64 host, the two forms give ELF `e_machine` `0x3e` (EM_X86_64) and `0xb7` (EM_AARCH64) respectively.

README. The custom-workspace example ran `alpamon:latest`, a tag `build.sh` never produces. The `%wheel` drop-in wrote straight into `/etc/sudoers.d/`, where a copy-paste typo takes effect immediately and breaks sudo for everyone including the operator who must repair it; it now stages under a dot-containing name that sudo ignores, validates with `visudo -cf`, and installs only on a clean parse. Verified both directions in the container.

Comments. Five spaced em-dashes this branch added, against CLAUDE.md:13. One wraps across a line break, so a plain `" — "` search misses it. The same commit then re-reads every comment this branch adds against the code beside it and cuts whatever the code already says: 53 comment lines become 31, and five comments go entirely. No executable line changes, `gofmt -l` empty, `go vet` clean. Pre-existing violations elsewhere are left untouched.

Two open items from the original description got settled along the way. `systemd-analyze --system unit-paths` on openSUSE Leap 15 lists both `/usr/lib/systemd/system` and `/lib/systemd/system`, so the `/lib/systemd/system` path `.goreleaser.yaml` installs all three units to (lines 113, 116 and 119) is searched on SUSE, even though `/lib` is not a usrmerge symlink there and the directory does not exist by default. The container also confirms `ID="opensuse-leap"`, which the new prefix table matches, and that PackageCloud's one-liner does not work on SUSE (zypper reads `/etc/zypp/repos.d/` while that script writes `/etc/yum.repos.d/`), hence the manual `zypper addrepo` guidance.

## History note

Commit hashes quoted in the earlier thread replies are stale: the branch has been rewritten and rebased since. What changed, in order. `bf54591` (the `golang:1.25` pin) and `a7b3298` (the repo-wide `GOARCH` fix) were dropped, both reversing a call of mine rather than review feedback, and `1432224` had its message rewritten to drop the same false build-failure claim. Then the comment trim was folded into the existing comment commit instead of being stacked beside it, since nothing distinguishes two adjacent commits that both edit only this branch's comments. Then the branch was rebased onto `ebf316a`, leaving eleven commits under new hashes. The openSUSE CI job, the per-row detection test, and two commits resolving the runner PATH quirk described under Testing (the first attempt via `GITHUB_ENV` is kept in history with its failure documented in the follow-up's message) were added on top of that, so the branch is fifteen commits now.

## Checklist

- [x] Every commit builds and tests clean in isolation
- [x] Tables cross-checked against alpacon-server `servers/constants.py`
- [x] Agent starts on an openSUSE Leap container, built from `Dockerfiles/opensuse/15`
- [ ] Install/upgrade/uninstall verified on a real SUSE host (needs a hosted rpm)

Closes #348

