### PR TITLE
fix(platform): classify openSUSE/SLES instead of crash-looping on it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,11 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.distro }})
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container }}
+    # PATH is pinned because the runner rebuilds each exec PATH from the container config, and opensuse/leap:15 alone defines none.
+    container:
+      image: ${{ matrix.container }}
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +104,11 @@ jobs:
             container: amazonlinux:2023
             pkg_manager: dnf
             runner: ubuntu-latest
+          # SUSE (amd64)
+          - distro: opensuse-leap-15
+            container: opensuse/leap:15
+            pkg_manager: zypper
+            runner: ubuntu-latest
           # ARM64
           - distro: ubuntu-24.04-arm64
             container: ubuntu:24.04
@@ -128,6 +137,11 @@ jobs:
       - name: Install dependencies (dnf)
         if: matrix.pkg_manager == 'dnf'
         run: dnf install -y --allowerasing git curl gcc glibc-devel tar
+
+      # gzip is explicit because the Leap base ships neither tar nor gzip, and setup-go extracts with `tar xz`.
+      - name: Install dependencies (zypper)
+        if: matrix.pkg_manager == 'zypper'
+        run: zypper --non-interactive install git curl gcc glibc-devel tar gzip
 
       - name: Mark workspace as safe for Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Dockerfiles/build.sh
+++ b/Dockerfiles/build.sh
@@ -31,3 +31,5 @@ docker build -t alpamon:redhat-8 -f Dockerfiles/redhat/8/Dockerfile .
 docker build -t alpamon:redhat-9 -f Dockerfiles/redhat/9/Dockerfile .
 
 docker build -t alpamon:centos-7 -f Dockerfiles/centos/7/Dockerfile .
+
+docker build -t alpamon:opensuse-15 -f Dockerfiles/opensuse/15/Dockerfile .

--- a/Dockerfiles/opensuse/15/Dockerfile
+++ b/Dockerfiles/opensuse/15/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.25 AS builder
+
+# Automatically set GOARCH to the build-time architecture
+ARG TARGETARCH
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=${TARGETARCH:-amd64}
+
+WORKDIR /build
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN go build -o alpamon ./cmd/alpamon/main.go
+
+FROM opensuse/leap:15
+
+WORKDIR /usr/local/alpamon
+
+COPY --from=builder /build/alpamon ./alpamon
+
+COPY Dockerfiles/opensuse/15/entrypoint.sh /usr/local/alpamon/entrypoint.sh
+
+RUN chmod +x /usr/local/alpamon/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/alpamon/entrypoint.sh"]

--- a/Dockerfiles/opensuse/15/entrypoint.sh
+++ b/Dockerfiles/opensuse/15/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+ALPACON_URL=${ALPACON_URL:-"http://host.docker.internal:8000"}
+PLUGIN_ID=${PLUGIN_ID:-"f4592c6d-cb9a-4b33-af1c-bd67b675b16f"}
+PLUGIN_KEY=${PLUGIN_KEY:-"alpaca"}
+
+mkdir -p /etc/alpamon /var/lib/alpamon /var/log/alpamon /run/alpamon
+chmod 700 /etc/alpamon
+chmod 750 /var/lib/alpamon /var/log/alpamon /run/alpamon
+
+cat > /etc/alpamon/alpamon.conf <<EOL
+[server]
+url = $ALPACON_URL
+id = $PLUGIN_ID
+key = $PLUGIN_KEY
+
+[logging]
+debug = true
+EOL
+
+echo -e "\nThe following configuration file is being used:\n"
+cat /etc/alpamon/alpamon.conf
+
+exec /usr/local/alpamon/alpamon

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ docker run \
     -e ALPACON_URL="https://<workspace>" \
     -e PLUGIN_ID="<plugin_id>" \
     -e PLUGIN_KEY="<plugin_key>" \
-    alpamon:latest
+    alpamon:opensuse-15
 ```
 
 Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9, openSUSE Leap 15. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Installed on each managed server, Alpamon establishes an outbound-only connectio
 | Platform | Minimum version | Arch |
 | --- | --- | --- |
 | Linux | Ubuntu 18.04+, Debian 11+, RHEL / Rocky / AlmaLinux 8+, Oracle Linux 8+, Amazon Linux 2 / 2023, Fedora (current or previous) | amd64, arm64 |
+| Linux (best-effort) | openSUSE Leap 15+, SLES 15+ | amd64, arm64 |
 | macOS | 11 (Big Sur) or later | amd64, arm64 (Apple Silicon) |
 | Windows | Windows 10 (1803+) / Windows 11, Windows Server 2019 or later | amd64 |
 
@@ -31,6 +32,13 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```bash
 curl -s https://packagecloud.io/install/repositories/alpacax/alpamon/script.rpm.sh?any=true | sudo bash
 sudo yum install alpamon
+sudo alpamon register --url https://<workspace> --token <TOKEN>
+```
+
+**openSUSE / SLES** (best-effort) — see [**docs/opensuse.md**](docs/opensuse.md) for the sudoers prerequisite and the `yum`-only server operations that still fail here.
+```bash
+sudo zypper addrepo -f 'https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch' alpamon
+sudo zypper --gpg-auto-import-keys refresh && sudo zypper install alpamon
 sudo alpamon register --url https://<workspace> --token <TOKEN>
 ```
 
@@ -90,6 +98,8 @@ The optional `alpamon-pam` package provides PAM integration for Alpacon-managed 
 sudo apt-get install alpamon-pam
 # RHEL / CentOS
 sudo yum install alpamon-pam
+# openSUSE / SLES
+sudo zypper install alpamon-pam
 ```
 
 After install, add to `/etc/pam.d/sudo`:
@@ -206,7 +216,7 @@ docker run \
     alpamon:latest
 ```
 
-Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.
+Covered distros: Ubuntu 22.04/20.04, Debian 11, RHEL 8/9, openSUSE Leap 15. Legacy Dockerfiles for Ubuntu 18.04, Debian 10, and CentOS 7 also ship under `Dockerfiles/` for best-effort builds against EOL platforms.
 
 ### Run locally
 

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -145,6 +145,8 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		platform = detected
+	} else if err := utils.ValidateServerPlatform(platform); err != nil {
+		return err
 	}
 
 	current, err := config.ReadServer(configPath)

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -65,6 +65,9 @@ var (
 	caCert          string
 	rollbackTimeout time.Duration
 	force           bool
+
+	// Test seam mirroring register's: no side effect, and it lets a detection failure be injected on any host.
+	detectPlatformFn = utils.DetectRegistrationPlatform
 )
 
 // Cmd is the migrate subcommand exported for registration in root.go.
@@ -140,15 +143,11 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("active config not found at %s: %w", configPath, err)
 	}
 
-	if platform == "" {
-		detected, err := utils.DetectRegistrationPlatform()
-		if err != nil {
-			return err
-		}
-		platform = detected
-	} else if err := utils.ValidateServerPlatform(runtime.GOOS, platform); err != nil {
+	resolvedPlatform, err := resolvePlatform()
+	if err != nil {
 		return err
 	}
+	platform = resolvedPlatform
 
 	current, err := config.ReadServer(configPath)
 	if err != nil {
@@ -266,6 +265,19 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 // facing prefix on the target workspace so the new server doesn't end up
 // with two stacked suffixes (`mybox-abc123-xyz789`).
 var generatedSuffixRE = regexp.MustCompile(`-[0-9a-f]{6}$`)
+
+// Split out of runMigrate so the detection-failure path is reachable without
+// runMigrate's systemd and config preconditions.
+func resolvePlatform() (string, error) {
+	resolved, warning, err := utils.ResolveServerPlatform(runtime.GOOS, platform, detectPlatformFn)
+	if err != nil {
+		return "", err
+	}
+	if warning != "" {
+		fmt.Println(warning)
+	}
+	return resolved, nil
+}
 
 func stripGeneratedSuffix(name string) string {
 	return generatedSuffixRE.ReplaceAllString(name, "")

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -42,7 +41,6 @@ import (
 	"github.com/alpacax/alpamon/v2/pkg/migrate"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
-	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
 )
 
@@ -98,7 +96,10 @@ func init() {
 	Cmd.Flags().StringVar(&newURL, "url", "", "Target Alpacon workspace URL (required)")
 	Cmd.Flags().StringVar(&apiToken, "token", "", "Registration token issued by the target workspace (required)")
 	Cmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
-	Cmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel/darwin/windows, auto-detected when omitted)")
+	Cmd.Flags().StringVar(&platform, "platform", "",
+		"Platform (debian/rhel/darwin/windows). Auto-detected when omitted.\n"+
+			"Affects the target workspace's server record only; the agent still\n"+
+			"refuses to start on an unsupported distribution.")
 	Cmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	Cmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	Cmd.Flags().DurationVar(&rollbackTimeout, "rollback-timeout", migrate.DefaultRollbackTimeout,
@@ -139,7 +140,11 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 	}
 
 	if platform == "" {
-		platform = detectPlatform()
+		detected, err := utils.DetectRegistrationPlatform()
+		if err != nil {
+			return err
+		}
+		platform = detected
 	}
 
 	current, err := config.ReadServer(configPath)
@@ -394,31 +399,4 @@ func normalizeHostname(h string) string {
 		return h[:i]
 	}
 	return h
-}
-
-func detectPlatform() string {
-	if runtime.GOOS == "windows" {
-		return "windows"
-	}
-	info, err := host.Info()
-	if err != nil {
-		return "debian"
-	}
-	switch info.Platform {
-	case "darwin":
-		return "darwin"
-	case "ubuntu", "debian", "raspbian":
-		return "debian"
-	case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-		return "rhel"
-	}
-	p := strings.ToLower(info.Platform)
-	switch {
-	case strings.Contains(p, "ubuntu"), strings.Contains(p, "debian"):
-		return "debian"
-	case strings.Contains(p, "centos"), strings.Contains(p, "rhel"),
-		strings.Contains(p, "fedora"), strings.Contains(p, "rocky"):
-		return "rhel"
-	}
-	return "debian"
 }

--- a/cmd/alpamon/command/migrate/migrate.go
+++ b/cmd/alpamon/command/migrate/migrate.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -145,7 +146,7 @@ func runMigrate(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		platform = detected
-	} else if err := utils.ValidateServerPlatform(platform); err != nil {
+	} else if err := utils.ValidateServerPlatform(runtime.GOOS, platform); err != nil {
 		return err
 	}
 

--- a/cmd/alpamon/command/migrate/migrate_test.go
+++ b/cmd/alpamon/command/migrate/migrate_test.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -225,5 +226,41 @@ func TestCleanupTargetRegistration_CallsUnregisterEndpoint(t *testing.T) {
 	case <-called:
 	default:
 		t.Fatalf("expected unregister endpoint to be hit")
+	}
+}
+
+// A detection failure must name the distribution instead of defaulting the write-once platform value.
+func TestResolvePlatform_DetectionFailurePropagates(t *testing.T) {
+	origPlatform := platform
+	origDetect := detectPlatformFn
+	t.Cleanup(func() { platform = origPlatform; detectPlatformFn = origDetect })
+
+	platform = ""
+	detectPlatformFn = func() (string, error) {
+		return "", errors.New("unrecognized Linux distribution \"arch\"")
+	}
+
+	if _, err := resolvePlatform(); err == nil {
+		t.Fatal("expected resolvePlatform to fail when platform detection fails")
+	} else if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
+	}
+}
+
+// The override and validation matrix is host-dependent and lives in utils.TestResolveServerPlatform.
+func TestResolvePlatform_UsesDetectionSeam(t *testing.T) {
+	origPlatform := platform
+	origDetect := detectPlatformFn
+	t.Cleanup(func() { platform = origPlatform; detectPlatformFn = origDetect })
+
+	platform = ""
+	detectPlatformFn = func() (string, error) { return "rhel", nil }
+
+	got, err := resolvePlatform()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "rhel" {
+		t.Errorf("expected the detected platform, got %q", got)
 	}
 }

--- a/cmd/alpamon/command/register/recovery_test.go
+++ b/cmd/alpamon/command/register/recovery_test.go
@@ -55,6 +55,7 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 		oSSL, oForce, oNoRB, oNCP             = sslVerify, force, noRollback, noCloudProbe
 		oTags                                 = tags
 		oDetect                               = detectCloud
+		oDetectPlatform                       = detectPlatformFn
 		oEnsure                               = ensureInstalledFn
 		oWrite, oDirs, oStart, oStop, oRemove = writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn
 		oUSSL, oUCA, oUYes, oUKeep            = unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig
@@ -64,6 +65,7 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 		sslVerify, force, noRollback, noCloudProbe = oSSL, oForce, oNoRB, oNCP
 		tags = oTags
 		detectCloud = oDetect
+		detectPlatformFn = oDetectPlatform
 		ensureInstalledFn = oEnsure
 		writeConfigFileFn, ensureDirectoriesFn, startServiceFn, stopServiceFn, removeServiceFn = oWrite, oDirs, oStart, oStop, oRemove
 		unregisterSSLVerify, unregisterCaCert, unregisterYes, unregisterKeepConfig = oUSSL, oUCA, oUYes, oUKeep
@@ -72,7 +74,10 @@ func withRecoveryTestEnv(t *testing.T, handler http.HandlerFunc) string {
 	serverURL = server.URL
 	apiToken = "test-token"
 	serverName = "test-server"
-	platform = "debian"
+	// Detection is stubbed rather than pinning platform: an explicit value is
+	// validated against the running host's OS, which would fail off-linux.
+	platform = ""
+	detectPlatformFn = func() (string, error) { return "debian", nil }
 	caCert = ""
 	sslVerify = true
 	force = false

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -23,7 +22,6 @@ import (
 	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/migrate"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
-	"github.com/shirou/gopsutil/v4/host"
 	"github.com/spf13/cobra"
 )
 
@@ -54,14 +52,15 @@ var (
 	// Test seams: indirections over the side-effecting steps so registration
 	// logic (within-run rollback, --force ordering) can be exercised without
 	// touching the real filesystem, OS service manager, or relying on platform
-	// service behavior. They default to the production implementations, mirroring
-	// the detectCloud seam above.
+	// service behavior. detectPlatformFn is the exception: it has no side effect
+	// and exists so a detection failure can be injected on any host.
 	ensureInstalledFn   = ensureInstalled
 	writeConfigFileFn   = writeConfigFile
 	ensureDirectoriesFn = ensureDirectories
 	startServiceFn      = startService
 	stopServiceFn       = stopService
 	removeServiceFn     = removeService
+	detectPlatformFn    = utils.DetectRegistrationPlatform
 )
 
 // registerCloudDetectTimeout caps the synchronous cloud probe at register time
@@ -115,7 +114,7 @@ Options:
   --url             Alpacon server URL (required)
   --token           API token (servers:register scope required)
   --name            Server name (optional, defaults to hostname)
-  --platform        Platform (debian/rhel, auto-detect if omitted)
+  --platform        Platform (debian/rhel/darwin/windows, auto-detected if omitted; server record only)
   --ssl-verify      SSL certificate verification (default: true)
   --ca-cert         CA certificate path
   --tag             Server tags in key=value format (repeatable, or comma-separated: "k1=v1,k2=v2")
@@ -129,7 +128,10 @@ func init() {
 	RegisterCmd.Flags().StringVar(&serverURL, "url", "", "Alpacon server URL (required)")
 	RegisterCmd.Flags().StringVar(&apiToken, "token", "", "API token (servers:register scope required)")
 	RegisterCmd.Flags().StringVar(&serverName, "name", "", "Server name (optional, defaults to hostname)")
-	RegisterCmd.Flags().StringVar(&platform, "platform", "", "Platform (debian/rhel, auto-detect)")
+	RegisterCmd.Flags().StringVar(&platform, "platform", "",
+		"Platform (debian/rhel/darwin/windows). Auto-detected when omitted.\n"+
+			"Affects the server-side record only; the agent still\n"+
+			"refuses to start on an unsupported distribution.")
 	RegisterCmd.Flags().BoolVar(&sslVerify, "ssl-verify", true, "SSL certificate verification")
 	RegisterCmd.Flags().StringVar(&caCert, "ca-cert", "", "CA certificate path")
 	RegisterCmd.Flags().StringToStringVar(&tags, "tag", nil, "Server tags in key=value format (repeatable, or comma-separated: \"k1=v1,k2=v2\")")
@@ -330,7 +332,11 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 	}
 
 	if platform == "" {
-		platform = detectPlatform()
+		detected, err := detectPlatformFn()
+		if err != nil {
+			return RegisterRequest{}, err
+		}
+		platform = detected
 		fmt.Printf("Platform auto-detected: %s\n", platform)
 	}
 
@@ -469,41 +475,6 @@ func normalizeServerName(value string) string {
 		n = n[:serverNameMaxLength]
 	}
 	return strings.TrimRight(n, "-")
-}
-
-func detectPlatform() string {
-	hostInfo, err := host.Info()
-	if err != nil {
-		fmt.Println("Warning: Failed to detect platform, defaulting to debian")
-		return "debian"
-	}
-
-	if runtime.GOOS == "windows" {
-		return "windows"
-	}
-
-	switch hostInfo.Platform {
-	case "darwin":
-		return "darwin"
-	case "ubuntu", "debian", "raspbian":
-		return "debian"
-	case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-		return "rhel"
-	default:
-		// Check if platform name contains known keywords
-		platformLower := strings.ToLower(hostInfo.Platform)
-		if strings.Contains(platformLower, "ubuntu") ||
-			strings.Contains(platformLower, "debian") {
-			return "debian"
-		}
-		if strings.Contains(platformLower, "centos") ||
-			strings.Contains(platformLower, "rhel") ||
-			strings.Contains(platformLower, "fedora") ||
-			strings.Contains(platformLower, "rocky") {
-			return "rhel"
-		}
-		return "debian" // default fallback
-	}
 }
 
 func sendRegisterRequest(req RegisterRequest) (*RegisterResponse, error) {

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -338,6 +338,8 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 		}
 		platform = detected
 		fmt.Printf("Platform auto-detected: %s\n", platform)
+	} else if err := utils.ValidateServerPlatform(platform); err != nil {
+		return RegisterRequest{}, err
 	}
 
 	finalTags := mergeCloudAndUserTags(detectCloudTags(cmd.Context()), tags)

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -338,7 +339,7 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 		}
 		platform = detected
 		fmt.Printf("Platform auto-detected: %s\n", platform)
-	} else if err := utils.ValidateServerPlatform(platform); err != nil {
+	} else if err := utils.ValidateServerPlatform(runtime.GOOS, platform); err != nil {
 		return RegisterRequest{}, err
 	}
 

--- a/cmd/alpamon/command/register/register.go
+++ b/cmd/alpamon/command/register/register.go
@@ -332,16 +332,17 @@ func buildRegisterRequest(cmd *cobra.Command) (RegisterRequest, error) {
 		fmt.Printf("Server name normalized to %q\n", serverName)
 	}
 
-	if platform == "" {
-		detected, err := detectPlatformFn()
-		if err != nil {
-			return RegisterRequest{}, err
-		}
-		platform = detected
-		fmt.Printf("Platform auto-detected: %s\n", platform)
-	} else if err := utils.ValidateServerPlatform(runtime.GOOS, platform); err != nil {
+	resolved, warning, err := utils.ResolveServerPlatform(runtime.GOOS, platform, detectPlatformFn)
+	if err != nil {
 		return RegisterRequest{}, err
 	}
+	if platform == "" {
+		fmt.Printf("Platform auto-detected: %s\n", resolved)
+	}
+	if warning != "" {
+		fmt.Println(warning)
+	}
+	platform = resolved
 
 	finalTags := mergeCloudAndUserTags(detectCloudTags(cmd.Context()), tags)
 

--- a/cmd/alpamon/command/register/register_test.go
+++ b/cmd/alpamon/command/register/register_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/alpacax/alpamon/v2/pkg/cloud"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -427,5 +428,30 @@ func TestTagFlagParsing(t *testing.T) {
 				assert.Equal(t, tt.expectedTags, parsedTags)
 			}
 		})
+	}
+}
+
+func TestBuildRegisterRequest_PlatformDetectionFailurePropagates(t *testing.T) {
+	origPlatform := platform
+	origName := serverName
+	t.Cleanup(func() { platform = origPlatform; serverName = origName })
+
+	platform = ""
+	serverName = "test-host"
+
+	orig := detectPlatformFn
+	detectPlatformFn = func() (string, error) {
+		return "", errors.New("unrecognized Linux distribution \"arch\"")
+	}
+	t.Cleanup(func() { detectPlatformFn = orig })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	_, err := buildRegisterRequest(cmd)
+	if err == nil {
+		t.Fatal("expected buildRegisterRequest to fail when platform detection fails")
+	}
+	if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
 	}
 }

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -20,7 +20,9 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 
 ## Sudoers prerequisite
 
-openSUSE ships `/etc/sudoers` with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Both `%wheel` lines in that file are commented out, so `wheel` membership grants nothing by itself. The drop-in below therefore does two things: it grants `%wheel` the rule, and it exempts `%wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
+openSUSE ships its sudoers file with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Both `%wheel` lines in that file are commented out, so `wheel` membership grants nothing by itself. The drop-in below therefore does two things: it grants `%wheel` the rule, and it exempts `%wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
+
+Leap keeps that file at `/etc/sudoers`; Tumbleweed ships it as `/usr/etc/sudoers` and has no `/etc/sudoers` at all. The drop-in path is the same on both, because either file ends with `@includedir /etc/sudoers.d`.
 
 Stage the drop-in under a name containing a dot, which sudo ignores when reading the include directory, so a typo cannot lock you out before `visudo -cf` has passed:
 
@@ -29,7 +31,8 @@ printf '%%wheel ALL=(ALL) ALL\nDefaults:%%wheel !targetpw\n' |
   sudo tee /etc/sudoers.d/alpacon-wheel.stage >/dev/null
 sudo visudo -cf /etc/sudoers.d/alpacon-wheel.stage &&
   sudo install -m 0440 -o root -g root \
-    /etc/sudoers.d/alpacon-wheel.stage /etc/sudoers.d/alpacon-wheel
+    /etc/sudoers.d/alpacon-wheel.stage /etc/sudoers.d/alpacon-wheel ||
+  echo 'sudoers validation failed: drop-in not installed'
 sudo rm -f /etc/sudoers.d/alpacon-wheel.stage
 ```
 
