### PR TITLE
feat(system): support agent upgrade behind an outbound proxy (package_proxy)

### DIFF
--- a/internal/protocol/command.go
+++ b/internal/protocol/command.go
@@ -101,6 +101,13 @@ type CommandData struct {
 	// Tunnel specific fields
 	TargetPort int    `json:"target_port"`
 	ClientType string `json:"client_type"` // cli, web, editor
+
+	// Upgrade specific fields.
+	// PackageProxy is an optional proxy URL for closed-network deployments.
+	// When present, it is applied to the package-manager upgrade shell and the
+	// GitHub version lookup only. Older servers omit it, which keeps the
+	// existing behavior.
+	PackageProxy string `json:"package_proxy,omitempty"`
 }
 
 // ParseCommandData parses the Data field of a Command into CommandData
@@ -189,6 +196,9 @@ func (c *CommandData) ToArgs() *common.CommandArgs {
 		// UFW specific
 		Direction: c.Direction,
 		Interface: c.Interface,
+
+		// Upgrade specific
+		PackageProxy: c.PackageProxy,
 	}
 
 	// Convert Files if present

--- a/internal/protocol/command_test.go
+++ b/internal/protocol/command_test.go
@@ -1,0 +1,45 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseCommandData_PackageProxy verifies that the optional package_proxy
+// field in the upgrade command payload is parsed and mapped into CommandArgs.
+func TestParseCommandData_PackageProxy(t *testing.T) {
+	cmd := &Command{
+		ID:    "test-123",
+		Shell: "internal",
+		Line:  "upgrade",
+		Data:  `{"package_proxy": "http://proxy.internal:3128"}`,
+	}
+
+	data, err := cmd.ParseCommandData()
+	require.NoError(t, err)
+	assert.Equal(t, "http://proxy.internal:3128", data.PackageProxy)
+
+	args := data.ToArgs()
+	assert.Equal(t, "http://proxy.internal:3128", args.PackageProxy)
+}
+
+// TestParseCommandData_PackageProxyAbsent pins backward compatibility: older
+// servers omit package_proxy (or send no data at all) and the field must
+// resolve to empty without error.
+func TestParseCommandData_PackageProxyAbsent(t *testing.T) {
+	for name, data := range map[string]string{
+		"empty data":  "",
+		"other field": `{"session_id": "sess-456"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := &Command{Shell: "internal", Line: "upgrade", Data: data}
+
+			parsed, err := cmd.ParseCommandData()
+			require.NoError(t, err)
+			assert.Empty(t, parsed.PackageProxy)
+			assert.Empty(t, parsed.ToArgs().PackageProxy)
+		})
+	}
+}

--- a/pkg/executor/executor_unix_test.go
+++ b/pkg/executor/executor_unix_test.go
@@ -50,6 +50,10 @@ func TestExecutor_ExecEnvReachesShell(t *testing.T) {
 	e := NewExecutor()
 	ctx := context.Background()
 
+	// CI or developer shells may already export https_proxy; assert the value
+	// is unchanged after Exec rather than assuming it starts empty.
+	preexisting := os.Getenv("https_proxy")
+
 	env := map[string]string{
 		"https_proxy": "http://proxy.internal:3128",
 		"no_proxy":    "localhost,169.254.169.254",
@@ -65,7 +69,7 @@ func TestExecutor_ExecEnvReachesShell(t *testing.T) {
 	if output != "http://proxy.internal:3128|localhost,169.254.169.254" {
 		t.Errorf("env override did not reach the shell, got %q", output)
 	}
-	if got := os.Getenv("https_proxy"); got != "" {
-		t.Errorf("child env override leaked into the agent process: https_proxy=%q", got)
+	if got := os.Getenv("https_proxy"); got != preexisting {
+		t.Errorf("child env override leaked into the agent process: https_proxy=%q (was %q)", got, preexisting)
 	}
 }

--- a/pkg/executor/executor_unix_test.go
+++ b/pkg/executor/executor_unix_test.go
@@ -4,6 +4,7 @@ package executor
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,5 +40,32 @@ func TestExecutor_DoesNotInheritProcessEnv(t *testing.T) {
 	}
 	if !strings.Contains(output, "USER=") {
 		t.Errorf("expected USER to be set in child env, got:\n%s", output)
+	}
+}
+
+// TestExecutor_ExecEnvReachesShell verifies that caller-provided env overrides
+// (e.g. the package proxy for closed-network upgrades) actually reach the
+// spawned shell, while Alpamon's own process environment stays untouched.
+func TestExecutor_ExecEnvReachesShell(t *testing.T) {
+	e := NewExecutor()
+	ctx := context.Background()
+
+	env := map[string]string{
+		"https_proxy": "http://proxy.internal:3128",
+		"no_proxy":    "localhost,169.254.169.254",
+	}
+
+	exitCode, output, err := e.Exec(ctx, []string{"sh", "-c", `printf '%s|%s' "$https_proxy" "$no_proxy"`}, "", "", env, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if output != "http://proxy.internal:3128|localhost,169.254.169.254" {
+		t.Errorf("env override did not reach the shell, got %q", output)
+	}
+	if got := os.Getenv("https_proxy"); got != "" {
+		t.Errorf("child env override leaked into the agent process: https_proxy=%q", got)
 	}
 }

--- a/pkg/executor/handlers/common/args.go
+++ b/pkg/executor/handlers/common/args.go
@@ -51,6 +51,12 @@ type CommandArgs struct {
 	// Environment
 	Env map[string]string
 
+	// Upgrade operations.
+	// PackageProxy is an optional proxy URL for closed-network deployments,
+	// applied only to the package-manager upgrade shell and the GitHub
+	// version lookup. Empty means no proxy (existing behavior).
+	PackageProxy string
+
 	// ChunkCallback, if non-nil, receives streamed stdout/stderr chunks.
 	// Sequencing is the caller's responsibility.
 	ChunkCallback func(content string)

--- a/pkg/executor/handlers/common/interfaces.go
+++ b/pkg/executor/handlers/common/interfaces.go
@@ -78,7 +78,11 @@ type APISession interface {
 
 // VersionResolver provides version information for upgrade decisions.
 type VersionResolver interface {
-	GetLatestVersion() string
+	// GetLatestVersion returns the latest release tag from GitHub, or "" on
+	// failure. proxyURL, when non-empty, routes this lookup request through
+	// the given proxy (per-request transport; the agent's own process
+	// environment and control-plane connection are never affected).
+	GetLatestVersion(proxyURL string) string
 	GetPamVersion() string
 	InvalidatePamCache()
 }

--- a/pkg/executor/handlers/common/testing.go
+++ b/pkg/executor/handlers/common/testing.go
@@ -30,6 +30,7 @@ type ExecutedCommand struct {
 	Name    string
 	Args    []string
 	User    string
+	Env     map[string]string
 	Timeout time.Duration
 }
 
@@ -91,7 +92,7 @@ func (m *MockCommandExecutor) Exec(ctx context.Context, args []string, username,
 	if len(args) == 0 {
 		return 0, "", nil
 	}
-	m.commands = append(m.commands, ExecutedCommand{Name: args[0], Args: args[1:], User: username, Timeout: timeout})
+	m.commands = append(m.commands, ExecutedCommand{Name: args[0], Args: args[1:], User: username, Env: env, Timeout: timeout})
 	return m.lookupResult(args[0], args[1:]...)
 }
 

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -165,7 +165,7 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandArgs) (int, string, error) {
 	var packageProxy string
 	if args != nil {
-		packageProxy = args.PackageProxy
+		packageProxy = sanitizePackageProxy(args.PackageProxy)
 	}
 
 	latestVersion := h.versionResolver.GetLatestVersion(packageProxy)
@@ -225,6 +225,30 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 		h.versionResolver.InvalidatePamCache()
 	}
 	return exitCode, output, err
+}
+
+// sanitizePackageProxy validates the payload-provided proxy URL once at
+// handleUpgrade entry. An invalid or unsupported value is treated as absent
+// for BOTH the version lookup and the package-manager shell environment, so
+// the two paths stay consistent (no half-applied proxy in the root shell).
+// The raw value is never logged because proxy URLs may embed credentials
+// (user:pass@); the scheme alone is safe to log.
+func sanitizePackageProxy(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Hostname() == "" {
+		log.Warn().Msg("Invalid package proxy URL in upgrade payload; ignoring it.")
+		return ""
+	}
+	switch parsed.Scheme {
+	case "http", "https", "socks5", "socks5h":
+		return raw
+	default:
+		log.Warn().Str("scheme", parsed.Scheme).Msg("Unsupported package proxy scheme in upgrade payload; ignoring it.")
+		return ""
+	}
 }
 
 // packageProxyEnv builds the proxy environment for the package-manager shell

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -40,6 +40,14 @@ type SystemHandler struct {
 	versionResolver common.VersionResolver
 	apiSession      common.APISession
 	selfUpdateFn    updater.SelfUpdateFunc // defaults to updater.SelfUpdate; tests inject a fake
+
+	// uninstallDelay defers executeUninstall so the byebye response is sent
+	// before the agent starts tearing itself down. Tests shorten it and use
+	// uninstallDone to drain the timer goroutine, which would otherwise
+	// outlive the test and race on package-level state (utils.PlatformLike).
+	uninstallDelay time.Duration
+	// uninstallDone, when non-nil, is closed after executeUninstall returns.
+	uninstallDone chan struct{}
 }
 
 // NewSystemHandler creates a new system handler.
@@ -69,6 +77,7 @@ func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClie
 		versionResolver: versionResolver,
 		apiSession:      apiSession,
 		selfUpdateFn:    updater.SelfUpdate,
+		uninstallDelay:  1 * time.Second,
 	}
 	return h
 }
@@ -221,7 +230,8 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandA
 // packageProxyEnv builds the proxy environment for the package-manager shell
 // in closed-network deployments. It returns nil when no proxy is configured,
 // which keeps behavior identical to an env-less invocation. no_proxy excludes
-// the Alpacon server host, the IMDS address, and localhost as a safeguard so
+// the Alpacon server host, the IMDS endpoints (AWS IPv4/IPv6, GCP), and
+// localhost as a safeguard so
 // nothing spawned by the upgrade can route control-plane or metadata traffic
 // through the package proxy.
 func packageProxyEnv(proxyURL string) map[string]string {
@@ -229,7 +239,7 @@ func packageProxyEnv(proxyURL string) map[string]string {
 		return nil
 	}
 
-	noProxy := "localhost,127.0.0.1,::1,169.254.169.254"
+	noProxy := "localhost,127.0.0.1,::1,169.254.169.254,fd00:ec2::254,metadata.google.internal"
 	if serverURL, err := url.Parse(config.GlobalSettings.ServerURL); err == nil && serverURL.Hostname() != "" {
 		noProxy += "," + serverURL.Hostname()
 	}
@@ -353,9 +363,13 @@ func (h *SystemHandler) unregisterFromConsole() {
 func (h *SystemHandler) handleUninstall() (int, string, error) {
 	log.Info().Msg("Uninstall request received.")
 
-	// Execute uninstall after 1 second to ensure response is sent
-	time.AfterFunc(1*time.Second, func() {
+	// Execute uninstall after a delay (1 second in production) to ensure the
+	// response is sent first.
+	time.AfterFunc(h.uninstallDelay, func() {
 		h.executeUninstall()
+		if h.uninstallDone != nil {
+			close(h.uninstallDone)
+		}
 	})
 
 	return 0, "Starting uninstall process...", nil

--- a/pkg/executor/handlers/system/system.go
+++ b/pkg/executor/handlers/system/system.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/alpacax/alpamon/v2/internal/pool"
 	"github.com/alpacax/alpamon/v2/pkg/agent"
+	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/updater"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
@@ -75,7 +77,9 @@ func NewSystemHandler(cmdExecutor common.CommandExecutor, wsClient common.WSClie
 func (h *SystemHandler) Execute(ctx context.Context, cmd string, args *common.CommandArgs) (int, string, error) {
 	switch cmd {
 	case common.Upgrade.String():
-		return h.withTimeout(ctx, common.UpgradeTimeout, h.handleUpgrade)
+		return h.withTimeout(ctx, common.UpgradeTimeout, func(ctx context.Context) (int, string, error) {
+			return h.handleUpgrade(ctx, args)
+		})
 	case common.Restart.String():
 		ctx, cancel := common.WithHandlerTimeout(ctx, common.SystemCmdTimeout)
 		defer cancel()
@@ -144,17 +148,28 @@ func (h *SystemHandler) Validate(cmd string, args *common.CommandArgs) error {
 // It checks alpamon and alpamon-pam versions independently and upgrades only
 // the packages that need it. This prevents skipping a pam-only upgrade when
 // alpamon is already at the latest version.
-func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) {
-	latestVersion := h.versionResolver.GetLatestVersion()
-	if latestVersion == "" {
-		return 1, "Failed to retrieve the latest Alpamon version from GitHub.",
-			errors.New("failed to retrieve the latest Alpamon version from GitHub")
+//
+// args.PackageProxy, when present, routes the GitHub version lookup and the
+// package-manager shell through the given proxy so closed-network deployments
+// with an outbound proxy can upgrade. A failed version lookup is not fatal on
+// linux: "latest" is delegated to the package manager instead.
+func (h *SystemHandler) handleUpgrade(ctx context.Context, args *common.CommandArgs) (int, string, error) {
+	var packageProxy string
+	if args != nil {
+		packageProxy = args.PackageProxy
 	}
 
-	needAlpamon := version.Version != latestVersion
+	latestVersion := h.versionResolver.GetLatestVersion(packageProxy)
+	if latestVersion == "" {
+		// Closed-network deployments may not be able to reach api.github.com.
+		// Delegate "latest" to the package manager instead of failing here.
+		log.Warn().Msg("Failed to retrieve the latest Alpamon version from GitHub; proceeding with package manager upgrade.")
+	}
+
+	needAlpamon := latestVersion == "" || version.Version != latestVersion
 
 	currentPamVersion := h.versionResolver.GetPamVersion()
-	needPam := currentPamVersion != "" && currentPamVersion != latestVersion
+	needPam := currentPamVersion != "" && (latestVersion == "" || currentPamVersion != latestVersion)
 
 	if !needAlpamon && !needPam {
 		pamDisplay := currentPamVersion
@@ -182,17 +197,51 @@ func (h *SystemHandler) handleUpgrade(ctx context.Context) (int, string, error) 
 	case "darwin", "windows":
 		// needAlpamon is always true here: needPam is always false on non-linux
 		// (pam unsupported; see pkg/utils/pam.go) and the switch is reached only when needAlpamon||needPam.
+		if latestVersion == "" {
+			// Self-update needs a concrete target version; there is no
+			// package manager to delegate "latest" to on these platforms.
+			return 1, "Failed to retrieve the latest Alpamon version from GitHub.",
+				errors.New("failed to retrieve the latest Alpamon version from GitHub")
+		}
 		return h.selfUpdate(ctx, latestVersion)
 	default:
 		return 1, fmt.Sprintf("Platform '%s' not supported.", utils.PlatformLike), nil
 	}
 
 	log.Debug().Msgf("Upgrading %s...", pkgList)
-	exitCode, output, err := h.Executor.RunAsUser(ctx, "root", "sh", "-c", cmd)
+	// The proxy environment (nil without a package proxy) applies to the
+	// spawned package-manager shell only, never to the agent process.
+	exitCode, output, err := h.Executor.Exec(ctx, []string{"sh", "-c", cmd}, "root", "root", packageProxyEnv(packageProxy), 0)
 	if exitCode == 0 && needPam {
 		h.versionResolver.InvalidatePamCache()
 	}
 	return exitCode, output, err
+}
+
+// packageProxyEnv builds the proxy environment for the package-manager shell
+// in closed-network deployments. It returns nil when no proxy is configured,
+// which keeps behavior identical to an env-less invocation. no_proxy excludes
+// the Alpacon server host, the IMDS address, and localhost as a safeguard so
+// nothing spawned by the upgrade can route control-plane or metadata traffic
+// through the package proxy.
+func packageProxyEnv(proxyURL string) map[string]string {
+	if proxyURL == "" {
+		return nil
+	}
+
+	noProxy := "localhost,127.0.0.1,::1,169.254.169.254"
+	if serverURL, err := url.Parse(config.GlobalSettings.ServerURL); err == nil && serverURL.Hostname() != "" {
+		noProxy += "," + serverURL.Hostname()
+	}
+
+	return map[string]string{
+		"http_proxy":  proxyURL,
+		"https_proxy": proxyURL,
+		"HTTP_PROXY":  proxyURL,
+		"HTTPS_PROXY": proxyURL,
+		"no_proxy":    noProxy,
+		"NO_PROXY":    noProxy,
+	}
 }
 
 // selfUpdate downloads and replaces the binary from GitHub Releases, then triggers restart.

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -506,7 +506,7 @@ func TestSystemHandler_Upgrade_PackageProxy(t *testing.T) {
 	}
 	for _, key := range []string{"no_proxy", "NO_PROXY"} {
 		noProxy := shell.Env[key]
-		for _, excluded := range []string{"localhost", "127.0.0.1", "169.254.169.254", "console.example.com"} {
+		for _, excluded := range []string{"localhost", "127.0.0.1", "169.254.169.254", "fd00:ec2::254", "metadata.google.internal", "console.example.com"} {
 			if !strings.Contains(noProxy, excluded) {
 				t.Errorf("expected env %s to exclude %q, got %q", key, excluded, noProxy)
 			}
@@ -666,6 +666,13 @@ func TestSystemHandler_Uninstall(t *testing.T) {
 	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, newMockVersionResolver(), nil)
 	ctx := context.Background()
 
+	// Neutralize the deferred-uninstall timer and drain its goroutine before
+	// the test returns: a leaked executeUninstall reads utils.PlatformLike
+	// after the test ends and races with SetPlatformLike in later tests.
+	handler.uninstallDelay = 0
+	done := make(chan struct{})
+	handler.uninstallDone = done
+
 	args := &common.CommandArgs{}
 
 	exitCode, output, err := handler.Execute(ctx, common.ByeBye.String(), args)
@@ -678,6 +685,12 @@ func TestSystemHandler_Uninstall(t *testing.T) {
 	}
 	if !strings.Contains(output, "uninstall") {
 		t.Errorf("expected output to mention uninstall, got %q", output)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("uninstall goroutine did not finish")
 	}
 }
 

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -552,6 +552,52 @@ func TestSystemHandler_Upgrade_NoPackageProxy(t *testing.T) {
 	}
 }
 
+// TestSystemHandler_Upgrade_InvalidPackageProxy verifies that an invalid
+// package_proxy is treated as absent consistently: the version lookup goes
+// direct AND no proxy environment is injected into the root shell.
+func TestSystemHandler_Upgrade_InvalidPackageProxy(t *testing.T) {
+	for name, proxy := range map[string]string{
+		"parse error":        "http://[::1",
+		"missing host":       "not a url",
+		"unsupported scheme": "ftp://proxy.internal:21",
+	} {
+		t.Run(name, func(t *testing.T) {
+			mockExec := common.NewMockCommandExecutor(t)
+			mockWS := &MockWSClient{}
+			ctxManager := agent.NewContextManager()
+			workerPool := pool.NewPool(2, 10)
+			defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+			defer ctxManager.Shutdown()
+
+			mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9", GotProxy: "sentinel"}
+			handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+			originalPlatformLike := utils.PlatformLike
+			utils.SetPlatformLike("debian")
+			t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+			exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{PackageProxy: proxy})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if exitCode != 0 {
+				t.Errorf("expected exit code 0, got %d", exitCode)
+			}
+			if mockVersions.GotProxy != "" {
+				t.Errorf("expected version lookup without proxy, got %q", mockVersions.GotProxy)
+			}
+
+			shell := findExecutedShell(mockExec)
+			if shell == nil {
+				t.Fatal("expected a package-manager shell to be spawned")
+			}
+			if len(shell.Env) != 0 {
+				t.Errorf("expected no env override for invalid proxy %q, got %v", proxy, shell.Env)
+			}
+		})
+	}
+}
+
 // TestSystemHandler_Upgrade_VersionLookupFailureProceeds verifies that a failed
 // GitHub version lookup (e.g. closed-network deployments) is no longer fatal on
 // linux: the upgrade proceeds and "latest" is delegated to the package manager.

--- a/pkg/executor/handlers/system/system_test.go
+++ b/pkg/executor/handlers/system/system_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alpacax/alpamon/v2/internal/pool"
 	"github.com/alpacax/alpamon/v2/pkg/agent"
+	"github.com/alpacax/alpamon/v2/pkg/config"
 	"github.com/alpacax/alpamon/v2/pkg/executor/handlers/common"
 	"github.com/alpacax/alpamon/v2/pkg/updater"
 	"github.com/alpacax/alpamon/v2/pkg/utils"
@@ -41,9 +42,11 @@ type MockVersionResolver struct {
 	LatestVersion       string
 	PamVersion          string
 	InvalidatePamCalled bool
+	GotProxy            string
 }
 
-func (m *MockVersionResolver) GetLatestVersion() string {
+func (m *MockVersionResolver) GetLatestVersion(proxyURL string) string {
+	m.GotProxy = proxyURL
 	return m.LatestVersion
 }
 
@@ -434,6 +437,191 @@ func TestSystemHandler_Upgrade_UpToDate(t *testing.T) {
 	}
 	if !strings.Contains(output, "up-to-date") {
 		t.Errorf("expected output to contain 'up-to-date', got %q", output)
+	}
+}
+
+// findExecutedShell returns the last executed "sh" command from the mock, or
+// nil when no shell was spawned.
+func findExecutedShell(mockExec *common.MockCommandExecutor) *common.ExecutedCommand {
+	cmds := mockExec.GetExecutedCommands()
+	for i := len(cmds) - 1; i >= 0; i-- {
+		if cmds[i].Name == "sh" {
+			return &cmds[i]
+		}
+	}
+	return nil
+}
+
+// TestSystemHandler_Upgrade_PackageProxy verifies that a package_proxy in the
+// upgrade payload reaches both the version lookup and the environment of the
+// spawned package-manager shell, and that no_proxy shields the Alpacon server
+// host, IMDS, and localhost.
+func TestSystemHandler_Upgrade_PackageProxy(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9"} // differs from version.Version -> needAlpamon
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	originalServerURL := config.GlobalSettings.ServerURL
+	config.GlobalSettings.ServerURL = "https://console.example.com"
+	t.Cleanup(func() { config.GlobalSettings.ServerURL = originalServerURL })
+
+	const proxy = "http://proxy.internal:3128"
+	args := &common.CommandArgs{PackageProxy: proxy}
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if mockVersions.GotProxy != proxy {
+		t.Errorf("expected version lookup to use proxy %q, got %q", proxy, mockVersions.GotProxy)
+	}
+
+	shell := findExecutedShell(mockExec)
+	if shell == nil {
+		t.Fatal("expected a package-manager shell to be spawned")
+	}
+	if shell.User != "root" {
+		t.Errorf("expected shell to run as root, got %q", shell.User)
+	}
+	if len(shell.Args) != 2 || shell.Args[0] != "-c" || !strings.Contains(shell.Args[1], "apt-get") {
+		t.Errorf("expected sh -c apt-get command, got %v", shell.Args)
+	}
+	for _, key := range []string{"http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"} {
+		if got := shell.Env[key]; got != proxy {
+			t.Errorf("expected env %s=%q, got %q", key, proxy, got)
+		}
+	}
+	for _, key := range []string{"no_proxy", "NO_PROXY"} {
+		noProxy := shell.Env[key]
+		for _, excluded := range []string{"localhost", "127.0.0.1", "169.254.169.254", "console.example.com"} {
+			if !strings.Contains(noProxy, excluded) {
+				t.Errorf("expected env %s to exclude %q, got %q", key, excluded, noProxy)
+			}
+		}
+	}
+}
+
+// TestSystemHandler_Upgrade_NoPackageProxy pins backward compatibility: an
+// upgrade payload without package_proxy spawns the shell with no proxy
+// environment override.
+func TestSystemHandler_Upgrade_NoPackageProxy(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: "v9.9.9"}
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if mockVersions.GotProxy != "" {
+		t.Errorf("expected version lookup without proxy, got %q", mockVersions.GotProxy)
+	}
+
+	shell := findExecutedShell(mockExec)
+	if shell == nil {
+		t.Fatal("expected a package-manager shell to be spawned")
+	}
+	if len(shell.Env) != 0 {
+		t.Errorf("expected no env override without package_proxy, got %v", shell.Env)
+	}
+}
+
+// TestSystemHandler_Upgrade_VersionLookupFailureProceeds verifies that a failed
+// GitHub version lookup (e.g. closed-network deployments) is no longer fatal on
+// linux: the upgrade proceeds and "latest" is delegated to the package manager.
+func TestSystemHandler_Upgrade_VersionLookupFailureProceeds(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	mockVersions := &MockVersionResolver{LatestVersion: ""} // lookup failure
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, mockVersions, nil)
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("debian")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	exitCode, _, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if err != nil {
+		t.Fatalf("expected version lookup failure to be non-fatal, got: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+
+	shell := findExecutedShell(mockExec)
+	if shell == nil {
+		t.Fatal("expected the package-manager upgrade to proceed despite the lookup failure")
+	}
+	if len(shell.Args) != 2 || !strings.Contains(shell.Args[1], "alpamon") {
+		t.Errorf("expected unpinned alpamon upgrade command, got %v", shell.Args)
+	}
+}
+
+// TestSystemHandler_Upgrade_VersionLookupFailureSelfUpdate pins the non-linux
+// behavior: self-update needs a concrete target version, so a failed lookup
+// still fails the upgrade on darwin/windows (no package manager to delegate to).
+func TestSystemHandler_Upgrade_VersionLookupFailureSelfUpdate(t *testing.T) {
+	mockExec := common.NewMockCommandExecutor(t)
+	mockWS := &MockWSClient{}
+	ctxManager := agent.NewContextManager()
+	workerPool := pool.NewPool(2, 10)
+	defer func() { _ = workerPool.Shutdown(1 * time.Second) }()
+	defer ctxManager.Shutdown()
+
+	handler := NewSystemHandler(mockExec, mockWS, ctxManager, workerPool, &MockVersionResolver{LatestVersion: ""}, nil)
+
+	var called bool
+	handler.selfUpdateFn = func(_ context.Context, _ string, _ updater.Options) error {
+		called = true
+		return nil
+	}
+
+	originalPlatformLike := utils.PlatformLike
+	utils.SetPlatformLike("darwin")
+	t.Cleanup(func() { utils.SetPlatformLike(originalPlatformLike) })
+
+	exitCode, output, err := handler.Execute(context.Background(), common.Upgrade.String(), &common.CommandArgs{})
+	if err == nil {
+		t.Fatal("expected error when version lookup fails on darwin")
+	}
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+	if called {
+		t.Error("self-update must not run without a target version")
+	}
+	if !strings.Contains(output, "GitHub") {
+		t.Errorf("expected lookup failure message, got %q", output)
 	}
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -133,14 +133,18 @@ func GetSystemUser(username string) (*user.User, error) {
 	return usr, nil
 }
 
-func GetLatestVersion() string {
+// GetLatestVersion returns the latest alpamon release tag from GitHub, or ""
+// on any failure. proxyURL, when non-empty, routes only this request through
+// the given proxy so closed-network deployments can reach GitHub without
+// touching the agent's process environment or control-plane connection.
+func GetLatestVersion(proxyURL string) string {
 	req, err := http.NewRequest("GET", "https://api.github.com/repos/alpacax/alpamon/releases/latest", nil)
 	if err != nil {
 		return ""
 	}
 	req.Header.Set("User-Agent", GetUserAgent("alpamon"))
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := NewVersionLookupClient(proxyURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return ""
@@ -158,6 +162,25 @@ func GetLatestVersion() string {
 		return ""
 	}
 	return release.TagName
+}
+
+// NewVersionLookupClient builds the HTTP client for the GitHub version lookup.
+// With an empty proxyURL it uses the default transport, which respects the
+// process-level proxy environment when present. With a proxyURL it uses a
+// per-request transport pinned to that proxy, so the payload-provided proxy
+// never leaks into the agent's process globals.
+func NewVersionLookupClient(proxyURL string) *http.Client {
+	client := &http.Client{Timeout: 10 * time.Second}
+	if proxyURL == "" {
+		return client
+	}
+	parsed, err := url.Parse(proxyURL)
+	if err != nil || parsed.Host == "" {
+		log.Warn().Str("proxy", proxyURL).Msg("Invalid package proxy URL; using default transport for version lookup.")
+		return client
+	}
+	client.Transport = &http.Transport{Proxy: http.ProxyURL(parsed)}
+	return client
 }
 
 func GetUserAgent(name string) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -179,7 +179,18 @@ func NewVersionLookupClient(proxyURL string) *http.Client {
 		log.Warn().Str("proxy", proxyURL).Msg("Invalid package proxy URL; using default transport for version lookup.")
 		return client
 	}
-	client.Transport = &http.Transport{Proxy: http.ProxyURL(parsed)}
+	// Clone the default transport so its settings (timeouts, TLS, HTTP/2)
+	// carry over, instead of a bare &http.Transport{} that also leaks its
+	// keep-alive connections. Safe assertion: instrumentation may swap
+	// http.DefaultTransport for a different RoundTripper.
+	var transport *http.Transport
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = base.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.Proxy = http.ProxyURL(parsed)
+	client.Transport = transport
 	return client
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -176,7 +176,8 @@ func NewVersionLookupClient(proxyURL string) *http.Client {
 	}
 	parsed, err := url.Parse(proxyURL)
 	if err != nil || parsed.Host == "" {
-		log.Warn().Str("proxy", proxyURL).Msg("Invalid package proxy URL; using default transport for version lookup.")
+		// Don't log the raw value: proxy URLs may embed credentials (user:pass@).
+		log.Warn().Msg("Invalid package proxy URL; using default transport for version lookup.")
 		return client
 	}
 	// Clone the default transport so its settings (timeouts, TLS, HTTP/2)

--- a/pkg/utils/version_lookup_test.go
+++ b/pkg/utils/version_lookup_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestNewVersionLookupClient_NoProxy pins the default: without a proxy URL the
+// client uses the default transport (nil Transport), which respects the
+// process-level proxy environment when present.
+func TestNewVersionLookupClient_NoProxy(t *testing.T) {
+	client := NewVersionLookupClient("")
+	if client.Transport != nil {
+		t.Errorf("expected default transport (nil), got %T", client.Transport)
+	}
+}
+
+// TestNewVersionLookupClient_WithProxy verifies a per-request transport is
+// pinned to the payload-provided proxy, without touching process globals.
+func TestNewVersionLookupClient_WithProxy(t *testing.T) {
+	client := NewVersionLookupClient("http://proxy.internal:3128")
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/alpacax/alpamon/releases/latest", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	proxy, err := transport.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy func returned error: %v", err)
+	}
+	if proxy == nil || proxy.String() != "http://proxy.internal:3128" {
+		t.Errorf("expected proxy http://proxy.internal:3128, got %v", proxy)
+	}
+}
+
+// TestNewVersionLookupClient_InvalidProxy verifies an unparsable proxy URL
+// falls back to the default transport instead of failing the lookup.
+func TestNewVersionLookupClient_InvalidProxy(t *testing.T) {
+	for _, invalid := range []string{"http://[::1", "not a url"} {
+		client := NewVersionLookupClient(invalid)
+		if client.Transport != nil {
+			t.Errorf("proxy %q: expected fallback to default transport (nil), got %T", invalid, client.Transport)
+		}
+	}
+}

--- a/pkg/utils/version_resolver.go
+++ b/pkg/utils/version_resolver.go
@@ -8,8 +8,8 @@ func NewDefaultVersionResolver() *DefaultVersionResolver {
 	return &DefaultVersionResolver{}
 }
 
-func (r *DefaultVersionResolver) GetLatestVersion() string {
-	return GetLatestVersion()
+func (r *DefaultVersionResolver) GetLatestVersion(proxyURL string) string {
+	return GetLatestVersion(proxyURL)
 }
 
 func (r *DefaultVersionResolver) GetPamVersion() string {


### PR DESCRIPTION
## Background

In a restricted network (with an outbound proxy), `agent upgrade` fails with "Command execution failed".

- The version lookup is hardcoded to api.github.com and, on failure, exits immediately before apt/yum is even attempted.
- Proxy environment variables are not passed to the upgrade shell (the `RunAsUser` path does not forward env).

## Changes

### Contract: add an optional `package_proxy` field to the upgrade command payload

An optional string field `package_proxy` (a proxy URL) is added to `command.data` (a JSON string). The sender side is implemented in the companion PR alpacax/alpacon-server#2757.

```json
{"query": "command", "command": {"shell": "internal", "line": "upgrade", "data": "{\"package_proxy\": \"http://proxy.example.com:3128\"}"}}
```

When the field is absent or empty (including older servers), the existing GitHub path runs unchanged.

### A. Scope of `package_proxy`

- Inject `http_proxy`/`https_proxy` (and their uppercase forms) **into the package-manager shell only**: `handleUpgrade` uses the existing `Exec(...env...)` path instead of `RunAsUser`. It is never injected into the agent process globally, nor into the WebSocket/control-plane clients.
- `no_proxy`/`NO_PROXY` safeguard: exclude the Alpacon server host, `169.254.169.254` (IMDS), and `localhost`/`127.0.0.1`/`::1`.
- The GitHub version lookup uses the same proxy through a per-request transport (`NewVersionLookupClient`), without touching the process env.

### C. Non-fatal handling when the version lookup fails

A failed version lookup no longer aborts the upgrade: it logs a warning and delegates "latest" to apt/yum (unpinned). darwin/windows self-update still fails as before, since it requires a target version.

## Tests

- `package_proxy` present/absent in the payload → shell env injected / not injected.
- Version lookup failure → linux proceeds unpinned, darwin still fails.
- `Exec` env actually reaches the shell and does not leak into the agent process.
- `package_proxy` parsing (including older-server compatibility) and fallback to the default transport when the proxy URL fails to parse.
- `go build ./...` / `go vet ./...` / `go test ./... -p 1` / golangci-lint v2.9.0 all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
