### PR TITLE
Consolidate syscall.Credential assembly into one demotion entry point

### DIFF
--- a/pkg/runner/pty_unix.go
+++ b/pkg/runner/pty_unix.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"syscall"
 
 	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -20,17 +19,11 @@ func (pc *PtyClient) setPtyCmdSysProcAttrAndEnv(uid, gid int, groupIds []string,
 		if err != nil {
 			return err
 		}
-		groups, _, err := utils.ResolveGroups(u32gid, groupIds)
+		sysProcAttr, _, err := utils.DemotedSysProcAttr(u32uid, u32gid, groupIds)
 		if err != nil {
 			return err
 		}
-		pc.cmd.SysProcAttr = &syscall.SysProcAttr{
-			Credential: &syscall.Credential{
-				Uid:    u32uid,
-				Gid:    u32gid,
-				Groups: groups,
-			},
-		}
+		pc.cmd.SysProcAttr = sysProcAttr
 	} else if uid != currentUID {
 		log.Warn().Int("requestedUID", uid).Int("processUID", currentUID).
 			Msg("PTY credential demotion skipped: alpamon is not running as root. Session will run as the alpamon process user.")

--- a/pkg/runner/tunnel_linux.go
+++ b/pkg/runner/tunnel_linux.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/alpacax/alpamon/v2/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
@@ -29,6 +30,8 @@ func getNobodyCredential() (*syscall.SysProcAttr, error) {
 		return nil, fmt.Errorf("failed to parse nobody credentials: %w", err)
 	}
 
+	// Groups stays nil so Go calls setgroups(0, NULL), dropping the daemon's
+	// supplementary groups; resolving them here would widen what it can reach.
 	return &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
 			Uid: uid,
@@ -158,47 +161,36 @@ func getCodeServerCredential(username, groupname string) (*syscall.SysProcAttr, 
 		return nil, fmt.Errorf("user %s not found: %w", username, err)
 	}
 
-	// Use user's primary group if groupname is empty
-	gidStr := usr.Gid
-	if groupname != "" {
-		group, err := user.LookupGroup(groupname)
-		if err != nil {
-			return nil, fmt.Errorf("group %s not found: %w", groupname, err)
-		}
-		gidStr = group.Gid
-	}
-
-	uid, gid, err := parseUserCredentials(usr.Uid, gidStr)
+	uid, gid, err := codeServerIDs(usr, groupname)
 	if err != nil {
 		return nil, err
 	}
 
-	groups := parseGroupIDs(usr)
+	groupIds, err := usr.GroupIds()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups of user %s: %w", username, err)
+	}
 
 	log.Debug().Msgf("Demoting code-server to user %s (group: %s).", username, groupname)
 
-	return &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid:    uid,
-			Gid:    gid,
-			Groups: groups,
-		},
-	}, nil
+	sysProcAttr, _, err := utils.DemotedSysProcAttr(uid, gid, groupIds)
+	if err != nil {
+		return nil, err
+	}
+	return sysProcAttr, nil
 }
 