@@ -65,6 +68,10 @@ Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational st
 | 107 | Installed, but an rpm `%post` script failed | failure |
 
 100 and 101 come from `patch-check`, which the agent never runs, so they are anomalous here rather than informational. 104 means nothing was updated. 107 matters because `%post` is what registers the systemd units and the PAM session lines, so a package that unpacked with a failed script is not a working install.
+
+## Console update on Tumbleweed
+
+Tumbleweed is a rolling release, so the console update button runs `zypper dup`, a full distribution upgrade, not the package-by-package update it runs on Leap and SLES. The vendored alpamon package is safe from being replaced by a distribution build, because `solver.dupAllowVendorChange` defaults to `false`, but `solver.dupAllowDowngrade` and `solver.dupAllowNameChange` both default to `true`, so an unattended `dup` may still downgrade or rename other packages. Leap and SLES never run `dup`: there it would advance the service pack.
 
 ## Known limitations
 

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -73,6 +73,10 @@ Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational st
 
 Tumbleweed is a rolling release, so the console update button runs `zypper dup`, a full distribution upgrade, not the package-by-package update it runs on Leap and SLES. The vendored alpamon package is safe from being replaced by a distribution build, because `solver.dupAllowVendorChange` defaults to `false`, but `solver.dupAllowDowngrade` and `solver.dupAllowNameChange` both default to `true`, so an unattended `dup` may still downgrade or rename other packages. Leap and SLES never run `dup`: there it would advance the service pack.
 
+## SLES 12 and Leap 42
+
+Detection accepts them, because it prefix-matches the distribution id the way the server does, but only 15 and later are verified. Two differences are handled rather than tested end to end: `systemd-run --collect` needs systemd 236 and SLES 12 ships 228, so the uninstall retries the scheduling without that flag; and SuSEfirewall2, which those releases use instead of firewalld, is detected as an active high-level firewall, which disables Alpacon firewall management the same way ufw and firewalld do. Without that detection Alpacon would write iptables rules that SuSEfirewall2 discards on its next reload.
+
 ## Known limitations
 
 Because the host reports `rhel`, console-driven package operations that the server composes still emit `yum` commands and fail on a SUSE host: Alpacon plugin install/upgrade and the automatic `alpamon-pam` install. Install those manually with `zypper` until the server side is zypper-aware. The agent's own upgrade, uninstall, and system-update paths do use `zypper`.

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -41,6 +41,21 @@ sudo zypper install alpamon-pam
 
 Configuration is the same as on other distributions; see the PAM section in the main README.
 
+## Zypper exit codes
+
+Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational states, and two of them follow a successful install. The agent maps those two to success and leaves everything else a failure, so a completed update does not surface in the console as a broken command:
+
+| Code | Meaning | Reported as |
+| --- | --- | --- |
+| 102 | Reboot needed after a successful install | success |
+| 103 | Package manager restart needed after a successful install | success |
+| 100, 101 | Patches available, none installed | failure |
+| 104 | No repository carries the requested package | failure |
+| 106 | A repository was skipped because it failed to refresh | failure |
+| 107 | Installed, but an rpm `%post` script failed | failure |
+
+100 and 101 come from `patch-check`, which the agent never runs, so they are anomalous here rather than informational. 104 means nothing was updated. 107 matters because `%post` is what registers the systemd units and the PAM session lines, so a package that unpacked with a failed script is not a working install.
+
 ## Known limitations
 
 Because the host reports `rhel`, console-driven package operations that the server composes still emit `yum` commands and fail on a SUSE host: Alpacon plugin install/upgrade and the automatic `alpamon-pam` install. Install those manually with `zypper` until the server side is zypper-aware. The agent's own upgrade, uninstall, and system-update paths do use `zypper`.

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -41,6 +41,16 @@ sudo zypper install alpamon-pam
 
 Configuration is the same as on other distributions; see the PAM section in the main README.
 
+## Repository scope for agent upgrades
+
+An unscoped `zypper refresh` fails with exit 4 if any single enabled repository is unreachable. On a long-lived host with a retired third-party repository or an expired subscription, chaining that refresh into the update would make `alpamon upgrade` and the console update button permanently unusable even though alpamon's own repository is fine.
+
+The agent therefore resolves the alias of the enabled repository whose URL points at `packagecloud.io/alpacax/alpamon` and refreshes only that one, as its own command rather than chained. Any alias works; a disabled repository or no match at all falls back to refreshing everything. A refresh failure still stops the upgrade, because the refresh is what keeps a stale-metadata no-op from being reported as a successful upgrade.
+
+The update itself is never scoped with `-r`. That option loads only the named repository, so dependency resolution then fails against the distribution repositories—`zypper install -r alpamon alpamon` reports `nothing provides 'nftables'`. Because the update stays unscoped, it exits 106 whenever any repository is unreachable; that code counts as success only when alpamon's own repository was refreshed on its own moments earlier, which rules out a skipped repository hiding a missed update.
+
+System-wide updates cannot be scoped this way—by definition they cover every repository—so the console update button still fails while a repository is unreachable.
+
 ## Zypper exit codes
 
 Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational states, and two of them follow a successful install. The agent maps those two to success and leaves everything else a failure, so a completed update does not surface in the console as a broken command:
@@ -51,7 +61,7 @@ Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational st
 | 103 | Package manager restart needed after a successful install | success |
 | 100, 101 | Patches available, none installed | failure |
 | 104 | No repository carries the requested package | failure |
-| 106 | A repository was skipped because it failed to refresh | failure |
+| 106 | A repository was skipped because it failed to refresh | success for an agent upgrade whose own repository refreshed, failure otherwise |
 | 107 | Installed, but an rpm `%post` script failed | failure |
 
 100 and 101 come from `patch-check`, which the agent never runs, so they are anomalous here rather than informational. 104 means nothing was updated. 107 matters because `%post` is what registers the systemd units and the PAM session lines, so a package that unpacked with a failed script is not a working install.

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -65,6 +65,8 @@ Unlike `apt-get` and `yum`, zypper reserves codes above 100 for informational st
 | 100, 101 | Patches available, none installed | failure |
 | 104 | No repository carries the requested package | failure |
 | 106 | A repository was skipped because it failed to refresh | success for an agent upgrade whose own repository refreshed, failure otherwise |
+
+Exit 4, 6, 7, 104, and a 106 that was not tolerated get a hint appended to the command output, because zypper's own message does not name what the operator has to change. An unregistered SLES host is the common case: `zypper lr` exits 6 and `zypper update alpamon` exits 104, neither mentioning the inactive subscription behind both. Check `SUSEConnect --status` there, and confirm alpamon's repository is present with `zypper lr --uri`. Exit 7 means the libzypp lock was still held after the retries; `zypper ps` names the holder.
 | 107 | Installed, but an rpm `%post` script failed | failure |
 
 100 and 101 come from `patch-check`, which the agent never runs, so they are anomalous here rather than informational. 104 means nothing was updated. 107 matters because `%post` is what registers the systemd units and the PAM session lines, so a package that unpacked with a failed script is not a working install.

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -22,7 +22,7 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 
 openSUSE ships its sudoers file with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Both `%wheel` lines in that file are commented out, so `wheel` membership grants nothing by itself. The drop-in below therefore does two things: it grants `%wheel` the rule, and it exempts `%wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
 
-Leap keeps that file at `/etc/sudoers`; Tumbleweed ships it as `/usr/etc/sudoers` and has no `/etc/sudoers` at all. The drop-in path is the same on both, because either file ends with `@includedir /etc/sudoers.d`.
+Leap keeps that file at `/etc/sudoers`; Tumbleweed ships it as `/usr/etc/sudoers` and has no `/etc/sudoers` at all. The drop-in path is the same on both, because either file ends with `@includedir /etc/sudoers.d`. Tumbleweed keeps `environment` and `login.defs` under `/usr/etc` for the same reason, which is why the agent reads system environment variables from both `/usr/etc/environment` and `/etc/environment`, the admin copy winning.
 
 Stage the drop-in under a name containing a dot, which sudo ignores when reading the include directory, so a typo cannot lock you out before `visudo -cf` has passed:
 

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -1,0 +1,54 @@
+# openSUSE / SLES
+
+Support is best-effort. Alpamon detects openSUSE and SLES, runs `zypper` for its own package operations, and starts cleanly, but the console still composes `yum` for some server-driven operations (see Known limitations below).
+
+## Why the platform reads as rhel
+
+openSUSE and SLES report `platform=rhel` to Alpacon. The three things the server gates on that value—rpm packaging, the `wheel` sudo group, and shadow-utils account tooling—behave identically on both families. The real distribution name is preserved separately in the OS information, and the agent runs `zypper` locally regardless of what it reports.
+
+## Installation
+
+The PackageCloud one-liner writes a yum repo file into `/etc/yum.repos.d/`, which zypper never reads, so add the repository to zypper directly:
+
+```bash
+sudo zypper addrepo -f \
+  'https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch' alpamon
+sudo zypper --gpg-auto-import-keys refresh
+sudo zypper install alpamon
+sudo alpamon register --url https://<workspace> --token <TOKEN>
+```
+
+## Sudoers prerequisite
+
+openSUSE ships `/etc/sudoers` with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Granting `wheel` membership changes nothing on its own, because authorization is not what `targetpw` gates. Exempt `wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
+
+Stage the drop-in under a name containing a dot, which sudo ignores when reading the include directory, so a typo cannot lock you out before `visudo -cf` has passed:
+
+```bash
+printf '%%wheel ALL=(ALL) ALL\nDefaults:%%wheel !targetpw\n' |
+  sudo tee /etc/sudoers.d/alpacon-wheel.stage >/dev/null
+sudo visudo -cf /etc/sudoers.d/alpacon-wheel.stage &&
+  sudo install -m 0440 -o root -g root \
+    /etc/sudoers.d/alpacon-wheel.stage /etc/sudoers.d/alpacon-wheel
+sudo rm -f /etc/sudoers.d/alpacon-wheel.stage
+```
+
+## PAM module
+
+```bash
+sudo zypper install alpamon-pam
+```
+
+Configuration is the same as on other distributions; see the PAM section in the main README.
+
+## Known limitations
+
+Because the host reports `rhel`, console-driven package operations that the server composes still emit `yum` commands and fail on a SUSE host: Alpacon plugin install/upgrade and the automatic `alpamon-pam` install. Install those manually with `zypper` until the server side is zypper-aware. The agent's own upgrade, uninstall, and system-update paths do use `zypper`.
+
+## Already-registered hosts
+
+A host that registered before openSUSE/SLES detection landed carries a wrong `platform` value on the server. That field is write-once, so the host must re-register to pick up the correct value:
+
+```bash
+sudo alpamon register --force --url https://<workspace> --token <TOKEN>
+```

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -20,7 +20,7 @@ sudo alpamon register --url https://<workspace> --token <TOKEN>
 
 ## Sudoers prerequisite
 
-openSUSE ships `/etc/sudoers` with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Granting `wheel` membership changes nothing on its own, because authorization is not what `targetpw` gates. Exempt `wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
+openSUSE ships `/etc/sudoers` with `Defaults targetpw` alongside `ALL ALL=(ALL) ALL`, so every user may already run any command—but only by typing root's password, not their own. Both `%wheel` lines in that file are commented out, so `wheel` membership grants nothing by itself. The drop-in below therefore does two things: it grants `%wheel` the rule, and it exempts `%wheel` from `targetpw` so Alpacon-managed admins authenticate as themselves.
 
 Stage the drop-in under a name containing a dot, which sudo ignores when reading the include directory, so a typo cannot lock you out before `visudo -cf` has passed:
 
@@ -45,6 +45,10 @@ Configuration is the same as on other distributions; see the PAM section in the 
 
 Because the host reports `rhel`, console-driven package operations that the server composes still emit `yum` commands and fail on a SUSE host: Alpacon plugin install/upgrade and the automatic `alpamon-pam` install. Install those manually with `zypper` until the server side is zypper-aware. The agent's own upgrade, uninstall, and system-update paths do use `zypper`.
 
+The console's registration instruction is one of those commands. The registration form offers no SUSE option, and its RHEL guide renders `yum install -y alpamon`, which fails here. Follow the zypper commands under Installation above instead.
+
+The `wheel` sudo group is granted but inert without the sudoers drop-in. For `rhel` the server adds Alpacon-managed admins to `wheel`, and that part succeeds on SUSE, but stock `/etc/sudoers` leaves both `%wheel` rules commented out, so membership alone authorizes nothing. Alpacon then shows the user as sudo-capable while the host refuses the command—the failure is silent, and nothing in the console reports it. The Sudoers prerequisite above is what closes the gap; skipping it leaves admins without sudo.
+
 ## Already-registered hosts
 
 A host that registered before openSUSE/SLES detection landed carries a wrong `platform` value on the server. That field is write-once, so the host must re-register to pick up the correct value:
@@ -52,3 +56,5 @@ A host that registered before openSUSE/SLES detection landed carries a wrong `pl
 ```bash
 sudo alpamon register --force --url https://<workspace> --token <TOKEN>
 ```
+
+This is not an in-place edit of the existing record. `--force` registers a new server, then retires the previous one, so the host gets a new ID. Tags are re-sent and survive; group memberships, console-side access rules, alert-rule customizations, and audit and session history stay attached to the retired record. For one host that is a minor annoyance—for an already-registered fleet, plan it as a migration rather than a routine re-register.

--- a/docs/opensuse.md
+++ b/docs/opensuse.md
@@ -77,7 +77,11 @@ Tumbleweed is a rolling release, so the console update button runs `zypper dup`,
 
 ## SLES 12 and Leap 42
 
-Detection accepts them, because it prefix-matches the distribution id the way the server does, but only 15 and later are verified. Two differences are handled rather than tested end to end: `systemd-run --collect` needs systemd 236 and SLES 12 ships 228, so the uninstall retries the scheduling without that flag; and SuSEfirewall2, which those releases use instead of firewalld, is detected as an active high-level firewall, which disables Alpacon firewall management the same way ufw and firewalld do. Without that detection Alpacon would write iptables rules that SuSEfirewall2 discards on its next reload.
+Detection accepts them, because it prefix-matches the distribution id the way the server does. Alpamon itself is only verified on 15 and later, but the two places where those releases differ are handled, and the difference was measured on systemd 228 (Leap 42.3, the same version SLES 12 ships) and on a systemd 229 host.
+
+The uninstall schedules the package removal through `systemd-run`, and two of its options behave differently there. `--collect` does not exist before systemd 236, so the scheduling is retried without it. The delay is passed as `--on-active=5` rather than `--timer-property=OnActiveSec=5`, because the older systemd rejects a `--timer-property` that is not accompanied by a timer option of its own; `--on-active` is accepted by every version and sets the same property. Both matter, since a scheduling failure falls back to removing the package synchronously, in the middle of the command that asked for it.
+
+SuSEfirewall2, which those releases use instead of firewalld, is detected as an active high-level firewall (`/usr/lib/systemd/system/SuSEfirewall2.service`), which disables Alpacon firewall management the same way ufw and firewalld do. Without that detection Alpacon would write iptables rules that SuSEfirewall2 discards on its next reload.
 
 ## Known limitations
 

--- a/pkg/executor/handlers/firewall/detection.go
+++ b/pkg/executor/handlers/firewall/detection.go
@@ -27,7 +27,14 @@ const (
 	HighLevelNone      HighLevelFirewall = ""
 	HighLevelUFW       HighLevelFirewall = "ufw"
 	HighLevelFirewalld HighLevelFirewall = "firewalld"
+	// SLES 12 and Leap 42, which the SUSE prefixes accept, ship SuSEfirewall2
+	// instead of firewalld. It owns the iptables ruleset and regenerates it on
+	// reload, so rules written behind its back disappear without an error.
+	HighLevelSuSEfirewall2 HighLevelFirewall = "SuSEfirewall2"
 )
+
+// Test seam: the units these checks query only exist on linux.
+var hasSystemd = utils.HasSystemd
 
 // DetectionResult holds the cached detection results
 type DetectionResult struct {
@@ -123,9 +130,9 @@ func (d *FirewallDetector) GetBackendType() BackendType {
 
 // detectHighLevelFirewall detects if high-level firewall management tools are active
 func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLevelFirewall {
-	hasSystemd := utils.HasSystemd()
+	systemdAvailable := hasSystemd()
 
-	if hasSystemd {
+	if systemdAvailable {
 		// Check ufw via systemctl (most reliable)
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "ufw")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {
@@ -141,7 +148,7 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 		return HighLevelUFW
 	}
 
-	if hasSystemd {
+	if systemdAvailable {
 		// Check firewalld via systemctl
 		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "firewalld")
 		if exitCode == 0 && strings.TrimSpace(output) == "active" {
@@ -155,6 +162,15 @@ func (d *FirewallDetector) detectHighLevelFirewall(ctx context.Context) HighLeve
 	if exitCode == 0 && strings.Contains(strings.ToLower(output), "running") {
 		log.Info().Msg("Detected active firewalld - Alpacon firewall management will be disabled")
 		return HighLevelFirewalld
+	}
+
+	if systemdAvailable {
+		// SuSEfirewall2 has no query command of its own; the unit is the only signal.
+		exitCode, output, _ := d.executor.RunWithTimeout(ctx, 5*time.Second, "systemctl", "is-active", "SuSEfirewall2")
+		if exitCode == 0 && strings.TrimSpace(output) == "active" {
+			log.Info().Msg("Detected active SuSEfirewall2 - Alpacon firewall management will be disabled")
+			return HighLevelSuSEfirewall2
+		}
 	}
 
 	log.Debug().Msg("No high-level firewall detected - Alpacon firewall management enabled")

--- a/pkg/executor/handlers/firewall/firewall_test.go
+++ b/pkg/executor/handlers/firewall/firewall_test.go
@@ -283,3 +283,27 @@ func TestFirewallHandler_BatchOperation(t *testing.T) {
 		t.Error("Execute() returned no output")
 	}
 }
+
+// SLES 12 and Leap 42 ship SuSEfirewall2 rather than firewalld. It owns the
+// iptables ruleset and regenerates it on reload, so rules Alpacon writes behind
+// its back vanish without an error.
+func TestFirewallDetector_SuSEfirewall2DisablesManagement(t *testing.T) {
+	orig := hasSystemd
+	hasSystemd = func() bool { return true }
+	t.Cleanup(func() { hasSystemd = orig })
+
+	mockExec := common.NewMockCommandExecutor(t)
+	mockExec.SetResult("systemctl is-active SuSEfirewall2", 0, "active", nil)
+
+	result := NewFirewallDetector(mockExec).Detect(context.Background())
+
+	if result.HighLevel != HighLevelSuSEfirewall2 {
+		t.Errorf("expected %q, got %q", HighLevelSuSEfirewall2, result.HighLevel)
+	}
+	if !result.Disabled {
+		t.Error("an active high-level firewall must disable Alpacon firewall management")
+	}
+	if result.Backend != BackendNone {
+		t.Errorf("expected no backend, got %q", result.Backend)
+	}
+}

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -312,6 +312,10 @@ const (
 // Var so tests do not sleep. Long enough for a short transaction elsewhere to finish, short enough to stay inside a console command's patience.
 var zypperLockRetryDelay = 15 * time.Second
 
+// Test seam: the uninstall scheduling it gates is linux-only, so without it the
+// path cannot be exercised from a darwin or windows test run.
+var hasSystemd = utils.HasSystemd
+
 // The alias to scope the refresh to, or "" when none resolves. `lr --export -` is
 // parsed rather than the table form: it emits ini and needs no column splitting.
 func (h *SystemHandler) resolveZypperAlpamonRepo(ctx context.Context) string {
@@ -588,7 +592,7 @@ func (h *SystemHandler) executeUninstall() {
 
 	ctx := context.Background()
 
-	if utils.HasSystemd() {
+	if hasSystemd() {
 		// Build the complete uninstall command that includes:
 		// 1. Package removal
 		// 2. Cleanup of transient systemd units created by this operation
@@ -596,10 +600,7 @@ func (h *SystemHandler) executeUninstall() {
 
 		// This ensures the uninstall continues even after the current process terminates
 		// The service will start 5 seconds after being scheduled
-		// --collect: Automatically clean up transient units after they complete (systemd 236+)
 		scheduleCmdArgs := []string{
-			"systemd-run",
-			"--collect",
 			"--uid=0",
 			"--gid=0",
 			"--unit=alpamon-uninstall",
@@ -609,7 +610,17 @@ func (h *SystemHandler) executeUninstall() {
 			"/bin/sh", "-c", uninstallCmd,
 		}
 
-		exitCode, output, _ := h.Executor.RunWithTimeout(ctx, 30*time.Second, scheduleCmdArgs[0], scheduleCmdArgs[1:]...)
+		// --collect cleans the transient units up on its own, but it needs systemd
+		// 236+ and SLES 12, which the SUSE prefixes accept, ships 228. Retry
+		// without it before falling back: the fallback removes the package
+		// synchronously, which tears the agent down mid-command. The reset-failed
+		// calls above already cover what --collect would have done.
+		withCollect := append([]string{"--collect"}, scheduleCmdArgs...)
+		exitCode, output, _ := h.Executor.RunWithTimeout(ctx, 30*time.Second, "systemd-run", withCollect...)
+		if exitCode != 0 {
+			log.Warn().Msgf("Could not schedule uninstall with --collect, retrying without it: %s", output)
+			exitCode, output, _ = h.Executor.RunWithTimeout(ctx, 30*time.Second, "systemd-run", scheduleCmdArgs...)
+		}
 
 		if exitCode != 0 {
 			log.Error().Msgf("Failed to schedule uninstall: %s", output)

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -198,6 +198,9 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	pkgList := strings.Join(packages, " ")
 
 	var cmd string
+	// Set when the refresh was scoped to alpamon's own repo, which is what makes
+	// a later "some repos were skipped" tolerable; see normalizeZypperExit.
+	var alpamonRepoRefreshed bool
 	switch utils.PackageManager {
 	case utils.PkgApt:
 		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
@@ -208,7 +211,22 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 		// were added with autorefresh on (`addrepo -f`). Against stale metadata
 		// `update` finds no candidate and still exits 0, which would report a
 		// successful upgrade that never happened.
-		cmd = fmt.Sprintf("zypper --non-interactive refresh && zypper --non-interactive update %s", pkgList)
+		//
+		// It runs as its own command, scoped to alpamon's repo when that can be
+		// resolved: chained with `&&`, one unreachable repo anywhere on the host
+		// exits 4 and update never runs, and a chained exit code cannot say
+		// which half produced it. The update itself stays unscoped because
+		// `update -r` loads only that repo and then cannot resolve dependencies
+		// living in the distribution repos. See docs/opensuse.md.
+		refresh := []string{"zypper", "--non-interactive", "refresh"}
+		if alias := h.resolveZypperAlpamonRepo(ctx); alias != "" {
+			refresh = append(refresh, alias)
+			alpamonRepoRefreshed = true
+		}
+		if code, out, rerr := h.Executor.Exec(ctx, refresh, "root", "root", packageProxyEnv(packageProxy), 0); code != 0 {
+			return code, out, rerr
+		}
+		cmd = fmt.Sprintf("zypper --non-interactive update %s", pkgList)
 	case utils.PkgBrew, utils.PkgNone:
 		// darwin/windows have no package channel for alpamon, so the binary
 		// replaces itself. needAlpamon is always true here: needPam is always
@@ -229,7 +247,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	// The proxy environment (nil without a package proxy) applies to the
 	// spawned package-manager shell only, never to the agent process.
 	exitCode, output, err := h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
-	exitCode, err = normalizeZypperExit(exitCode, err)
+	exitCode, err = normalizeZypperExit(exitCode, err, alpamonRepoRefreshed)
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
 	}
@@ -260,15 +278,60 @@ func sanitizePackageProxy(raw string) string {
 	}
 }
 
+// alpamonRepoURL matches the PackageCloud repository that carries alpamon under
+// whatever alias the operator gave it.
+const alpamonRepoURL = "packagecloud.io/alpacax/alpamon"
+
+// resolveZypperAlpamonRepo returns the alias of the enabled repo pointing at
+// alpamon's PackageCloud repository, or "" when there is none to scope to.
+// `lr --export -` is parsed instead of the table form because it emits ini
+// (`[alias]` plus `baseurl=`) and needs no column splitting.
+func (h *SystemHandler) resolveZypperAlpamonRepo(ctx context.Context) string {
+	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "zypper", "--non-interactive", "lr", "--export", "-")
+	if err != nil || exitCode != 0 {
+		log.Debug().Int("exitCode", exitCode).Msg("Could not list zypper repositories; upgrading without a repo scope.")
+		return ""
+	}
+
+	var alias string
+	enabled, matched := true, false
+	resolved := func() string {
+		if matched && enabled {
+			return alias
+		}
+		return ""
+	}
+
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]"):
+			if got := resolved(); got != "" {
+				return got
+			}
+			alias = strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			enabled, matched = true, false
+		case strings.HasPrefix(line, "enabled="):
+			enabled = strings.TrimPrefix(line, "enabled=") == "1"
+		case strings.Contains(line, alpamonRepoURL):
+			matched = true
+		}
+	}
+	return resolved()
+}
+
 // zypper's 102/103 follow a successful install; every other code stays a
 // failure, and the dropped error is the *exec.ExitError for the same code.
-// Per-code reasoning and the apt/yum contrast are in docs/opensuse.md.
-func normalizeZypperExit(exitCode int, err error) (int, error) {
+// 106 (some repos skipped) is success only when alpamonRepoRefreshed says the
+// repo we depend on was refreshed on its own moments earlier, so the skipped one
+// cannot be hiding a missed update. Per-code reasoning and the apt/yum contrast
+// are in docs/opensuse.md.
+func normalizeZypperExit(exitCode int, err error, alpamonRepoRefreshed bool) (int, error) {
 	if utils.PackageManager != utils.PkgZypper {
 		return exitCode, err
 	}
-	switch exitCode {
-	case 102, 103:
+	switch {
+	case exitCode == 102, exitCode == 103, exitCode == 106 && alpamonRepoRefreshed:
 		log.Info().Int("zypperExitCode", exitCode).Msg("zypper reported an informational exit code; treating the command as successful.")
 		return 0, nil
 	}
@@ -550,7 +613,9 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 		return 1, fmt.Sprintf("Platform '%s' (package manager %q) not supported.", utils.PlatformLike, utils.PackageManager), nil
 	}
 
+	// A system-wide update covers every repo by definition, so a skipped repo
+	// means part of the update did not happen: 106 stays a failure here.
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
-	exitCode, err = normalizeZypperExit(exitCode, err)
+	exitCode, err = normalizeZypperExit(exitCode, err, false)
 	return exitCode, output, err
 }

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -207,23 +207,22 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	case utils.PkgYum:
 		cmd = fmt.Sprintf("yum update -y %s", pkgList)
 	case utils.PkgZypper:
-		// The refresh is explicit because zypper only auto-refreshes repos that
-		// were added with autorefresh on (`addrepo -f`). Against stale metadata
-		// `update` finds no candidate and still exits 0, which would report a
-		// successful upgrade that never happened.
-		//
-		// It runs as its own command, scoped to alpamon's repo when that can be
-		// resolved: chained with `&&`, one unreachable repo anywhere on the host
-		// exits 4 and update never runs, and a chained exit code cannot say
-		// which half produced it. The update itself stays unscoped because
-		// `update -r` loads only that repo and then cannot resolve dependencies
-		// living in the distribution repos. See docs/opensuse.md.
+		// The refresh is explicit because zypper only auto-refreshes repos added
+		// with autorefresh on (`addrepo -f`), and against stale metadata `update`
+		// finds no candidate and still exits 0. It runs as its own command because
+		// chaining it with `&&` lets one unreachable repo anywhere on the host exit
+		// 4 with update never running, and hides which half produced the code. The
+		// update stays unscoped: `update -r` loads only that repo and then cannot
+		// resolve dependencies from the distribution repos.
 		refresh := []string{"zypper", "--non-interactive", "refresh"}
 		if alias := h.resolveZypperAlpamonRepo(ctx); alias != "" {
 			refresh = append(refresh, alias)
 			alpamonRepoRefreshed = true
 		}
-		if code, out, rerr := h.Executor.Exec(ctx, refresh, "root", "root", packageProxyEnv(packageProxy), 0); code != 0 {
+		code, out, rerr := retryWhileZypperLocked(ctx, func() (int, string, error) {
+			return h.Executor.Exec(ctx, refresh, "root", "root", packageProxyEnv(packageProxy), 0)
+		})
+		if code != 0 {
 			return code, out, rerr
 		}
 		cmd = fmt.Sprintf("zypper --non-interactive update %s", pkgList)
@@ -246,7 +245,9 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	log.Debug().Msgf("Upgrading %s...", pkgList)
 	// The proxy environment (nil without a package proxy) applies to the
 	// spawned package-manager shell only, never to the agent process.
-	exitCode, output, err := h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
+	exitCode, output, err := retryWhileZypperLocked(ctx, func() (int, string, error) {
+		return h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
+	})
 	exitCode, err = normalizeZypperExit(exitCode, err, alpamonRepoRefreshed)
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
@@ -278,14 +279,23 @@ func sanitizePackageProxy(raw string) string {
 	}
 }
 
-// alpamonRepoURL matches the PackageCloud repository that carries alpamon under
-// whatever alias the operator gave it.
-const alpamonRepoURL = "packagecloud.io/alpacax/alpamon"
+// zypper behavior the other package managers do not share; per-code reasoning and the apt/yum contrast are in docs/opensuse.md.
+const (
+	// The PackageCloud repository carrying alpamon, whatever alias the operator gave it.
+	alpamonRepoURL = "packagecloud.io/alpacax/alpamon"
 
-// resolveZypperAlpamonRepo returns the alias of the enabled repo pointing at
-// alpamon's PackageCloud repository, or "" when there is none to scope to.
-// `lr --export -` is parsed instead of the table form because it emits ini
-// (`[alias]` plus `baseurl=`) and needs no column splitting.
+	// ZYPP_LOCKED: packagekit, an operator's session, or a console update racing
+	// the agent's own upgrade holds the libzypp lock. dnf waits for its lock and
+	// apt can be told to retry; zypper --non-interactive gives up at once.
+	zypperLockedExit   = 7
+	zypperLockAttempts = 3
+)
+
+// Var so tests do not sleep. Long enough for a short transaction elsewhere to finish, short enough to stay inside a console command's patience.
+var zypperLockRetryDelay = 15 * time.Second
+
+// The alias to scope the refresh to, or "" when none resolves. `lr --export -` is
+// parsed rather than the table form: it emits ini and needs no column splitting.
 func (h *SystemHandler) resolveZypperAlpamonRepo(ctx context.Context) string {
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "zypper", "--non-interactive", "lr", "--export", "-")
 	if err != nil || exitCode != 0 {
@@ -320,12 +330,25 @@ func (h *SystemHandler) resolveZypperAlpamonRepo(ctx context.Context) string {
 	return resolved()
 }
 
-// zypper's 102/103 follow a successful install; every other code stays a
-// failure, and the dropped error is the *exec.ExitError for the same code.
-// 106 (some repos skipped) is success only when alpamonRepoRefreshed says the
-// repo we depend on was refreshed on its own moments earlier, so the skipped one
-// cannot be hiding a missed update. Per-code reasoning and the apt/yum contrast
-// are in docs/opensuse.md.
+func retryWhileZypperLocked(ctx context.Context, run func() (int, string, error)) (int, string, error) {
+	for attempt := 1; ; attempt++ {
+		exitCode, output, err := run()
+		if exitCode != zypperLockedExit || utils.PackageManager != utils.PkgZypper || attempt >= zypperLockAttempts {
+			return exitCode, output, err
+		}
+		log.Info().Int("attempt", attempt).Msg("zypper is locked by another process; retrying.")
+		select {
+		case <-ctx.Done():
+			return exitCode, output, err
+		case <-time.After(zypperLockRetryDelay):
+		}
+	}
+}
+
+// 102/103 follow a successful install; every other code stays a failure, and the
+// dropped error is the *exec.ExitError for the same code. 106 (some repos skipped)
+// is success only when alpamonRepoRefreshed says the repo we depend on was
+// refreshed on its own, so the skipped one cannot hide a missed update.
 func normalizeZypperExit(exitCode int, err error, alpamonRepoRefreshed bool) (int, error) {
 	if utils.PackageManager != utils.PkgZypper {
 		return exitCode, err
@@ -615,7 +638,9 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 
 	// A system-wide update covers every repo by definition, so a skipped repo
 	// means part of the update did not happen: 106 stays a failure here.
-	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	exitCode, output, err := retryWhileZypperLocked(ctx, func() (int, string, error) {
+		return h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	})
 	exitCode, err = normalizeZypperExit(exitCode, err, false)
 	return exitCode, output, err
 }

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -227,7 +227,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 			return h.Executor.Exec(ctx, refresh, "root", "root", packageProxyEnv(packageProxy), 0)
 		})
 		if code != 0 {
-			return code, out, rerr
+			return code, withZypperHint(code, out), rerr
 		}
 		cmd = fmt.Sprintf("zypper --non-interactive update %s", pkgList)
 		versionsBefore = h.installedRPMVersions(ctx, packages)
@@ -267,6 +267,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 			output = strings.TrimRight(output, "\n") + "\n\n" + note
 		}
 	}
+	output = withZypperHint(exitCode, output)
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
 	}
@@ -394,6 +395,39 @@ func (h *SystemHandler) unmovedPackages(ctx context.Context, versionsBefore map[
 	}
 	slices.Sort(stale)
 	return stale
+}
+
+// The console shows an operator the exit code and the command output, and zypper's
+// own output does not say what the operator has to change. Measured on an
+// unregistered sles12sp5 container: `lr` exits 6 and `update alpamon` exits 104,
+// neither of them mentioning the missing subscription that caused both.
+func withZypperHint(exitCode int, output string) string {
+	if utils.PackageManager != utils.PkgZypper {
+		return output
+	}
+
+	var hint string
+	switch exitCode {
+	case 4:
+		hint = "A repository could not be refreshed. One unreachable repository fails the whole " +
+			"command, even when alpamon's own repository is fine: check `zypper lr --uri`."
+	case 6:
+		hint = "No repositories are defined. On SLES this usually means the host has no active " +
+			"subscription (`SUSEConnect --status`); alpamon's repository also has to be added with " +
+			"`zypper addrepo`, because the PackageCloud one-liner writes a yum repo file zypper never reads."
+	case zypperLockedExit:
+		hint = "Another process still holds the libzypp lock after several retries. Find it with " +
+			"`zypper ps`, and expect packagekit or an operator's own zypper session."
+	case 104:
+		hint = "No configured repository carries the package. Add alpamon's repository with " +
+			"`zypper addrepo`, and on SLES check that the subscription is active (`SUSEConnect --status`)."
+	case 106:
+		hint = "A repository was skipped because it failed to refresh, so the update may have missed " +
+			"packages: `zypper refresh` names the one that failed."
+	default:
+		return output
+	}
+	return strings.TrimRight(output, "\n") + "\n\n" + hint
 }
 
 // 102/103 follow a successful install; every other code stays a failure, and the
@@ -700,5 +734,5 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 		return h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
 	})
 	exitCode, err = normalizeZypperExit(exitCode, err, false)
-	return exitCode, output, err
+	return exitCode, withZypperHint(exitCode, output), err
 }

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -634,11 +634,17 @@ func (h *SystemHandler) executeUninstall() {
 
 		// This ensures the uninstall continues even after the current process terminates
 		// The service will start 5 seconds after being scheduled
+		// The delay is expressed with --on-active rather than
+		// --timer-property=OnActiveSec, because systemd before 236 rejects a
+		// --timer-property that is not accompanied by a timer option of its own
+		// ("--timer-property= has no effect without any other timer options",
+		// measured on systemd 229 and 228). --on-active is accepted by both and
+		// sets the same property.
 		scheduleCmdArgs := []string{
 			"--uid=0",
 			"--gid=0",
 			"--unit=alpamon-uninstall",
-			"--timer-property=OnActiveSec=5",
+			"--on-active=5",
 			"--timer-property=AccuracySec=1s",
 			"--description=Alpamon Uninstall Service",
 			"/bin/sh", "-c", uninstallCmd,

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -229,6 +229,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	// The proxy environment (nil without a package proxy) applies to the
 	// spawned package-manager shell only, never to the agent process.
 	exitCode, output, err := h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
+	exitCode, err = normalizeZypperExit(exitCode, err)
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
 	}
@@ -257,6 +258,21 @@ func sanitizePackageProxy(raw string) string {
 		log.Warn().Str("scheme", parsed.Scheme).Msg("Unsupported package proxy scheme in upgrade payload; ignoring it.")
 		return ""
 	}
+}
+
+// zypper's 102/103 follow a successful install; every other code stays a
+// failure, and the dropped error is the *exec.ExitError for the same code.
+// Per-code reasoning and the apt/yum contrast are in docs/opensuse.md.
+func normalizeZypperExit(exitCode int, err error) (int, error) {
+	if utils.PackageManager != utils.PkgZypper {
+		return exitCode, err
+	}
+	switch exitCode {
+	case 102, 103:
+		log.Info().Int("zypperExitCode", exitCode).Msg("zypper reported an informational exit code; treating the command as successful.")
+		return 0, nil
+	}
+	return exitCode, err
 }
 
 // packageProxyEnv builds the proxy environment for the package-manager shell
@@ -535,5 +551,6 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 	}
 
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	exitCode, err = normalizeZypperExit(exitCode, err)
 	return exitCode, output, err
 }

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -174,17 +174,25 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	pkgList := strings.Join(packages, " ")
 
 	var cmd string
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
-	case "rhel":
+	case utils.PkgYum:
 		cmd = fmt.Sprintf("yum update -y %s", pkgList)
-	case "darwin", "windows":
-		// needAlpamon is always true here: needPam is always false on non-linux
-		// (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
+	case utils.PkgZypper:
+		// The refresh is explicit because zypper only auto-refreshes repos that
+		// were added with autorefresh on (`addrepo -f`). Against stale metadata
+		// `update` finds no candidate and still exits 0, which would report a
+		// successful upgrade that never happened.
+		cmd = fmt.Sprintf("zypper --non-interactive refresh && zypper --non-interactive update %s", pkgList)
+	case utils.PkgBrew, utils.PkgNone:
+		// darwin/windows have no package channel for alpamon, so the binary
+		// replaces itself. needAlpamon is always true here: needPam is always
+		// false on non-linux (pam unsupported; see pkg/utils/pam.go) and the
+		// switch is reached only when needAlpamon||needPam.
 		return h.selfUpdate(ctx, latestVersion)
 	default:
-		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
+		return 1, fmt.Sprintf("Platform '%s' (package manager %q) not supported.", utils.PlatformLike, utils.PackageManager), nil
 	}
 
 	log.Debug().Msgf("Upgrading %s...", pkgList)