-func parseGroupIDs(usr *user.User) []uint32 {
-	groupIds, err := usr.GroupIds()
-	if err != nil {
-		return nil
+// codeServerIDs cannot defer to utils.Demote: Demote treats an empty groupname
+// as "do not demote", which would leave the code-server session running as root.
+func codeServerIDs(usr *user.User, groupname string) (uint32, uint32, error) {
+	gidStr := usr.Gid
+	if groupname != "" {
+		group, err := user.LookupGroup(groupname)
+		if err != nil {
+			return 0, 0, fmt.Errorf("group %s not found: %w", groupname, err)
+		}
+		gidStr = group.Gid
 	}
 
-	groups := make([]uint32, 0, len(groupIds))
-	for _, gidStr := range groupIds {
-		gid, err := strconv.ParseUint(gidStr, 10, 32)
-		if err != nil {
-			continue
-		}
-		groups = append(groups, uint32(gid))
-	}
-	return groups
+	return parseUserCredentials(usr.Uid, gidStr)
 }

--- a/pkg/runner/tunnel_linux_test.go
+++ b/pkg/runner/tunnel_linux_test.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodeServerIDs(t *testing.T) {
+	// Regression guard: utils.Demote would skip demotion here and run as root.
+	t.Run("empty groupname falls back to the primary group", func(t *testing.T) {
+		uid, gid, err := codeServerIDs(&user.User{Uid: "1000", Gid: "1000"}, "")
+		require.NoError(t, err)
+		assert.Equal(t, uint32(1000), uid)
+		assert.Equal(t, uint32(1000), gid)
+	})
+
+	t.Run("groupname overrides the primary group", func(t *testing.T) {
+		// Skip rather than fail: an unreadable group database is an environment
+		// problem, not a codeServerIDs defect.
+		grp, err := user.LookupGroupId("0")
+		if err != nil {
+			t.Skipf("gid 0 is not resolvable on this host: %v", err)
+		}
+
+		uid, gid, err := codeServerIDs(&user.User{Uid: "1000", Gid: "1000"}, grp.Name)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(1000), uid)
+		assert.Equal(t, uint32(0), gid)
+	})
+
+	t.Run("unknown groupname is an error", func(t *testing.T) {
+		_, _, err := codeServerIDs(&user.User{Uid: "1000", Gid: "1000"}, "alpamon-nonexistent-group")
+		assert.Error(t, err)
+	})
+
+	t.Run("unparsable uid is an error", func(t *testing.T) {
+		_, _, err := codeServerIDs(&user.User{Uid: "not-a-uid", Gid: "1000"}, "")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/utils/privilege_unix.go
+++ b/pkg/utils/privilege_unix.go
@@ -32,21 +32,27 @@ func DemotedSysProcAttr(uid, gid uint32, groupIds []string) (attr *syscall.SysPr
 
 // resolveGroups builds the supplementary group list for Credential.Groups.
 // The primary gid is placed first so it survives truncation, and the requested
-// gid's membership is reported via groupInList for ValidateGroup. When
+// gid's membership is reported via groupInList for ValidateGroup. Duplicates are
+// dropped before capping so a repeated gid cannot push a distinct one out. When
 // maxGroups > 0 the list is capped to that many entries.
 func resolveGroups(gid uint32, groupIds []string, maxGroups int) (groups []uint32, groupInList bool, err error) {
 	groups = make([]uint32, 0, len(groupIds)+1)
 	groups = append(groups, gid)
+	seen := map[uint32]struct{}{gid: {}}
 	for _, gidStr := range groupIds {
 		gidUint, err := strconv.ParseUint(gidStr, 10, 32)
 		if err != nil {
 			return nil, false, fmt.Errorf("invalid supplementary group id: %w", err)
 		}
-		if uint32(gidUint) == gid {
+		group := uint32(gidUint)
+		if group == gid {
 			groupInList = true
+		}
+		if _, dup := seen[group]; dup {
 			continue
 		}
-		groups = append(groups, uint32(gidUint))
+		seen[group] = struct{}{}
+		groups = append(groups, group)
 	}
 	if maxGroups > 0 && len(groups) > maxGroups {
 		log.Debug().Int("requested", len(groups)).Int("cap", maxGroups).

--- a/pkg/utils/privilege_unix.go
+++ b/pkg/utils/privilege_unix.go
@@ -12,12 +12,22 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// ResolveGroups builds the supplementary group list for Credential.Groups,
-// applying the current platform's setgroups(2) cap. It is the single entry
-// point shared by every privilege-demotion path (Demote and the websh PTY),
-// so group handling stays identical across them.
-func ResolveGroups(gid uint32, groupIds []string) (groups []uint32, groupInList bool, err error) {
-	return resolveGroups(gid, groupIds, maxSupplementaryGroups())
+// DemotedSysProcAttr is the single entry point for demotions that keep the
+// user's supplementary groups (Demote, websh PTY, code-server): one place for
+// setgroups(2) capping, so those paths cannot drift. Demotions that must drop
+// the group list build their own Credential with Groups left nil.
+func DemotedSysProcAttr(uid, gid uint32, groupIds []string) (attr *syscall.SysProcAttr, groupInList bool, err error) {
+	groups, groupInList, err := resolveGroups(gid, groupIds, maxSupplementaryGroups())
+	if err != nil {
+		return nil, false, err
+	}
+	return &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid:    uid,
+			Gid:    gid,
+			Groups: groups,
+		},
+	}, groupInList, nil
 }
 
 // resolveGroups builds the supplementary group list for Credential.Groups.
@@ -99,7 +109,7 @@ func Demote(username, groupname string, opts DemoteOptions) (*DemoteResult, erro
 		return nil, err
 	}
 
-	groups, groupInList, err := ResolveGroups(uint32(gid), groupIds)
+	sysProcAttr, groupInList, err := DemotedSysProcAttr(uint32(uid), uint32(gid), groupIds)
 	if err != nil {
 		return nil, err
 	}
@@ -111,13 +121,7 @@ func Demote(username, groupname string, opts DemoteOptions) (*DemoteResult, erro
 	log.Debug().Msgf("Demote permission to match user: %s, group: %s.", username, groupname)
 
 	return &DemoteResult{
-		SysProcAttr: &syscall.SysProcAttr{
-			Credential: &syscall.Credential{
-				Uid:    uint32(uid),
-				Gid:    uint32(gid),
-				Groups: groups,
-			},
-		},
-		User: usr,
+		SysProcAttr: sysProcAttr,
+		User:        usr,
 	}, nil
 }

--- a/pkg/utils/privilege_unix_test.go
+++ b/pkg/utils/privilege_unix_test.go
@@ -89,17 +89,71 @@ func TestResolveGroups(t *testing.T) {
 	}
 }
 
-func TestResolveGroups_AppliesPlatformCap(t *testing.T) {
+func TestDemotedSysProcAttr(t *testing.T) {
+	tests := []struct {
+		name       string
+		uid        uint32
+		gid        uint32
+		groupIds   []string
+		wantGroups []uint32
+		wantInList bool
+		wantErr    bool
+	}{
+		{
+			name: "assembles credential with resolved groups", uid: 501, gid: 20,
+			groupIds:   []string{"80", "20", "12"},
+			wantGroups: []uint32{20, 80, 12}, wantInList: true,
+		},
+		{
+			// Non-membership is reported, not rejected: enforcing it is the
+			// caller's choice via DemoteOptions.ValidateGroup.
+			name: "reports non-member group without failing", uid: 501, gid: 99,
+			groupIds:   []string{"80"},
+			wantGroups: []uint32{99, 80},
+		},
+		{
+			name: "no supplementary groups keeps only the primary gid", uid: 0, gid: 0,
+			groupIds:   nil,
+			wantGroups: []uint32{0},
+		},
+		{
+			// Must fail the demotion, not silently drop the gid as the old paths did.
+			name: "unparsable group id is an error", uid: 501, gid: 20,
+			groupIds: []string{"nope"}, wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr, inList, err := DemotedSysProcAttr(tt.uid, tt.gid, tt.groupIds)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, attr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, attr)
+			require.NotNil(t, attr.Credential)
+			assert.Equal(t, tt.uid, attr.Credential.Uid)
+			assert.Equal(t, tt.gid, attr.Credential.Gid)
+			assert.Equal(t, tt.wantGroups, attr.Credential.Groups)
+			assert.Equal(t, tt.wantInList, inList)
+		})
+	}
+}
+
+func TestDemotedSysProcAttr_AppliesPlatformCap(t *testing.T) {
 	groupIds := make([]string, 0, 64)
 	for i := 1; i <= 64; i++ {
 		groupIds = append(groupIds, strconv.Itoa(i))
 	}
 
-	groups, _, err := ResolveGroups(99, groupIds)
+	attr, _, err := DemotedSysProcAttr(501, 99, groupIds)
 	require.NoError(t, err)
 
 	// The exported entry point must apply maxSupplementaryGroups(); anything
 	// larger would make setgroups(2) fail with EINVAL on a capped platform.
+	groups := attr.Credential.Groups
 	if cap := maxSupplementaryGroups(); cap > 0 {
 		assert.Len(t, groups, cap)
 	} else {

--- a/pkg/utils/privilege_unix_test.go
+++ b/pkg/utils/privilege_unix_test.go
@@ -43,6 +43,12 @@ func TestResolveGroups(t *testing.T) {
 			want:      []uint32{99, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 		},
 		{
+			// Without dedup the repeated 80 would eat a cap slot and push 12 out.
+			name: "duplicate supplementary gids deduped before capping", gid: 99,
+			groupIds: []string{"80", "80", "12"}, maxGroups: 3,
+			want: []uint32{99, 80, 12},
+		},
+		{
 			name: "exactly at cap keeps every entry", gid: 99,
 			groupIds: []string{"1", "2"}, maxGroups: 3,
 			want: []uint32{99, 1, 2},
@@ -110,6 +116,11 @@ func TestDemotedSysProcAttr(t *testing.T) {
 			name: "reports non-member group without failing", uid: 501, gid: 99,
 			groupIds:   []string{"80"},
 			wantGroups: []uint32{99, 80},
+		},
+		{
+			name: "duplicate group ids deduped", uid: 501, gid: 99,
+			groupIds:   []string{"80", "80", "12"},
+			wantGroups: []uint32{99, 80, 12},
 		},
 		{
 			name: "no supplementary groups keeps only the primary gid", uid: 0, gid: 0,


### PR DESCRIPTION
## Background

PR #380 consolidated supplementary-group resolution into `utils.ResolveGroups`, settling four rules: the primary gid goes first, the platform `setgroups(2)` cap applies, an unparsable gid is an error, and a `usr.GroupIds()` failure propagates. Only resolution was consolidated, though. Assembly stayed with the callers, so each one called `ResolveGroups` and then built `syscall.SysProcAttr{Credential: ...}` on its own.

As a result `parseGroupIDs` in `pkg/runner/tunnel_linux.go` never went through #380, and it handled all four rules differently.

| Rule | `resolveGroups` | `parseGroupIDs` |
|---|---|---|
| Primary gid placed first | Yes | No |
| `maxSupplementaryGroups()` cap | Applied | Not applied |
| Unparsable gid | Returns an error | Skipped with `continue` |
| `usr.GroupIds()` failure | Propagated | `return nil` |

That last one is the damaging case. A nil `Credential.Groups` makes Go call `setgroups(0, NULL)` (`$GOROOT/src/syscall/exec_linux.go:490-506`), so the code-server session came up with every supplementary group stripped and no error to show for it. The file is `_linux.go`, so none of this was reachable from the darwin symptom #380 fixed.

## Changes

`ResolveGroups` is gone, replaced by `DemotedSysProcAttr(uid, gid, groupIds)`, which resolves the group list and assembles the credential together. Leaving exactly one exported entry point is the point: as long as `ResolveGroups` existed, a new call site could reach for manual assembly again.

`Demote` returns the helper's result and `setPtyCmdSysProcAttrAndEnv` assigns it directly, which also drops `syscall` from `pty_unix.go`'s imports.

`getCodeServerCredential` deletes `parseGroupIDs` and assembles through `utils.DemotedSysProcAttr`. The `usr.GroupIds()` error is now propagated, and an unparsable gid fails the session start instead of being silently omitted.

One more gap surfaced in review: `resolveGroups` only dropped gids that matched the primary gid, so a gid repeated inside `groupIds` stayed in the list, consumed a slot of the `setgroups(2)` cap, and could push a distinct group out. It now dedupes the whole list before capping. On darwin, where the cap is `kern.ngroups` (16), a repeated gid no longer evicts a group the user actually needs. Dedup lives in `resolveGroups` rather than in `DemotedSysProcAttr` so it sits beside the cap it interacts with.

## Permissions

`utils.Demote` could not be substituted wholesale. It returns `nil, nil` for an empty groupname, which callers read as "run as the current user", while code-server accepts an empty groupname and must still demote to the user's primary group. Substituting it would have run code-server as root.

Only the uid/gid resolution was split out into `codeServerIDs`, with assembly shared. That split makes it testable without root, so `TestCodeServerIDs` actually runs in CI and pins the rule as a regression test.

Effective privileges are unchanged. The primary gid now appears in `Groups`, but `Credential.Gid` already grants the same gid via setgid.

## Safety

`getNobodyCredential` is deliberately excluded and keeps assembling its own `Credential`. There the `setgroups(0, NULL)` call is the point: the tunnel daemon should hold no supplementary groups at all, so routing it through the shared helper would widen what it can reach. The reason is noted in place so the exception reads as deliberate.

Production sites that assemble a `syscall.Credential{}` therefore drop from four to two: the shared entry point plus the documented nobody exception. Consolidating all four was never the goal. The nil `Groups` in `getNobodyCredential` is a feature, not a defect.

## Tests

`TestDemotedSysProcAttr` adds five cases: uid/gid placement, a requested group the user is not a member of still assembling while membership is reported as false, duplicate group ids being deduped, no supplementary groups leaving only the primary gid, and an unparsable gid failing the whole demotion. `TestResolveGroups_AppliesPlatformCap` now guards the exported surface, so it moved to `TestDemotedSysProcAttr_AppliesPlatformCap`. The existing ten `TestResolveGroups` cases covering the unexported `resolveGroups` are kept, and an eleventh pins dedup-before-capping: with a cap of three, `groupIds` of `80, 80, 12` under primary gid 99 used to yield `99, 80, 80` and drop 12 entirely.

`TestCodeServerIDs` adds four cases: the primary-group fallback for an empty groupname, groupname taking precedence, an unknown groupname erroring, and an unparsable uid erroring. `tunnel_linux_test.go` only compiles on Linux, so it was run in Docker (`golang:1.25`) to verify.

`go build` and `go vet` pass on darwin, linux, and windows. `GOOS=linux golangci-lint run` reports 0 issues and `go test ./pkg/utils/... ./pkg/runner/...` passes. To confirm the branch adds no dead code, `origin/main` was checked out in a separate worktree and the same linters (`unused`, `unparam`, `ineffassign`, `staticcheck`) were run across all three platforms; the finding lists matched down to the line numbers.

`getCodeServerCredential` and `Demote` themselves remain untested because they require root, unchanged from before. Demotion was not verified against a real production server.

Closes #386