@@ -323,20 +331,21 @@ func (h *SystemHandler) executeUninstall() {
 
 	var cmd string
 
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		// Use purge to remove package and config files
 		cmd = "apt-get purge alpamon -y && apt-get autoremove -y"
-	case "rhel":
-		// Remove package using yum
+	case utils.PkgYum:
 		cmd = "yum remove alpamon -y"
-	case "darwin":
+	case utils.PkgZypper:
+		cmd = "zypper --non-interactive remove alpamon"
+	case utils.PkgBrew:
 		// For macOS development environment, just shutdown
 		log.Warn().Msgf("Platform '%s' does not support full uninstall. Shutting down instead.", utils.PlatformLike)
 		h.wsClient.ShutDown()
 		return
 	default:
-		log.Error().Msgf("Platform '%s' not supported for uninstall.", utils.PlatformLike)
+		log.Error().Msgf("Platform '%s' (package manager %q) not supported for uninstall.", utils.PlatformLike, utils.PackageManager)
 		h.wsClient.ShutDown()
 		return
 	}
@@ -415,15 +424,27 @@ func (h *SystemHandler) handleSystemUpdate(ctx context.Context) (int, string, er
 	log.Info().Msg("Upgrade system requested.")
 
 	var cmd string
-	switch utils.PlatformLike {
-	case "debian":
+	switch utils.PackageManager {
+	case utils.PkgApt:
 		cmd = "apt-get update -o Acquire::Retries=3 && apt-get upgrade -y -o Acquire::Retries=3 && apt-get autoremove -y"
-	case "rhel":
+	case utils.PkgYum:
 		cmd = "yum update -y"
-	case "darwin":
+	case utils.PkgZypper:
+		// Tumbleweed is a rolling release: `zypper update` cannot perform the
+		// vendor changes a distribution upgrade needs. Leap/SLES must NOT use
+		// dup: it would jump to the next service pack.
+		//
+		// The refresh mirrors the apt branch's `apt-get update`; see handleUpgrade
+		// for why zypper cannot be relied on to refresh itself.
+		if utils.IsTumbleweed(utils.PlatformID) {
+			cmd = "zypper --non-interactive refresh && zypper --non-interactive dup"
+		} else {
+			cmd = "zypper --non-interactive refresh && zypper --non-interactive update"
+		}
+	case utils.PkgBrew:
 		cmd = "brew upgrade"
 	default:
-		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
+		return 1, fmt.Sprintf("Platform '%s' (package manager %q) not supported.", utils.PlatformLike, utils.PackageManager), nil
 	}
 
 	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -258,11 +258,17 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	// is routine, and the console already shows the version the agent reports.
 	if exitCode == 0 {
 		if stale := h.unmovedPackages(ctx, versionsBefore); len(stale) > 0 {
+			// Per package: alpamon and alpamon-pam carry their own version-release,
+			// so one shared number would misname the other one's.
+			held := make([]string, 0, len(stale))
+			for _, pkg := range stale {
+				held = append(held, fmt.Sprintf("%s (still %s)", pkg, versionsBefore[pkg]))
+			}
 			note := fmt.Sprintf(
-				"zypper exited 0 but %s did not move (still %s). The repository may not carry a newer "+
+				"zypper exited 0 but %s did not move. The repository may not carry a newer "+
 					"build yet, or its vendor changed: solver.allowVendorChange is off by default, and "+
 					"zypper then declines the upgrade without failing.",
-				strings.Join(stale, ", "), versionsBefore[stale[0]])
+				strings.Join(held, ", "))
 			log.Warn().Msg(note)
 			output = strings.TrimRight(output, "\n") + "\n\n" + note
 		}

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -201,6 +202,9 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 	// Set when the refresh was scoped to alpamon's own repo, which is what makes
 	// a later "some repos were skipped" tolerable; see normalizeZypperExit.
 	var alpamonRepoRefreshed bool
+	// Populated on the zypper path only, to catch an update that exits 0 without
+	// moving anything; see unmovedPackages.
+	var versionsBefore map[string]string
 	switch utils.PackageManager {
 	case utils.PkgApt:
 		cmd = fmt.Sprintf("apt-get update -y -o Acquire::Retries=3 && apt-get install --only-upgrade %s -y -o Acquire::Retries=3", pkgList)
@@ -226,6 +230,7 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 			return code, out, rerr
 		}
 		cmd = fmt.Sprintf("zypper --non-interactive update %s", pkgList)
+		versionsBefore = h.installedRPMVersions(ctx, packages)
 	case utils.PkgBrew, utils.PkgNone:
 		// darwin/windows have no package channel for alpamon, so the binary
 		// replaces itself. needAlpamon is always true here: needPam is always
@@ -249,6 +254,19 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 		return h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
 	})
 	exitCode, err = normalizeZypperExit(exitCode, err, alpamonRepoRefreshed)
+	// Reported, not failed: a repository that has not published the new build yet
+	// is routine, and the console already shows the version the agent reports.
+	if exitCode == 0 {
+		if stale := h.unmovedPackages(ctx, versionsBefore); len(stale) > 0 {
+			note := fmt.Sprintf(
+				"zypper exited 0 but %s did not move (still %s). The repository may not carry a newer "+
+					"build yet, or its vendor changed: solver.allowVendorChange is off by default, and "+
+					"zypper then declines the upgrade without failing.",
+				strings.Join(stale, ", "), versionsBefore[stale[0]])
+			log.Warn().Msg(note)
+			output = strings.TrimRight(output, "\n") + "\n\n" + note
+		}
+	}
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
 	}
@@ -343,6 +361,35 @@ func retryWhileZypperLocked(ctx context.Context, run func() (int, string, error)
 		case <-time.After(zypperLockRetryDelay):
 		}
 	}
+}
+
+// version-release of each package rpm can report, skipping the rest.
+func (h *SystemHandler) installedRPMVersions(ctx context.Context, packages []string) map[string]string {
+	versions := make(map[string]string, len(packages))
+	for _, pkg := range packages {
+		exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "rpm", "-q", "--qf", "%{VERSION}-%{RELEASE}", pkg)
+		if err != nil || exitCode != 0 {
+			continue
+		}
+		versions[pkg] = strings.TrimSpace(output)
+	}
+	return versions
+}
+
+// Packages an upgrade left in place after reporting success. zypper keeps
+// solver.allowVendorChange off, so a vendor change in a published build makes
+// `update` print "No update candidate" and exit 0 with the old version still
+// installed, which is the silent no-op the explicit refresh cannot catch. apt and
+// yum have no vendor gate, so versionsBefore is empty there and this is a no-op.
+func (h *SystemHandler) unmovedPackages(ctx context.Context, versionsBefore map[string]string) []string {
+	var stale []string
+	for pkg, before := range versionsBefore {
+		if after, ok := h.installedRPMVersions(ctx, []string{pkg})[pkg]; ok && after == before {
+			stale = append(stale, pkg)
+		}
+	}
+	slices.Sort(stale)
+	return stale
 }
 
 // 102/103 follow a successful install; every other code stays a failure, and the

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -137,6 +137,26 @@ func (e *lockedThenFreeExecutor) RunAsUser(ctx context.Context, username string,
 	return e.MockCommandExecutor.RunAsUser(ctx, username, name, args...)
 }
 
+// Answers the rpm version probe with before on the first call and after on the
+// rest, so an upgrade that zypper reported as successful can be shown to have
+// moved the package or not.
+type versionSteppingExecutor struct {
+	*common.MockCommandExecutor
+	before, after string
+	probes        int
+}
+
+func (e *versionSteppingExecutor) RunAsUser(ctx context.Context, username string, name string, args ...string) (int, string, error) {
+	if name == "rpm" {
+		e.probes++
+		if e.probes == 1 {
+			return 0, e.before, nil
+		}
+		return 0, e.after, nil
+	}
+	return e.MockCommandExecutor.RunAsUser(ctx, username, name, args...)
+}
+
 func TestSystemHandler_Name(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}
@@ -1427,5 +1447,73 @@ func TestSystemHandler_ZypperLockIsRetried(t *testing.T) {
 				t.Errorf("expected a retry, got %d lockable calls", mockExec.calls)
 			}
 		})
+	}
+}
+
+// zypper exits 0 with "No update candidate" when vendor stickiness blocks the
+// upgrade, so the exit code alone cannot say whether the package moved.
+func TestSystemHandler_Upgrade_ZypperNoOpIsReported(t *testing.T) {
+	tests := []struct {
+		name         string
+		afterVersion string
+		wantNote     bool
+	}{
+		{"version moved", "2.4.1-1", false},
+		{"version unchanged", "2.4.0-1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := &versionSteppingExecutor{
+				MockCommandExecutor: common.NewMockCommandExecutor(t),
+				before:              "2.4.0-1",
+				after:               tt.afterVersion,
+			}
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+			exitCode, output, _ := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+			// A repo that has not published the build yet is routine, so the
+			// command stays successful either way.
+			if exitCode != 0 {
+				t.Fatalf("expected exit 0, got %d (%q)", exitCode, output)
+			}
+			if gotNote := strings.Contains(output, "did not move"); gotNote != tt.wantNote {
+				t.Errorf("note present = %v, want %v: %q", gotNote, tt.wantNote, output)
+			}
+			if tt.wantNote && !strings.Contains(output, "2.4.0-1") {
+				t.Errorf("note must name the version still installed, got %q", output)
+			}
+		})
+	}
+}
+
+// An apt host must not pay for the rpm query, and must keep reporting the
+// package manager's own exit code.
+func TestSystemHandler_Upgrade_NoVersionProbeOnApt(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+	setPackageManagerAndID(t, utils.PkgApt, "ubuntu")
+
+	exitCode, _, _ := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if exitCode != 0 {
+		t.Errorf("expected exit 0, got %d", exitCode)
+	}
+	if mockExec.Invoked("rpm") {
+		t.Error("apt host must not run rpm")
 	}
 }

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -1580,3 +1580,67 @@ func TestSystemHandler_Uninstall_RetriesWithoutCollect(t *testing.T) {
 		})
 	}
 }
+
+// zypper's own output does not name the missing subscription or repository that
+// produced these codes, and the console shows the operator nothing else.
+func TestWithZypperHint(t *testing.T) {
+	tests := []struct {
+		name       string
+		pkgManager string
+		exitCode   int
+		wantHint   string
+	}{
+		{"unreachable repo", utils.PkgZypper, 4, "zypper lr --uri"},
+		{"no repositories", utils.PkgZypper, 6, "SUSEConnect --status"},
+		{"package in no repository", utils.PkgZypper, 104, "zypper addrepo"},
+		{"lock never cleared", utils.PkgZypper, 7, "zypper ps"},
+		{"skipped repo that was not tolerated", utils.PkgZypper, 106, "zypper refresh"},
+		{"success is left alone", utils.PkgZypper, 0, ""},
+		{"other failures are left alone", utils.PkgZypper, 8, ""},
+		{"yum is left alone", utils.PkgYum, 6, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setPackageManagerAndID(t, tt.pkgManager, "opensuse-leap")
+
+			got := withZypperHint(tt.exitCode, "zypper said something")
+			if tt.wantHint == "" {
+				if got != "zypper said something" {
+					t.Errorf("expected the output untouched, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantHint) {
+				t.Errorf("expected a hint mentioning %q, got %q", tt.wantHint, got)
+			}
+			if !strings.HasPrefix(got, "zypper said something") {
+				t.Errorf("the hint must follow zypper's own output, got %q", got)
+			}
+		})
+	}
+}
+
+// The refresh runs before the update and returns on its own, so its failures need
+// the hint too.
+func TestSystemHandler_Upgrade_ZypperRefreshFailureCarriesTheHint(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+	setPackageManagerAndID(t, utils.PkgZypper, "sles")
+	mockExec.SetResult("zypper --non-interactive refresh", 6, "No repositories defined.", errors.New("exit status 6"))
+
+	exitCode, output, _ := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if exitCode != 6 {
+		t.Fatalf("expected exit 6, got %d", exitCode)
+	}
+	if !strings.Contains(output, "SUSEConnect --status") {
+		t.Errorf("expected the subscription hint, got %q", output)
+	}
+}

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -104,6 +104,39 @@ func (m *MockAPISession) lastDeleteURL() string {
 	return m.DeleteCalls[len(m.DeleteCalls)-1]
 }
 
+// Reports the zypper lock exit code for the first lockedRuns `zypper` commands,
+// then defers to the mock, whose one fixed result per command cannot express
+// "locked now, free on the retry".
+type lockedThenFreeExecutor struct {
+	*common.MockCommandExecutor
+	lockedRuns int
+	calls      int
+}
+
+func (e *lockedThenFreeExecutor) zypperLocked(args []string) bool {
+	joined := strings.Join(args, " ")
+	// `zypper lr` does not take the libzypp lock, measured on opensuse/leap:15.
+	if !strings.Contains(joined, "zypper") || strings.Contains(joined, " lr ") {
+		return false
+	}
+	e.calls++
+	return e.calls <= e.lockedRuns
+}
+
+func (e *lockedThenFreeExecutor) Exec(ctx context.Context, args []string, username, groupname string, env map[string]string, timeout time.Duration) (int, string, error) {
+	if e.zypperLocked(args) {
+		return 7, "System management is locked by the application with pid 1234", errors.New("exit status 7")
+	}
+	return e.MockCommandExecutor.Exec(ctx, args, username, groupname, env, timeout)
+}
+
+func (e *lockedThenFreeExecutor) RunAsUser(ctx context.Context, username string, name string, args ...string) (int, string, error) {
+	if e.zypperLocked(args) {
+		return 7, "System management is locked by the application with pid 1234", errors.New("exit status 7")
+	}
+	return e.MockCommandExecutor.RunAsUser(ctx, username, name, args...)
+}
+
 func TestSystemHandler_Name(t *testing.T) {
 	mockExec := common.NewMockCommandExecutor(t)
 	mockWS := &MockWSClient{}
@@ -1314,5 +1347,85 @@ func TestSystemHandler_Uninstall_UsesZypper(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected a zypper remove command, got %+v", mockExec.GetExecutedCommands())
+	}
+}
+
+func TestRetryWhileZypperLocked(t *testing.T) {
+	orig := zypperLockRetryDelay
+	zypperLockRetryDelay = 0
+	t.Cleanup(func() { zypperLockRetryDelay = orig })
+
+	tests := []struct {
+		name       string
+		pkgManager string
+		lockedRuns int
+		wantCalls  int
+		wantExit   int
+	}{
+		{"retries until the lock clears", utils.PkgZypper, 1, 2, 0},
+		{"gives up after the attempt cap", utils.PkgZypper, 99, zypperLockAttempts, 7},
+		// apt has no ZYPP_LOCKED, so 7 there is a real failure to report as-is.
+		{"apt exit 7 is not retried", utils.PkgApt, 99, 1, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setPackageManagerAndID(t, tt.pkgManager, "opensuse-leap")
+
+			var calls int
+			exitCode, _, _ := retryWhileZypperLocked(context.Background(), func() (int, string, error) {
+				calls++
+				if calls <= tt.lockedRuns {
+					return 7, "locked", errors.New("exit status 7")
+				}
+				return 0, "", nil
+			})
+
+			if calls != tt.wantCalls {
+				t.Errorf("expected %d attempts, got %d", tt.wantCalls, calls)
+			}
+			if exitCode != tt.wantExit {
+				t.Errorf("expected exit %d, got %d", tt.wantExit, exitCode)
+			}
+		})
+	}
+}
+
+// A console update racing the agent's own upgrade, or packagekit holding the
+// lock, must not surface as a failed command when the lock clears.
+func TestSystemHandler_ZypperLockIsRetried(t *testing.T) {
+	orig := zypperLockRetryDelay
+	zypperLockRetryDelay = 0
+	t.Cleanup(func() { zypperLockRetryDelay = orig })
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"system update", common.Update.String()},
+		{"agent upgrade", common.Upgrade.String()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := &lockedThenFreeExecutor{MockCommandExecutor: common.NewMockCommandExecutor(t), lockedRuns: 1}
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+			exitCode, _, _ := handler.Execute(context.Background(), tt.command, &common.CommandArgs{})
+			if exitCode != 0 {
+				t.Errorf("expected the retry to recover, got exit %d", exitCode)
+			}
+			if mockExec.calls < 2 {
+				t.Errorf("expected a retry, got %d lockable calls", mockExec.calls)
+			}
+		})
 	}
 }

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -581,10 +581,17 @@ func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
 	}
 }
 
-// TestSystemHandler_Upgrade_SelfUpdate: darwin and windows route handleUpgrade through selfUpdateFn instead of returning "not supported".
+// Both axes are set explicitly: leaving PackageManager at its zero value would
+// pass by accident.
 func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
-	for _, platform := range []string{"darwin", "windows"} {
-		t.Run(platform, func(t *testing.T) {
+	for _, tc := range []struct {
+		platformLike   string
+		packageManager string
+	}{
+		{"darwin", utils.PkgBrew},
+		{"windows", utils.PkgNone},
+	} {
+		t.Run(tc.platformLike, func(t *testing.T) {
 			mockExec := common.NewMockCommandExecutor(t)
 			mockWS := &MockWSClient{}
 			ctxManager := agent.NewContextManager()
@@ -607,8 +614,9 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 			}
 
 			originalPlatformLike := utils.PlatformLike
-			utils.SetPlatformLike(platform)
+			utils.SetPlatformLike(tc.platformLike)
 			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+			setPackageManagerAndID(t, tc.packageManager, "")
 
 			exitCode, output, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
 
@@ -616,7 +624,7 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !called {
-				t.Errorf("expected selfUpdateFn to be called on %s", platform)
+				t.Errorf("expected selfUpdateFn to be called on %s", tc.platformLike)
 			}
 			if gotVersion != "v9.9.9" {
 				t.Errorf("expected self-update version v9.9.9, got %q", gotVersion)
@@ -625,7 +633,7 @@ func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 				t.Errorf("expected exit code 0, got %d", exitCode)
 			}
 			if strings.Contains(output, "not supported") {
-				t.Errorf("%s should route to self-update, got %q", platform, output)
+				t.Errorf("%s should route to self-update, got %q", tc.platformLike, output)
 			}
 		})
 	}
@@ -693,5 +701,137 @@ func TestSystemHandler_SelfUpdate_RestartScheduleFails(t *testing.T) {
 	}
 	if mockWS.RestartCalled {
 		t.Error("restart must not fire when scheduling failed")
+	}
+}
+
+func setPackageManagerAndID(t *testing.T, pkgManager, platformID string) {
+	t.Helper()
+	origPM := utils.PackageManager
+	origID := utils.PlatformID
+	utils.SetPackageManager(pkgManager)
+	utils.SetPlatformID(platformID)
+	t.Cleanup(func() {
+		utils.SetPackageManager(origPM)
+		utils.SetPlatformID(origID)
+	})
+}
+
+// openSUSE/SLES report platform_like=rhel but must run zypper locally, which is
+// why PackageManager is a separate axis.
+func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	var found bool
+	for _, c := range mockExec.GetExecutedCommands() {
+		joined := strings.Join(c.Args, " ")
+		if strings.Contains(joined, "zypper --non-interactive update alpamon") {
+			found = true
+			// Against stale metadata a bare `update` exits 0 without upgrading,
+			// so the refresh must survive refactors.
+			if !strings.Contains(joined, "refresh && zypper --non-interactive update alpamon") {
+				t.Errorf("update must be preceded by a refresh: %q", joined)
+			}
+		}
+		if strings.Contains(joined, "yum ") || strings.Contains(joined, "apt-get ") {
+			t.Errorf("zypper host must not run yum/apt: %q", joined)
+		}
+	}
+	if !found {
+		t.Errorf("expected a zypper update command, got %+v", mockExec.GetExecutedCommands())
+	}
+}
+
+// Leap/SLES must NOT use dup: it would jump to the next service pack.
+func TestSystemHandler_SystemUpdate_ZypperDupOnlyOnTumbleweed(t *testing.T) {
+	tests := []struct {
+		name       string
+		platformID string
+		wantCmd    string
+		rejectCmd  string
+	}{
+		{"tumbleweed", "opensuse-tumbleweed", "zypper --non-interactive dup", "zypper --non-interactive update"},
+		{"leap", "opensuse-leap", "zypper --non-interactive update", "zypper --non-interactive dup"},
+		{"sles", "sles", "zypper --non-interactive update", "zypper --non-interactive dup"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{}, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, tt.platformID)
+
+			if _, _, err := handler.Execute(context.Background(), common.Update.String(), &common.CommandArgs{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var found bool
+			for _, c := range mockExec.GetExecutedCommands() {
+				joined := strings.Join(c.Args, " ")
+				if strings.Contains(joined, tt.rejectCmd) {
+					t.Fatalf("%s must not run %q", tt.name, tt.rejectCmd)
+				}
+				if strings.Contains(joined, tt.wantCmd) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected %q, got %+v", tt.wantCmd, mockExec.GetExecutedCommands())
+			}
+		})
+	}
+}
+
+// Asserts against every captured command: the uninstall is scheduled through
+// systemd-run where systemd exists and a deferred subshell where it does not, so
+// the zypper string lands in different argv positions per host.
+func TestSystemHandler_Uninstall_UsesZypper(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+	handler.executeUninstall()
+
+	var found bool
+	for _, c := range mockExec.GetExecutedCommands() {
+		joined := strings.Join(c.Args, " ")
+		if strings.Contains(joined, "zypper --non-interactive remove alpamon") {
+			found = true
+		}
+		if strings.Contains(joined, "yum remove") || strings.Contains(joined, "apt-get purge") {
+			t.Errorf("zypper host must not run yum/apt: %q", joined)
+		}
+	}
+	if !found {
+		t.Errorf("expected a zypper remove command, got %+v", mockExec.GetExecutedCommands())
 	}
 }

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -581,8 +581,8 @@ func TestSystemHandler_UnregisterFromConsole_DeleteError(t *testing.T) {
 	}
 }
 
-// Both axes are set explicitly: leaving PackageManager at its zero value would
-// pass by accident.
+// Both axes are set explicitly. PkgNone is a non-empty sentinel, so a
+// zero-value PackageManager would hit the unsupported branch, not pass here.
 func TestSystemHandler_Upgrade_SelfUpdate(t *testing.T) {
 	for _, tc := range []struct {
 		platformLike   string

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -1011,6 +1011,87 @@ func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
 	}
 }
 
+// A kernel or zypper self-update ends the command with an informational code,
+// which must not reach the console as a failure.
+func TestSystemHandler_SystemUpdate_ZypperInformationalExitCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		pkgManager string
+		platformID string
+		cmd        string
+		exitCode   int
+		want       int
+	}{
+		{"reboot needed", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 102, 0},
+		{"package manager restart needed", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 103, 0},
+		// Informational does not mean successful; see docs/opensuse.md.
+		{"patch-check code stays a failure", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 100, 100},
+		{"capability not found stays a failure", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 104, 104},
+		{"skipped repo stays a failure", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 106, 106},
+		{"failed post script stays a failure", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 107, 107},
+		{"unreachable repo stays a failure", utils.PkgZypper, "opensuse-leap", "zypper --non-interactive refresh && zypper --non-interactive update", 4, 4},
+		// apt has no informational family, so 102 there is a real failure.
+		{"apt is untouched", utils.PkgApt, "ubuntu", "apt-get update -o Acquire::Retries=3 && apt-get upgrade -y -o Acquire::Retries=3 && apt-get autoremove -y", 102, 102},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{}, nil)
+			setPackageManagerAndID(t, tt.pkgManager, tt.platformID)
+			mockExec.SetResult("sh -c "+tt.cmd, tt.exitCode, "", errors.New("exit status"))
+
+			exitCode, _, err := handler.Execute(context.Background(), common.Update.String(), &common.CommandArgs{})
+			if exitCode != tt.want {
+				t.Errorf("exit %d: expected %d, got %d", tt.exitCode, tt.want, exitCode)
+			}
+			if tt.want == 0 && err != nil {
+				t.Errorf("a normalized exit must drop the error, got %v", err)
+			}
+			if tt.want != 0 && err == nil {
+				t.Error("a real failure must keep its error")
+			}
+		})
+	}
+}
+
+// The agent's own upgrade shares the normalization, where the exit code also
+// gates the pam version cache invalidation.
+func TestSystemHandler_Upgrade_ZypperRebootNeededIsSuccess(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: "v1.0.0"}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+
+	mockExec.SetResult(
+		"sh -c zypper --non-interactive refresh && zypper --non-interactive update alpamon alpamon-pam",
+		102, "", errors.New("exit status 102"),
+	)
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0 for reboot-needed, got %d", exitCode)
+	}
+	if err != nil {
+		t.Errorf("a normalized exit must drop the error, got %v", err)
+	}
+	if !mockVersions.InvalidatePamCalled {
+		t.Error("pam cache must be invalidated when the upgrade succeeded")
+	}
+}
+
 // Leap/SLES must NOT use dup: it would jump to the next service pack.
 func TestSystemHandler_SystemUpdate_ZypperDupOnlyOnTumbleweed(t *testing.T) {
 	tests := []struct {

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -1517,3 +1517,66 @@ func TestSystemHandler_Upgrade_NoVersionProbeOnApt(t *testing.T) {
 		t.Error("apt host must not run rpm")
 	}
 }
+
+// SLES 12, which the SUSE prefixes accept, ships systemd 228 and so rejects
+// --collect. Retrying without it keeps the removal scheduled instead of falling
+// back to a synchronous one that tears the agent down mid-command.
+func TestSystemHandler_Uninstall_RetriesWithoutCollect(t *testing.T) {
+	orig := hasSystemd
+	hasSystemd = func() bool { return true }
+	t.Cleanup(func() { hasSystemd = orig })
+
+	tests := []struct {
+		name            string
+		plainScheduleOK bool
+		wantSyncRemoval bool
+	}{
+		{"retry schedules the removal", true, false},
+		{"both attempts fail, removal runs synchronously", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
+			handler.uninstallDelay = time.Millisecond
+			handler.uninstallDone = make(chan struct{})
+			setPackageManagerAndID(t, utils.PkgZypper, "sles")
+
+			schedule := "--uid=0 --gid=0 --unit=alpamon-uninstall --timer-property=OnActiveSec=5 --timer-property=AccuracySec=1s --description=Alpamon Uninstall Service /bin/sh -c zypper --non-interactive remove alpamon; systemctl reset-failed alpamon-uninstall.service 2>/dev/null || true; systemctl reset-failed alpamon-uninstall.timer 2>/dev/null || true"
+			mockExec.SetResult("systemd-run --collect "+schedule, 1, "unrecognized option '--collect'", errors.New("exit status 1"))
+			if !tt.plainScheduleOK {
+				mockExec.SetResult("systemd-run "+schedule, 1, "failed", errors.New("exit status 1"))
+			}
+
+			if _, _, err := handler.Execute(context.Background(), common.ByeBye.String(), &common.CommandArgs{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			<-handler.uninstallDone
+
+			var retried, syncRemoval bool
+			for _, c := range mockExec.GetExecutedCommands() {
+				joined := c.Name + " " + strings.Join(c.Args, " ")
+				switch {
+				case joined == "systemd-run "+schedule:
+					retried = true
+				case c.Name == "sh" && strings.Contains(joined, "zypper --non-interactive remove alpamon") &&
+					!strings.Contains(joined, "systemd-run"):
+					syncRemoval = true
+				}
+			}
+			if !retried {
+				t.Errorf("expected a retry without --collect, got %+v", mockExec.GetExecutedCommands())
+			}
+			if syncRemoval != tt.wantSyncRemoval {
+				t.Errorf("synchronous removal = %v, want %v", syncRemoval, tt.wantSyncRemoval)
+			}
+		})
+	}
+}

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -991,23 +991,171 @@ func TestSystemHandler_Upgrade_UsesZypper(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
 
-	var found bool
-	for _, c := range mockExec.GetExecutedCommands() {
-		joined := strings.Join(c.Args, " ")
+	refreshedAt, updatedAt := -1, -1
+	for i, c := range mockExec.GetExecutedCommands() {
+		joined := c.Name + " " + strings.Join(c.Args, " ")
+		if strings.Contains(joined, "zypper --non-interactive refresh") {
+			refreshedAt = i
+		}
 		if strings.Contains(joined, "zypper --non-interactive update alpamon") {
-			found = true
-			// Against stale metadata a bare `update` exits 0 without upgrading,
-			// so the refresh must survive refactors.
-			if !strings.Contains(joined, "refresh && zypper --non-interactive update alpamon") {
-				t.Errorf("update must be preceded by a refresh: %q", joined)
-			}
+			updatedAt = i
 		}
 		if strings.Contains(joined, "yum ") || strings.Contains(joined, "apt-get ") {
 			t.Errorf("zypper host must not run yum/apt: %q", joined)
 		}
 	}
-	if !found {
-		t.Errorf("expected a zypper update command, got %+v", mockExec.GetExecutedCommands())
+	if updatedAt < 0 {
+		t.Fatalf("expected a zypper update command, got %+v", mockExec.GetExecutedCommands())
+	}
+	// Against stale metadata a bare `update` exits 0 without upgrading, so the
+	// refresh must survive refactors.
+	if refreshedAt < 0 || refreshedAt > updatedAt {
+		t.Errorf("update must be preceded by a refresh, got %+v", mockExec.GetExecutedCommands())
+	}
+}
+
+// One unreachable repo anywhere on the host exits an unscoped refresh 4, so the
+// chained update never runs. Scoping both halves to alpamon's own repo is what
+// keeps a dead third-party repo from making the agent unupgradable.
+func TestSystemHandler_Upgrade_ScopesZypperToAlpamonRepo(t *testing.T) {
+	const alpamonSection = "[alpamon]\nenabled=1\nautorefresh=1\nbaseurl=https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch\n"
+	const deadSection = "[deadrepo]\nenabled=1\nautorefresh=0\nbaseurl=http://dead.invalid.example/repo\n"
+
+	tests := []struct {
+		name        string
+		repoExport  string
+		wantRefresh string
+	}{
+		{
+			name:        "refresh is scoped to the resolved alias",
+			repoExport:  deadSection + "\n" + alpamonSection,
+			wantRefresh: "zypper --non-interactive refresh alpamon",
+		},
+		{
+			name:        "operator alias is honored",
+			repoExport:  "[alpacax-alpamon]\nenabled=1\nbaseurl=https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch\n",
+			wantRefresh: "zypper --non-interactive refresh alpacax-alpamon",
+		},
+		{
+			name:        "no alpamon repo falls back to an unscoped refresh",
+			repoExport:  deadSection,
+			wantRefresh: "zypper --non-interactive refresh",
+		},
+		{
+			// A disabled repo serves nothing, so scoping to it would turn a
+			// working upgrade into a failing one.
+			name:        "disabled alpamon repo falls back",
+			repoExport:  "[alpamon]\nenabled=0\nbaseurl=https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch\n",
+			wantRefresh: "zypper --non-interactive refresh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+			mockExec.SetResult("zypper --non-interactive lr --export -", 0, tt.repoExport, nil)
+
+			if _, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var refreshed, updated bool
+			for _, c := range mockExec.GetExecutedCommands() {
+				switch c.Name + " " + strings.Join(c.Args, " ") {
+				case tt.wantRefresh:
+					refreshed = true
+				// `update -r <alias>` would load only that repo and fail to
+				// resolve dependencies from the distribution repos.
+				case "sh -c zypper --non-interactive update alpamon":
+					updated = true
+				}
+			}
+			if !refreshed {
+				t.Errorf("expected %q, got %+v", tt.wantRefresh, mockExec.GetExecutedCommands())
+			}
+			if !updated {
+				t.Errorf("expected an unscoped update, got %+v", mockExec.GetExecutedCommands())
+			}
+		})
+	}
+}
+
+// The refresh exists to keep a stale-metadata no-op from reporting success, so
+// its failure must stop the upgrade instead of falling through to the update.
+func TestSystemHandler_Upgrade_ZypperRefreshFailureStopsTheUpgrade(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+	setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+	mockExec.SetResult("zypper --non-interactive refresh", 4, "repo error", errors.New("exit status 4"))
+
+	exitCode, _, _ := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if exitCode != 4 {
+		t.Errorf("expected the refresh exit code 4, got %d", exitCode)
+	}
+	for _, c := range mockExec.GetExecutedCommands() {
+		if strings.Contains(strings.Join(c.Args, " "), "update") {
+			t.Errorf("update must not run after a failed refresh: %+v", c)
+		}
+	}
+}
+
+// A repo skipped elsewhere on the host cannot hide a missed alpamon update once
+// alpamon's own repo has been refreshed on its own, so 106 is success there and
+// a failure when there was nothing to scope to.
+func TestSystemHandler_Upgrade_ZypperSkippedRepoDependsOnScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		repoExport string
+		want       int
+	}{
+		{
+			name:       "scoped refresh tolerates a skipped repo",
+			repoExport: "[alpamon]\nenabled=1\nbaseurl=https://packagecloud.io/alpacax/alpamon/rpm_any/rpm_any/$basearch\n",
+			want:       0,
+		},
+		{
+			name:       "unscoped refresh does not",
+			repoExport: "[repo-oss]\nenabled=1\nbaseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/\n",
+			want:       106,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", PamVersion: ""}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+			setPackageManagerAndID(t, utils.PkgZypper, "opensuse-leap")
+			mockExec.SetResult("zypper --non-interactive lr --export -", 0, tt.repoExport, nil)
+			mockExec.SetResult("sh -c zypper --non-interactive update alpamon", 106, "", errors.New("exit status 106"))
+
+			exitCode, _, _ := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+			if exitCode != tt.want {
+				t.Errorf("expected %d, got %d", tt.want, exitCode)
+			}
+		})
 	}
 }
 

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -1549,7 +1549,7 @@ func TestSystemHandler_Uninstall_RetriesWithoutCollect(t *testing.T) {
 			handler.uninstallDone = make(chan struct{})
 			setPackageManagerAndID(t, utils.PkgZypper, "sles")
 
-			schedule := "--uid=0 --gid=0 --unit=alpamon-uninstall --timer-property=OnActiveSec=5 --timer-property=AccuracySec=1s --description=Alpamon Uninstall Service /bin/sh -c zypper --non-interactive remove alpamon; systemctl reset-failed alpamon-uninstall.service 2>/dev/null || true; systemctl reset-failed alpamon-uninstall.timer 2>/dev/null || true"
+			schedule := "--uid=0 --gid=0 --unit=alpamon-uninstall --on-active=5 --timer-property=AccuracySec=1s --description=Alpamon Uninstall Service /bin/sh -c zypper --non-interactive remove alpamon; systemctl reset-failed alpamon-uninstall.service 2>/dev/null || true; systemctl reset-failed alpamon-uninstall.timer 2>/dev/null || true"
 			mockExec.SetResult("systemd-run --collect "+schedule, 1, "unrecognized option '--collect'", errors.New("exit status 1"))
 			if !tt.plainScheduleOK {
 				mockExec.SetResult("systemd-run "+schedule, 1, "failed", errors.New("exit status 1"))

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -297,13 +297,20 @@ func ScheduleSelfRestart(delay time.Duration) error {
 	}
 	secs := int(delay.Seconds())
 	unit := fmt.Sprintf("alpamon-restart-%d", time.Now().UnixNano())
-	cmd := exec.Command("systemd-run",
+	schedule := []string{
 		fmt.Sprintf("--on-active=%ds", secs),
-		"--collect",
 		"--unit", unit,
 		"systemctl", "restart", "alpamon",
-	)
-	out, err := cmd.CombinedOutput()
+	}
+
+	// --collect needs systemd 236 and SLES 12, which alpamon classifies, ships
+	// 228: `systemd-run: unrecognized option '--collect'`, measured on 228 and
+	// 229. Without the retry the migration commits its config swap and then has
+	// no way to restart into it, leaving the rollback watchdog as the only exit.
+	out, err := exec.Command("systemd-run", append([]string{"--collect"}, schedule...)...).CombinedOutput()
+	if err != nil {
+		out, err = exec.Command("systemd-run", schedule...).CombinedOutput()
+	}
 	if err != nil {
 		return fmt.Errorf("systemd-run: %w: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -299,6 +299,9 @@ func ScheduleSelfRestart(delay time.Duration) error {
 	unit := fmt.Sprintf("alpamon-restart-%d", time.Now().UnixNano())
 	schedule := []string{
 		fmt.Sprintf("--on-active=%ds", secs),
+		// Without this the default AccuracySec of 1min lets systemd coalesce
+		// the trigger up to a minute past the requested delay.
+		"--timer-property=AccuracySec=1s",
 		"--unit", unit,
 		"systemctl", "restart", "alpamon",
 	}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -12,18 +12,18 @@ import (
 // both the Websh PTY path and the exec/shell path so the two stay in sync.
 const DefaultLSColors = `rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:`
 
-// LoadEtcEnvironment parses /etc/environment and merges system-wide
-// environment variables into the provided map. This supplements the PAM
-// pam_env module, which is not invoked for non-login execution paths such as
-// Websh PTY sessions and demoted exec/shell commands. The path is resolved via
-// EnvironmentFilePath and is empty (a no-op) on platforms without an
-// /etc/environment equivalent.
+// LoadEtcEnvironment merges the system-wide environment files into env,
+// supplementing the PAM pam_env module, which is not invoked for non-login
+// execution paths such as Websh PTY sessions and demoted exec/shell commands.
+// EnvironmentFilePaths orders them so a later file overrides an earlier one, and
+// is empty on platforms with no /etc/environment equivalent.
 func LoadEtcEnvironment(env map[string]string) {
-	envFilePath := EnvironmentFilePath()
-	if envFilePath == "" {
-		return
+	for _, path := range EnvironmentFilePaths() {
+		loadEnvironmentFile(path, env)
 	}
+}
 
+func loadEnvironmentFile(envFilePath string, env map[string]string) {
 	file, err := os.Open(envFilePath)
 	if err != nil {
 		return

--- a/pkg/utils/env_test.go
+++ b/pkg/utils/env_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLoadEnvironmentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "environment")
+	content := "# comment\n\nPATH=/usr/bin\nLANG=\"en_US.UTF-8\"\n  HTTP_PROXY = http://proxy:3128  \nnot-an-assignment\n=novalue\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	env := map[string]string{}
+	loadEnvironmentFile(path, env)
+
+	want := map[string]string{
+		"PATH":       "/usr/bin",
+		"LANG":       "en_US.UTF-8",
+		"HTTP_PROXY": "http://proxy:3128",
+	}
+	if len(env) != len(want) {
+		t.Errorf("expected %d entries, got %v", len(want), env)
+	}
+	for key, value := range want {
+		if env[key] != value {
+			t.Errorf("%s = %q, want %q", key, env[key], value)
+		}
+	}
+}
+
+func TestLoadEnvironmentFile_MissingFileIsANoOp(t *testing.T) {
+	env := map[string]string{"KEEP": "1"}
+	loadEnvironmentFile(filepath.Join(t.TempDir(), "absent"), env)
+	if len(env) != 1 || env["KEEP"] != "1" {
+		t.Errorf("expected env untouched, got %v", env)
+	}
+}
+
+// Vendor defaults load first so an admin copy overrides them, which is what the
+// EnvironmentFilePaths order encodes.
+func TestLoadEnvironmentFile_LaterFileOverrides(t *testing.T) {
+	dir := t.TempDir()
+	vendor := filepath.Join(dir, "usr-etc")
+	admin := filepath.Join(dir, "etc")
+	if err := os.WriteFile(vendor, []byte("PATH=/vendor\nONLY_VENDOR=1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(admin, []byte("PATH=/admin\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	env := map[string]string{}
+	for _, path := range []string{vendor, admin} {
+		loadEnvironmentFile(path, env)
+	}
+
+	if env["PATH"] != "/admin" {
+		t.Errorf("PATH = %q, want the admin value", env["PATH"])
+	}
+	if env["ONLY_VENDOR"] != "1" {
+		t.Errorf("a vendor-only entry must survive, got %v", env)
+	}
+}
+
+// Tumbleweed and the transactional variants ship /usr/etc/environment and no
+// /etc/environment at all, so both paths are read, vendor first.
+func TestEnvironmentFilePaths_Linux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("no /etc/environment equivalent on %s", runtime.GOOS)
+	}
+
+	paths := EnvironmentFilePaths()
+	if len(paths) != 2 || paths[0] != "/usr/etc/environment" || paths[1] != "/etc/environment" {
+		t.Errorf("expected the vendor path first, got %v", paths)
+	}
+}

--- a/pkg/utils/paths_darwin.go
+++ b/pkg/utils/paths_darwin.go
@@ -25,6 +25,6 @@ func DefaultPath() string {
 	return "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/homebrew/bin"
 }
 
-// EnvironmentFilePath returns the path to the system environment file.
-// macOS does not use /etc/environment; returns empty to skip loading.
-func EnvironmentFilePath() string { return "" }
+// EnvironmentFilePaths returns the system environment files.
+// macOS has no /etc/environment equivalent, so there is nothing to load.
+func EnvironmentFilePaths() []string { return nil }

--- a/pkg/utils/paths_linux.go
+++ b/pkg/utils/paths_linux.go
@@ -23,5 +23,9 @@ func DefaultPath() string {
 	return "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 }
 
-// EnvironmentFilePath returns the path to the system environment file.
-func EnvironmentFilePath() string { return "/etc/environment" }
+// EnvironmentFilePaths returns the system environment files, vendor defaults
+// first: Tumbleweed and the transactional variants keep theirs in /usr/etc and
+// ship no /etc/environment at all, where an admin copy overrides it.
+func EnvironmentFilePaths() []string {
+	return []string{"/usr/etc/environment", "/etc/environment"}
+}

--- a/pkg/utils/paths_windows.go
+++ b/pkg/utils/paths_windows.go
@@ -33,5 +33,5 @@ func DefaultShellArgs() []string { return []string{"-NoLogo"} }
 // DefaultPath returns the system PATH on Windows.
 func DefaultPath() string { return os.Getenv("PATH") }
 
-// EnvironmentFilePath returns empty on Windows (no /etc/environment equivalent).
-func EnvironmentFilePath() string { return "" }
+// EnvironmentFilePaths returns nothing on Windows (no /etc/environment equivalent).
+func EnvironmentFilePaths() []string { return nil }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -101,6 +101,25 @@ func ValidateServerPlatform(goos, p string) error {
 	return nil
 }
 
+// The warning covers what ValidateServerPlatform cannot catch: --platform debian passes on an openSUSE host, and then the server composes apt while the agent runs zypper. A warning rather than an error because the override may be correcting a real misdetection.
+func ResolveServerPlatform(goos, explicit string, detect func() (string, error)) (platform, warning string, err error) {
+	if explicit == "" {
+		detected, derr := detect()
+		return detected, "", derr
+	}
+	if verr := ValidateServerPlatform(goos, explicit); verr != nil {
+		return "", "", verr
+	}
+	// A failed detection is why --platform exists, so it must not warn.
+	if detected, derr := detect(); derr == nil && detected != explicit {
+		return explicit, fmt.Sprintf(
+			"Warning: --platform %s disagrees with the detected platform %s.\n"+
+				"Server.platform is write-once, so if the override is wrong, the only fix "+
+				"is to register the host again.", explicit, detected), nil
+	}
+	return explicit, "", nil
+}
+
 // The value register and migrate send; errors instead of defaulting because the server persists it write-once, fixable only by re-registering.
 func DetectRegistrationPlatform() (string, error) {
 	var raw string

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -37,13 +37,13 @@ var platformAliases = map[string]string{
 // Mirrors SUSE_PLATFORM_PREFIXES; prefix-matched because the ids proliferate (opensuse-microos, sle-micro, sle_hpc) and gopsutil's exact-match PlatformFamily returns "" for several.
 var susePrefixes = []string{"opensuse", "sle", "suse"}
 
-// Exported so the switches in pkg/executor/handlers/system are compiler-checked; PkgNone names windows, which has no package channel and self-updates the binary instead.
+// Exported so the switches in pkg/executor/handlers/system are compiler-checked; PkgNone (windows self-updates) is non-empty so a zero value falls to default instead of that arm.
 const (
 	PkgApt    = "apt"
 	PkgYum    = "yum"
 	PkgZypper = "zypper"
 	PkgBrew   = "brew"
-	PkgNone   = ""
+	PkgNone   = "none"
 )
 
 // Pure, so the table is testable without a host; ok=false must never be defaulted by callers (see platformAliases).

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -1,0 +1,125 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+// Three axes because on SUSE the reported value (PlatformLike=rhel, per SERVER_PLATFORMS) and the local command (PackageManager=zypper) disagree; PlatformID keeps the raw id for the Tumbleweed branch.
+var (
+	PlatformLike   string
+	PackageManager string
+	PlatformID     string
+)
+
+// Mirrors alpacon-server servers/constants.py PLATFORM_ALIASES 1:1 — never add ids the server lacks: write-once Server.platform makes a divergence permanent.
+var platformAliases = map[string]string{
+	"debian":    "debian",
+	"ubuntu":    "debian",
+	"raspbian":  "debian",
+	"rhel":      "rhel",
+	"centos":    "rhel",
+	"redhat":    "rhel",
+	"amazon":    "rhel",
+	"amzn":      "rhel",
+	"fedora":    "rhel",
+	"rocky":     "rhel",
+	"almalinux": "rhel",
+	"oracle":    "rhel",
+	"ol":        "rhel",
+}
+
+// Mirrors SUSE_PLATFORM_PREFIXES; prefix-matched because the ids proliferate (opensuse-microos, sle-micro, sle_hpc) and gopsutil's exact-match PlatformFamily returns "" for several.
+var susePrefixes = []string{"opensuse", "sle", "suse"}
+
+// Exported so the switches in pkg/executor/handlers/system are compiler-checked; PkgNone names windows, which has no package channel and self-updates the binary instead.
+const (
+	PkgApt    = "apt"
+	PkgYum    = "yum"
+	PkgZypper = "zypper"
+	PkgBrew   = "brew"
+	PkgNone   = ""
+)
+
+// Pure, so the table is testable without a host; ok=false must never be defaulted by callers (see platformAliases).
+func ResolvePlatform(goos, rawPlatform string) (like, pkgManager string, ok bool) {
+	switch goos {
+	case "darwin":
+		return "darwin", PkgBrew, true
+	case "windows":
+		return "windows", PkgNone, true
+	case "linux":
+		// fall through
+	default:
+		return "", "", false
+	}
+
+	id := strings.ToLower(strings.TrimSpace(rawPlatform))
+	if id == "" {
+		return "", "", false
+	}
+
+	for _, prefix := range susePrefixes {
+		if strings.HasPrefix(id, prefix) {
+			return "rhel", PkgZypper, true
+		}
+	}
+
+	switch platformAliases[id] {
+	case "debian":
+		return "debian", PkgApt, true
+	case "rhel":
+		return "rhel", PkgYum, true
+	}
+	return "", "", false
+}
+
+// Classifies the host once at startup; unclassifiable is fatal because every handler switches on these values and guessing would misreport to the server.
+func InitPlatform() {
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to retrieve platform information.")
+			os.Exit(1)
+		}
+		raw = info.Platform
+	}
+
+	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
+	if !ok {
+		log.Fatal().Msgf(
+			"Unsupported platform: os=%s distribution=%q. "+
+				"alpamon supports debian- and rhel-family Linux distributions "+
+				"(including openSUSE/SLES), macOS, and Windows.",
+			runtime.GOOS, raw)
+	}
+
+	PlatformLike = like
+	PackageManager = pkgManager
+	PlatformID = raw
+}
+
+// SetPlatformLike sets PlatformLike for tests.
+func SetPlatformLike(platform string) {
+	PlatformLike = platform
+}
+
+// SetPackageManager sets PackageManager for tests.
+func SetPackageManager(pm string) {
+	PackageManager = pm
+}
+
+// SetPlatformID sets PlatformID for tests.
+func SetPlatformID(id string) {
+	PlatformID = id
+}
+
+// Lives beside susePrefixes so both SUSE id decisions normalize case alike; why the caller cares is at the call site.
+func IsTumbleweed(id string) bool {
+	return strings.Contains(strings.ToLower(id), "tumbleweed")
+}

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -76,6 +77,36 @@ func ResolvePlatform(goos, rawPlatform string) (like, pkgManager string, ok bool
 		return "rhel", PkgYum, true
 	}
 	return "", "", false
+}
+
+// The value register and migrate send; errors instead of defaulting because the server persists it write-once, fixable only by re-registering.
+func DetectRegistrationPlatform() (string, error) {
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			return "", fmt.Errorf(
+				"failed to detect the host platform: %w.\n"+
+					"Pass --platform debian|rhel to skip detection if you know the host is compatible",
+				err)
+		}
+		raw = info.Platform
+	}
+	return ResolveRegistrationPlatform(runtime.GOOS, raw)
+}
+
+// DetectRegistrationPlatform's pure half, so the mapping and its error text are testable without a host.
+func ResolveRegistrationPlatform(goos, raw string) (string, error) {
+	like, _, ok := ResolvePlatform(goos, raw)
+	if !ok {
+		return "", fmt.Errorf(
+			"unrecognized Linux distribution %q.\n"+
+				"alpamon supports debian- and rhel-family distributions, "+
+				"including openSUSE/SLES.\n"+
+				"Pass --platform debian|rhel to override if you know the host is compatible",
+			raw)
+	}
+	return like, nil
 }
 
 // Classifies the host once at startup; unclassifiable is fatal because every handler switches on these values and guessing would misreport to the server.

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -79,19 +80,23 @@ func ResolvePlatform(goos, rawPlatform string) (like, pkgManager string, ok bool
 	return "", "", false
 }
 
-// The alpacon-server SERVER_PLATFORMS set: the register endpoint gates Server.platform with a ChoiceField over exactly these.
-var serverPlatforms = map[string]bool{
-	"debian":  true,
-	"rhel":    true,
-	"darwin":  true,
-	"windows": true,
+// Which SERVER_PLATFORMS values are true per host — write-once Server.platform makes --platform windows on a Linux box permanent damage.
+var hostServerPlatforms = map[string][]string{
+	"linux":   {"debian", "rhel"},
+	"darwin":  {"darwin"},
+	"windows": {"windows"},
 }
 
-// Rejects an explicit --platform the server would reject, so the operator fails fast instead of at the registration request.
-func ValidateServerPlatform(p string) error {
-	if !serverPlatforms[p] {
+// Rejects an explicit --platform wrong for this host, failing fast instead of misclassifying the write-once record.
+func ValidateServerPlatform(goos, p string) error {
+	accepted, ok := hostServerPlatforms[goos]
+	if !ok {
+		return fmt.Errorf("unsupported os %q for --platform validation", goos)
+	}
+	if !slices.Contains(accepted, p) {
 		return fmt.Errorf(
-			"invalid --platform %q: accepted values are debian, rhel, darwin, windows", p)
+			"invalid --platform %q on %s: accepted values are %s",
+			p, goos, strings.Join(accepted, ", "))
 	}
 	return nil
 }

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -79,6 +79,23 @@ func ResolvePlatform(goos, rawPlatform string) (like, pkgManager string, ok bool
 	return "", "", false
 }
 
+// The alpacon-server SERVER_PLATFORMS set: the register endpoint gates Server.platform with a ChoiceField over exactly these.
+var serverPlatforms = map[string]bool{
+	"debian":  true,
+	"rhel":    true,
+	"darwin":  true,
+	"windows": true,
+}
+
+// Rejects an explicit --platform the server would reject, so the operator fails fast instead of at the registration request.
+func ValidateServerPlatform(p string) error {
+	if !serverPlatforms[p] {
+		return fmt.Errorf(
+			"invalid --platform %q: accepted values are debian, rhel, darwin, windows", p)
+	}
+	return nil
+}
+
 // The value register and migrate send; errors instead of defaulting because the server persists it write-once, fixable only by re-registering.
 func DetectRegistrationPlatform() (string, error) {
 	var raw string

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -114,19 +114,37 @@ func TestResolveRegistrationPlatform_UnsupportedReturnsError(t *testing.T) {
 	}
 }
 
-// --platform forwards verbatim to Server.platform, so an explicit value must be checked against the same four-value set the server gates on.
+// --platform forwards verbatim to write-once Server.platform: all four values are server-side members, but "windows" on Linux would poison the record.
 func TestValidateServerPlatform(t *testing.T) {
-	for _, p := range []string{"debian", "rhel", "darwin", "windows"} {
-		if err := ValidateServerPlatform(p); err != nil {
-			t.Errorf("ValidateServerPlatform(%q) = %v, want nil", p, err)
-		}
-	}
-	err := ValidateServerPlatform("rehl")
-	if err == nil {
-		t.Fatal("expected an error for a value the server rejects")
-	}
-	if !strings.Contains(err.Error(), "rehl") {
-		t.Errorf("error must name the rejected value, got %q", err)
+	for _, tt := range []struct {
+		goos, p string
+		ok      bool
+	}{
+		{"linux", "debian", true},
+		{"linux", "rhel", true},
+		{"darwin", "darwin", true},
+		{"windows", "windows", true},
+
+		{"linux", "windows", false},
+		{"linux", "darwin", false},
+		{"linux", "rehl", false},
+		{"darwin", "debian", false},
+		{"windows", "rhel", false},
+	} {
+		t.Run(tt.goos+"/"+tt.p, func(t *testing.T) {
+			err := ValidateServerPlatform(tt.goos, tt.p)
+			if tt.ok && err != nil {
+				t.Fatalf("ValidateServerPlatform(%q, %q) = %v, want nil", tt.goos, tt.p, err)
+			}
+			if !tt.ok {
+				if err == nil {
+					t.Fatal("expected an error for a value invalid on this host")
+				}
+				if !strings.Contains(err.Error(), tt.p) {
+					t.Errorf("error must name the rejected value, got %q", err)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,8 +1,12 @@
 package utils
 
 import (
+	"os"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/shirou/gopsutil/v4/host"
 )
 
 // Vectors mirror alpacon-server servers/test_utils.py:68-96: the 1:1 table correspondence is the contract, and write-once Server.platform makes a divergence permanent.
@@ -108,6 +112,28 @@ func TestResolveRegistrationPlatform_UnsupportedReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "--platform") {
 		t.Errorf("error must tell the operator about the override, got %q", err)
 	}
+}
+
+// Feeds ResolvePlatform what InitPlatform reads, so every CI row guards its own distro — the #348 case the pure vectors miss; CI-gated to keep local runs green off-matrix.
+func TestResolvePlatform_CIHost(t *testing.T) {
+	if os.Getenv("CI") == "" {
+		t.Skip("CI-matrix guard: host distros are only pinned supported on CI runners")
+	}
+
+	var raw string
+	if runtime.GOOS == "linux" {
+		info, err := host.Info()
+		if err != nil {
+			t.Fatalf("host.Info() failed: %v", err)
+		}
+		raw = info.Platform
+	}
+
+	like, pkgManager, ok := ResolvePlatform(runtime.GOOS, raw)
+	if !ok {
+		t.Fatalf("CI host not classified: os=%s distribution=%q", runtime.GOOS, raw)
+	}
+	t.Logf("os=%s distribution=%q -> like=%s pkgManager=%s", runtime.GOOS, raw, like, pkgManager)
 }
 
 // Both directions: a false negative skips a needed dup, a false positive runs a destructive one.

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -49,7 +49,7 @@ func TestResolvePlatform(t *testing.T) {
 
 		// non-linux: raw platform is ignored
 		{"darwin", "darwin", "darwin", "darwin", "brew"},
-		{"windows", "windows", "Microsoft Windows Server 2025 Datacenter", "windows", ""},
+		{"windows", "windows", "Microsoft Windows Server 2025 Datacenter", "windows", "none"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -114,6 +114,22 @@ func TestResolveRegistrationPlatform_UnsupportedReturnsError(t *testing.T) {
 	}
 }
 
+// --platform forwards verbatim to Server.platform, so an explicit value must be checked against the same four-value set the server gates on.
+func TestValidateServerPlatform(t *testing.T) {
+	for _, p := range []string{"debian", "rhel", "darwin", "windows"} {
+		if err := ValidateServerPlatform(p); err != nil {
+			t.Errorf("ValidateServerPlatform(%q) = %v, want nil", p, err)
+		}
+	}
+	err := ValidateServerPlatform("rehl")
+	if err == nil {
+		t.Fatal("expected an error for a value the server rejects")
+	}
+	if !strings.Contains(err.Error(), "rehl") {
+		t.Errorf("error must name the rejected value, got %q", err)
+	}
+}
+
 // Feeds ResolvePlatform what InitPlatform reads, so every CI row guards its own distro — the #348 case the pure vectors miss; CI-gated to keep local runs green off-matrix.
 func TestResolvePlatform_CIHost(t *testing.T) {
 	if os.Getenv("CI") == "" {

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"strings"
@@ -188,6 +189,62 @@ func TestIsTumbleweed(t *testing.T) {
 		t.Run(tt.id, func(t *testing.T) {
 			if got := IsTumbleweed(tt.id); got != tt.want {
 				t.Errorf("IsTumbleweed(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// ValidateServerPlatform accepts debian on any Linux host, so a contradicting
+// override is the only signal left that the write-once record is about to
+// disagree with the package manager the agent runs.
+func TestResolveServerPlatform(t *testing.T) {
+	detects := func(p string) func() (string, error) {
+		return func() (string, error) { return p, nil }
+	}
+	fails := func() (string, error) { return "", errors.New("unrecognized Linux distribution \"arch\"") }
+
+	tests := []struct {
+		name        string
+		explicit    string
+		detect      func() (string, error)
+		want        string
+		wantWarning string
+		wantErr     string
+	}{
+		{name: "detection fills an omitted platform", detect: detects("rhel"), want: "rhel"},
+		{name: "detection failure propagates", detect: fails, wantErr: "arch"},
+		{name: "override agreeing with detection is silent", explicit: "rhel", detect: detects("rhel"), want: "rhel"},
+		{
+			name: "override contradicting detection warns", explicit: "debian", detect: detects("rhel"),
+			want: "debian", wantWarning: "rhel",
+		},
+		{
+			// A failed detection is why --platform exists, so it must not warn.
+			name: "override is silent when detection fails", explicit: "debian", detect: fails, want: "debian",
+		},
+		{name: "cross-os override is rejected", explicit: "windows", detect: detects("rhel"), wantErr: "invalid --platform"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, warning, err := ResolveServerPlatform("linux", tt.explicit, tt.detect)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected an error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("platform = %q, want %q", got, tt.want)
+			}
+			if tt.wantWarning == "" && warning != "" {
+				t.Errorf("expected no warning, got %q", warning)
+			}
+			if tt.wantWarning != "" && !strings.Contains(warning, tt.wantWarning) {
+				t.Errorf("warning must name the detected platform %q, got %q", tt.wantWarning, warning)
 			}
 		})
 	}

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -81,6 +82,31 @@ func TestResolvePlatform_Unsupported(t *testing.T) {
 				t.Errorf("unsupported input must return empty values, got (%q, %q)", like, pkgMgr)
 			}
 		})
+	}
+}
+
+// Asserted once here because register and migrate both send this value.
+func TestResolveRegistrationPlatform_SuseMapsToRhel(t *testing.T) {
+	got, err := ResolveRegistrationPlatform("linux", "opensuse-leap")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "rhel" {
+		t.Errorf("platform = %q, want rhel", got)
+	}
+}
+
+// A silent "debian" default is unrecoverable: the server persists it write-once with no admin edit path.
+func TestResolveRegistrationPlatform_UnsupportedReturnsError(t *testing.T) {
+	_, err := ResolveRegistrationPlatform("linux", "arch")
+	if err == nil {
+		t.Fatal("expected an error for an unclassifiable distribution")
+	}
+	if !strings.Contains(err.Error(), "arch") {
+		t.Errorf("error must name the distribution, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "--platform") {
+		t.Errorf("error must tell the operator about the override, got %q", err)
 	}
 }
 

--- a/pkg/utils/platform_test.go
+++ b/pkg/utils/platform_test.go
@@ -1,0 +1,108 @@
+package utils
+
+import (
+	"testing"
+)
+
+// Vectors mirror alpacon-server servers/test_utils.py:68-96: the 1:1 table correspondence is the contract, and write-once Server.platform makes a divergence permanent.
+func TestResolvePlatform(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		raw        string
+		wantLike   string
+		wantPkgMgr string
+	}{
+		{"debian", "linux", "debian", "debian", "apt"},
+		{"ubuntu", "linux", "ubuntu", "debian", "apt"},
+		{"raspbian", "linux", "raspbian", "debian", "apt"},
+
+		{"rhel", "linux", "rhel", "rhel", "yum"},
+		{"centos", "linux", "centos", "rhel", "yum"},
+		{"redhat", "linux", "redhat", "rhel", "yum"},
+		{"amazon", "linux", "amazon", "rhel", "yum"},
+		{"amzn", "linux", "amzn", "rhel", "yum"},
+		{"fedora", "linux", "fedora", "rhel", "yum"},
+		{"rocky", "linux", "rocky", "rhel", "yum"},
+		{"almalinux", "linux", "almalinux", "rhel", "yum"},
+		{"oracle", "linux", "oracle", "rhel", "yum"},
+		{"ol", "linux", "ol", "rhel", "yum"},
+
+		// Prefix-matched; the immutable variants (opensuse-microos, sle-micro) pin table parity only, not support: their read-only root likely breaks the zypper commands.
+		{"suse", "linux", "suse", "rhel", "zypper"},
+		{"opensuse", "linux", "opensuse", "rhel", "zypper"},
+		{"opensuse-leap", "linux", "opensuse-leap", "rhel", "zypper"},
+		{"opensuse-tumbleweed", "linux", "opensuse-tumbleweed", "rhel", "zypper"},
+		{"opensuse-microos", "linux", "opensuse-microos", "rhel", "zypper"},
+		{"sles", "linux", "sles", "rhel", "zypper"},
+		{"sled", "linux", "sled", "rhel", "zypper"},
+		{"sle-micro", "linux", "sle-micro", "rhel", "zypper"},
+		{"sle_hpc", "linux", "sle_hpc", "rhel", "zypper"},
+
+		{"uppercase", "linux", "SLES", "rhel", "zypper"},
+		{"padded", "linux", "  sles ", "rhel", "zypper"},
+
+		// non-linux: raw platform is ignored
+		{"darwin", "darwin", "darwin", "darwin", "brew"},
+		{"windows", "windows", "Microsoft Windows Server 2025 Datacenter", "windows", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			like, pkgMgr, ok := ResolvePlatform(tt.goos, tt.raw)
+			if !ok {
+				t.Fatalf("ResolvePlatform(%q, %q) = not ok, want ok", tt.goos, tt.raw)
+			}
+			if like != tt.wantLike {
+				t.Errorf("platformLike = %q, want %q", like, tt.wantLike)
+			}
+			if pkgMgr != tt.wantPkgMgr {
+				t.Errorf("packageManager = %q, want %q", pkgMgr, tt.wantPkgMgr)
+			}
+		})
+	}
+}
+
+// A wider set than the server's splits the two tables, and the value pinned at registration cannot be taken back.
+func TestResolvePlatform_Unsupported(t *testing.T) {
+	for _, raw := range []string{
+		"arch", "alpine", "gentoo",
+		// slackware also guards against the "sle" prefix overmatching.
+		"slackware",
+		"linuxmint", "cloudlinux", "uos",
+		"", "   ",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			like, pkgMgr, ok := ResolvePlatform("linux", raw)
+			if ok {
+				t.Fatalf("ResolvePlatform(linux, %q) = (%q, %q, ok), want not ok", raw, like, pkgMgr)
+			}
+			if like != "" || pkgMgr != "" {
+				t.Errorf("unsupported input must return empty values, got (%q, %q)", like, pkgMgr)
+			}
+		})
+	}
+}
+
+// Both directions: a false negative skips a needed dup, a false positive runs a destructive one.
+func TestIsTumbleweed(t *testing.T) {
+	for _, tt := range []struct {
+		id   string
+		want bool
+	}{
+		{"opensuse-tumbleweed", true},
+		{"opensuse-tumbleweed-kubic", true},
+		{"openSUSE-Tumbleweed", true},
+		{"opensuse-leap", false},
+		{"sles", false},
+		{"sle-micro", false},
+		{"rhel", false},
+		{"", false},
+	} {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := IsTumbleweed(tt.id); got != tt.want {
+				t.Errorf("IsTumbleweed(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,56 +10,17 @@ import (
 	"os"
 	"os/user"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/pkg/version"
 	"github.com/rs/zerolog/log"
-	"github.com/shirou/gopsutil/v4/host"
 )
 
 var (
-	PlatformLike string
-	pattern      = regexp.MustCompile(`[^\w@%+=:,./-]`)
+	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 )
-
-func InitPlatform() {
-	getPlatformLike()
-}
-
-func getPlatformLike() {
-	system := runtime.GOOS
-
-	switch system {
-	case "darwin":
-		PlatformLike = system
-	case "linux":
-		platformInfo, err := host.Info()
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to retrieve platform information.")
-			os.Exit(1)
-		}
-		switch platformInfo.Platform {
-		case "ubuntu", "debian", "raspbian":
-			PlatformLike = "debian"
-		case "centos", "rhel", "redhat", "amazon", "amzn", "fedora", "rocky", "oracle", "ol":
-			PlatformLike = "rhel"
-		default:
-			log.Fatal().Msgf("Platform %s not supported.", platformInfo.Platform)
-		}
-	case "windows":
-		PlatformLike = "windows"
-	default:
-		log.Fatal().Msgf("Unsupported os: %s.", runtime.GOOS)
-	}
-}
-
-// SetPlatformLike allows setting PlatformLike for testing purposes.
-func SetPlatformLike(platform string) {
-	PlatformLike = platform
-}
 
 func JoinPath(base string, paths ...string) string {
 	fullURL, err := url.JoinPath(base, paths...)


### PR DESCRIPTION
## Background

Alpamon broke both ways on openSUSE/SLES. At runtime, `getPlatformLike` had no branch for the SUSE family, so those ids fell to the default and `log.Fatal`'d the agent at startup (AlmaLinux died the same way despite README listing it as supported). At registration, `detectPlatform` silently returned `"debian"` whenever it could not classify the host. alpacon-server persists that value to `Server.platform`, which is write-once with no admin edit path, so a wrong value can only be corrected by re-registering the host. On openSUSE it also made the server pick the `sudo` group, which does not exist there, silently leaving admin users without sudo.

Classifying the family is the fix for the crash. Everything after that is the second half of the problem: once a SUSE host stays up, it runs zypper, and zypper's failure modes differ from apt's and dnf's in ways that turn into silent no-ops or spurious errors unless each one is handled by name.

## Classification

`pkg/utils/platform.go` becomes the single detection source, and the one overloaded variable splits into three axes, because on SUSE the value we report and the command we run disagree:

| Variable | Values | Purpose |
| --- | --- | --- |
| `PlatformLike` | debian / rhel / darwin / windows | what we report to the server |
| `PackageManager` | apt / yum / zypper / brew / PkgNone | what we run locally |
| `PlatformID` | raw os-release id | the one distro-level branch (Tumbleweed) |

`platformAliases` and `susePrefixes` mirror alpacon-server `servers/constants.py` entry for entry, and the test vectors are the same ones as `servers/test_utils.py:68-96`. Reporting SUSE as `rhel` is a behavior bucket, not a genealogy claim: the three things the server gates on `platform` (rpm packaging, the `wheel` sudo group, shadow-utils tooling) are identical for both families. Matching is by prefix rather than by an exact id set because the id list keeps growing (`sle-micro`, `opensuse-microos`) and gopsutil returns an empty `PlatformFamily` for several of them.

The duplicated `detectPlatform` copies in `register` and `migrate` are unified into `utils.DetectRegistrationPlatform`, which returns an error naming the distribution and pointing at `--platform` instead of defaulting. The `--platform` help now lists all four accepted values, and an explicit flag value is validated locally per host OS (`utils.ValidateServerPlatform`: linux takes debian|rhel, darwin darwin, windows windows), failing fast instead of poisoning the write-once server record with a cross-OS value. An explicit `--platform` that contradicts a successful detection warns rather than errors, since the override may be correcting a real misdetection, and it stays silent when detection failed, because that is the case the flag exists for. `PkgNone` is a non-empty sentinel (`"none"`) so a zero-value `PackageManager` falls to the unsupported branch rather than the windows self-update arm.

## zypper command paths

The three package-manager sites in `pkg/executor/handlers/system/system.go` move onto the `PackageManager` axis and gain a zypper arm. `handleSystemUpdate`'s `dup` is gated to Tumbleweed only. Each of the following is a separate zypper behavior that has no apt or dnf equivalent, so each needed its own handling:

Refresh is a separate command scoped to alpamon's own repository. zypper only auto-refreshes repositories added with autorefresh on, so against stale metadata a bare `update` finds no candidate and still exits 0. Chaining `refresh && update` instead means one dead repository anywhere on the host exits 4 and the update never runs; the alias is resolved by URL match against `zypper lr --export -` (`packagecloud.io/alpacax/alpamon`) rather than hardcoded, because `refresh no-such-alias` exits 3 if an operator named it differently.

The update itself stays unscoped. `-r` loads only the named repository, so the solver cannot see distribution packages: measured, `zypper install -r alpamon alpamon` fails with `nothing provides 'nftables'`.

Exit codes are normalized rather than treated as a plain pass/fail, because zypper uses the 100 range for information. Only 102 (reboot needed) and 103 (restart needed) map to success, both documented as following a completed install. 106 (repository skipped) counts as success only right after alpamon's own repository refreshed cleanly, and stays a failure for a system-wide update. 100 and 101 belong to `patch-check`, which the agent never runs; 104 means nothing was updated; 107 means an rpm `%post` failed, and `%post` is where our units and PAM lines get registered. Codes 4, 6, 7, 104, and an untolerated 106 also get an operator hint appended to the output, because none of them name the cause on their own: on an unregistered SLES container, `zypper lr` exits 6 and `zypper update alpamon` exits 104 without either mentioning the inactive subscription behind both.

A command that loses the libzypp lock is retried, bounded. `zypper --non-interactive` exits 7 immediately when another transaction holds the lock, where dnf waits and apt can be told to retry, so packagekit or an operator's own console update racing the agent turned into a failed command. `zypper lr` is not wrapped, measured not to take the lock.

An upgrade that exits 0 without moving the package is reported. `solver.allowVendorChange` is off by default and the published package's vendor is `AlpacaX`, so a vendor change makes `update` print "No update candidate" and exit 0 with the old version still installed. The handler compares each package's installed version-release before and after and appends a note naming every package that did not move, with its own held version, since `alpamon` and `alpamon-pam` carry independent versions. The exit code is deliberately left alone: a repository lagging behind a GitHub release is routine and indistinguishable from a vendor block by exit code alone.

## SLES 12 and Leap 42

The SUSE prefixes ignore `VERSION_ID`, so they admit `sles` 12.5 and Leap 42 while only 15.6 was verified. Two things break there.

SuSEfirewall2 was not in the high-level firewall list, so Alpacon would have written iptables rules that SuSEfirewall2 discards on its next reload, without an error anywhere. `pkg/executor/handlers/firewall/detection.go` now detects it by unit and disables firewall management the same way it already does for ufw and firewalld.

`systemd-run` needed two changes, not one. On systemd 228 and in a systemd 229 VM, `--collect` is rejected outright (it is 236+), and `--timer-property=OnActiveSec=5` is also rejected on its own with "has no effect without any other timer options", so dropping `--collect` alone was not enough. The delay is now `--on-active=5`, accepted by every version and equivalent on modern systemd. `pkg/migrate/migrate.go`'s `ScheduleSelfRestart` carried the same `--collect` defect, where the consequence is worse: it commits the config swap and then has no way to restart into it.

## Stateless /etc

Tumbleweed ships no `/etc/environment` at all, only `/usr/etc/environment`, so `LoadEtcEnvironment` opened nothing and Websh PTY sessions and demoted exec sessions lost the distribution's own variables, which is what that function exists to supply. `utils.EnvironmentFilePath` becomes `EnvironmentFilePaths` and reads both, vendor file first so an admin copy wins.

## CI, images, and docs

CI gains an `opensuse-leap-15` matrix row (the existing matrix had no zypper host at all). The job pins PATH in `container.env` because `opensuse/leap:15` is the only matrix image whose config defines no PATH, and the runner rebuilds each container exec's PATH as "prepended dirs + container config PATH", so after `setup-go` an empty base loses `/usr/bin`. `TestResolvePlatform_CIHost` makes every matrix row verify that its own distro classifies, which is the guard against the #348 class of bug recurring; it is gated on the `CI` env var so local runs on unsupported distros stay green.

Also: an openSUSE Leap 15 smoke image (`Dockerfiles/opensuse/15/`), and documentation. The README gets an openSUSE/SLES install block the same size as its Debian and RHEL siblings, pointing at a new `docs/opensuse.md` for the rest — the same split Windows already uses. That page carries what does not fit inline: why the platform reads as `rhel`, the `zypper addrepo` step the PackageCloud one-liner cannot cover, a sudoers drop-in that grants and exempts `%wheel` against openSUSE's `Defaults targetpw` and is validated with `visudo -cf` before install, the zypper exit codes an operator will see, the `yum`-only server operations that still fail, and how to re-register a host that registered before this fix.

## Safety

`zypper dup` is hard to undo: on Leap or SLES it advances the service pack. The Tumbleweed guard goes through `utils.IsTumbleweed` and is tested in both directions; never widen it. `Server.platform` being write-once means reintroducing a default is permanent damage, so a propagation test fails if someone does.

## Testing

`go test ./... -p 1` passes. New coverage: `pkg/utils/platform_test.go` (classification vectors, registration error text, the CI-host guard), `pkg/utils/env_test.go` (both environment file paths, override order), `system_test.go` (zypper paths, Tumbleweed both ways, refresh scoping, exit-code normalization, lock retry, the no-op note, the `--collect` fallback), `firewall_test.go` (SuSEfirewall2 detection), `register_test.go` and `migrate_test.go` (detection-failure propagation through both commands).

Each commit of the original twelve-commit series was checked out in its own worktree and reports build OK with zero failing tests, so any midpoint in that range bisects. The twelve follow-up commits were not re-verified that way; the suite passes at HEAD. An earlier head of this work passed the full 20-job matrix including `opensuse-leap-15` on GitHub runners (run 30416116325), with the job log showing the detection test running on the real runner: `distribution="opensuse-leap" -> like=rhel pkgManager=zypper`.

The branch was also run end to end against a real openSUSE host: an AWS Lightsail instance on openSUSE Leap 15.6 (x86_64), registered to a dev workspace with a binary cross-compiled from this branch. `register` printed `Platform auto-detected: rhel` and completed; the service came up `active` with no "Unsupported platform" log and both WebSocket channels connected. The console shows `Platform: opensuse-leap`, `Platform like: rhel`, `Version: 15.6`, which is the split this change exists to produce. Console-driven operations work over that registration: `alpacon exec` runs commands as an Alpacon-provisioned account (`uid=2006(chaejisung) gid=2000(alpacon)`), confirming that leaving `user.go`/`group.go` on the `PlatformLike` axis is correct because shadow-utils behaves the same on SUSE as on RHEL, and `alpacon tunnel -l 18022 -r 22` carried an SSH session through to the host. The same shell confirms the premise of the `PackageManager` split: `command -v zypper` is `/usr/bin/zypper` and yum is absent.

That run installed the binary and the five `configs/` files by hand rather than from an rpm, so it exercises detection, startup, registration, and the console paths — not packaging.

Packaging was then covered by a local VM matrix: openSUSE Leap 15.6 (systemd 254), Leap 16.0 (257), and Tumbleweed 20260701 (260), each a Lima VM running a binary and test binary cross-compiled from this branch. On all three, the platform tests pass on the real host os-release, `register` prints `Platform auto-detected: rhel`, the agent starts without an "Unsupported platform" log, and the published packagecloud rpm installs end to end: scoped refresh 0, install 0, `alpamon-2.4.0-1.aarch64` with its three units registered, update-when-current 0, remove 0. The same VMs reproduce update-of-a-missing-package as 104 and a concurrent zypper as 7. The exact transient-unit arguments the agent schedules with were confirmed to be accepted and to fire within 4 seconds on systemd 254, 257, 260, and (without `--collect`, via the retry path) 229, where `--collect` is rejected with `unrecognized option` and a lone `--timer-property` with `has no effect without any other timer options`. The matrix also showed `/usr/etc/environment` is present on Leap 16 as well as Tumbleweed, so the two-path read applies to the next Leap generation, not just the rolling release.

That matrix caught one defect, fixed here: `migrate.ScheduleSelfRestart` pinned no `AccuracySec`, so its `--on-active` delay could coalesce up to the 1-minute default past the requested two seconds (an 8-second slip was measured); the uninstall scheduler already pinned `AccuracySec=1s`, and migrate now does the same.

The zypper behaviors above were each measured in a container or VM rather than inferred: exit 104 for a package no repository carries, exit 4 and 6 on an unregistered SLES image, exit 7 under a held lock, exit 106 on an unscoped update with an unreachable repository, `-r` breaking the solver, systemd 228 and 229 rejecting `--collect` and a lone `--timer-property`, and the SuSEfirewall2 unit path on Leap 42.3.

## Known limitations

alpacon-server still composes `yum` commands for `platform == 'rhel'`, so console-driven plugin install/upgrade and the automatic `alpamon-pam` install fail on a SUSE host until the server side is zypper-aware; `docs/opensuse.md` documents the manual `zypper` path. That work is tracked in alpacax/alpacon-server#2767.

Unverified, and stated as such rather than assumed working:

- SLES 12's own systemd version and SuSEfirewall2 on a real host. The `sles12sp5` image ships no systemd and its repositories need a subscription, so the systemd behavior was measured on Leap 42.3 (228) and in a 229 VM instead.
- The vendor-change no-op scenario, which needs a second repository carrying the same package under a different vendor.
- Upgrade to a genuinely newer rpm, along with whether zypper passes `$1=2` to rpm scriptlets on upgrade: the VM matrix verified install, update-when-current, and uninstall of the hosted rpm, but no newer build existed to step to.
- The immutable variants (MicroOS, Leap Micro) are classified for table parity with the server but are unverified end to end: their read-only root likely breaks the composed zypper commands, and a container cannot verify that.

Out of scope and filed separately: #397 (an unsupported distribution should fail once, not crash-loop), #393 (Arch and Alpine), #398 (`byebye` answers the console before the removal is scheduled).

## Checklist

- [x] Every commit of the original series builds and tests clean in isolation
- [x] Tables cross-checked against alpacon-server `servers/constants.py`
- [x] Agent starts on an openSUSE Leap container, built from `Dockerfiles/opensuse/15`
- [x] Registered and driven from the console on a real openSUSE Leap 15.6 host (exec, tunnel)
- [x] Each zypper exit code and failure mode handled here reproduced in a container or VM
- [x] Install and uninstall of the hosted rpm verified on Leap 15.6, Leap 16.0, and Tumbleweed VMs
- [ ] Upgrade to a newer rpm verified (needs a newer hosted build)
- [ ] SLES 12 verified on a real host (needs a subscription)

## CI note (not addressed here)

On one run the `opensuse-leap-15` job spent over 12 minutes inside the zypper install step, with no other step started; the same job took 188 seconds on the previous run (ubuntu-22.04 120s, rocky-9 139s, fedora-41 145s). Presumed cause: the Leap image starts with an empty repo metadata cache and seven enabled repos, all fetched from download.opensuse.org, the only matrix origin that is neither Azure-local nor CDN-backed, so this row is the one exposed to upstream slowness. The expired signing key in the log is a warning only and was already present on the fast run. Recorded here so the fix is known if it recurs: keep only repo-oss and repo-update, the two that carry the needed packages, and add a step timeout. Measured locally on the same image, that cuts metadata refresh from 183MB/80s to 53MB/31s.

Closes #348
