### PR TITLE
refactor(runner): drop dead localSudoRequests map and its read paths

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -745,7 +745,8 @@ func (am *AuthManager) signalCompletion(requestID string) {
 		select {
 		case ch <- struct{}{}:
 		default:
-			// Channel already signaled or closed
+			// Already signaled: the capacity-1 buffer is full and the waiter
+			// only needs one signal. Nothing closes these channels.
 		}
 	}
 }

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -438,11 +438,7 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		Str("command_id", sudoApprovalReq.CommandID).
 		Msg("Alpacon user sudo request")
 
-	// Store completion channel so HandleSudoApprovalResponse can unblock the wait below.
-	// Buffered so signalCompletion's non-blocking send lands even if the response is
-	// processed before this goroutine reaches the select.
-	completionChan := make(chan struct{}, 1)
-	am.storeCompletionChannel(sudoApprovalReq.RequestID, completionChan)
+	completionChan := am.newCompletionChannel(sudoApprovalReq.RequestID)
 
 	// Send Sudo Approval request to the alpacon-server with retry
 	if err := am.sendSudoRequestWithRetry(sudoApprovalReq); err != nil {
@@ -724,10 +720,15 @@ func RegisterCommandPID(pid int, commandID, username string) func() {
 	return func() { am.RemovePIDCommandMapping(pid, commandID) }
 }
 
-func (am *AuthManager) storeCompletionChannel(requestID string, ch chan struct{}) {
+// Capacity 1 is load-bearing: signalCompletion sends without blocking, so an
+// unbuffered channel drops the signal when the response beats the waiter's select.
+func (am *AuthManager) newCompletionChannel(requestID string) chan struct{} {
+	ch := make(chan struct{}, 1)
 	am.mu.Lock()
 	am.completionChannels[requestID] = ch
 	am.mu.Unlock()
+
+	return ch
 }
 
 func (am *AuthManager) removeCompletionChannel(requestID string) {
@@ -745,8 +746,7 @@ func (am *AuthManager) signalCompletion(requestID string) {
 		select {
 		case ch <- struct{}{}:
 		default:
-			// Already signaled: the capacity-1 buffer is full and the waiter
-			// only needs one signal. Nothing closes these channels.
+			// Already signaled; the waiter only needs one.
 		}
 	}
 }

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -438,8 +438,10 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		Str("command_id", sudoApprovalReq.CommandID).
 		Msg("Alpacon user sudo request")
 
-	// Store completion channel so HandleSudoApprovalResponse can unblock the wait below
-	completionChan := make(chan struct{})
+	// Store completion channel so HandleSudoApprovalResponse can unblock the wait below.
+	// Buffered so signalCompletion's non-blocking send lands even if the response is
+	// processed before this goroutine reaches the select.
+	completionChan := make(chan struct{}, 1)
 	am.storeCompletionChannel(sudoApprovalReq.RequestID, completionChan)
 
 	// Send Sudo Approval request to the alpacon-server with retry

--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -133,7 +133,6 @@ type AuthManager struct {
 	pidToSessionMap    map[int]*SessionInfo
 	controlClient      *ControlClient
 	listener           net.Listener
-	localSudoRequests  map[string]*SudoRequest
 	completionChannels map[string]chan struct{}
 	session            *scheduler.Session
 	blockLocalSudo     bool
@@ -154,7 +153,6 @@ func GetAuthManager(controlClient *ControlClient, session *scheduler.Session) *A
 	authManagerOnce.Do(func() {
 		authManager = &AuthManager{
 			pidToSessionMap:    make(map[int]*SessionInfo),
-			localSudoRequests:  make(map[string]*SudoRequest),
 			completionChannels: make(map[string]chan struct{}),
 			session:            session,
 		}
@@ -162,10 +160,6 @@ func GetAuthManager(controlClient *ControlClient, session *scheduler.Session) *A
 
 	if authManager.controlClient == nil {
 		authManager.controlClient = controlClient
-	}
-
-	if authManager.localSudoRequests == nil {
-		authManager.localSudoRequests = make(map[string]*SudoRequest)
 	}
 
 	if authManager.completionChannels == nil {
@@ -386,9 +380,6 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		return
 	}
 
-	// Create completion channel to signal when response is received
-	completionChan := make(chan struct{})
-
 	sid, sidOK := sessionID(sudoApprovalReq.PID)
 	am.mu.Lock()
 	session, exists := am.lookupSessionLocked(sid, sidOK, sudoApprovalReq.PPID)
@@ -447,7 +438,8 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 		Str("command_id", sudoApprovalReq.CommandID).
 		Msg("Alpacon user sudo request")
 
-	// Store completion channel for this request
+	// Store completion channel so HandleSudoApprovalResponse can unblock the wait below
+	completionChan := make(chan struct{})
 	am.storeCompletionChannel(sudoApprovalReq.RequestID, completionChan)
 
 	// Send Sudo Approval request to the alpacon-server with retry
@@ -545,7 +537,6 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 	am.mu.Lock()
 	var sudoRequest *SudoRequest
 
-	// 1. find in alpacon user requests
 	for _, session := range am.pidToSessionMap {
 		if req, exists := session.Requests[response.RequestID]; exists {
 			delete(session.Requests, response.RequestID)
@@ -554,22 +545,10 @@ func (am *AuthManager) HandleSudoApprovalResponse(response SudoApprovalResponse)
 			break
 		}
 	}
-
-	// 2. find in local user requests
-	if sudoRequest == nil {
-		if req, exists := am.localSudoRequests[response.RequestID]; exists {
-			delete(am.localSudoRequests, response.RequestID)
-			sudoRequest = req
-			log.Debug().Msgf("Found local user request for ID: %s", response.RequestID)
-		} else {
-			log.Debug().Msgf("Request ID %s not found in localSudoRequests", response.RequestID)
-		}
-	}
 	am.mu.Unlock()
 
 	if sudoRequest == nil {
 		am.mu.RLock()
-		log.Debug().Msgf("Current localSudoRequests: %+v", am.localSudoRequests)
 		for _, session := range am.pidToSessionMap {
 			log.Debug().Msgf("Session %s requests: %+v", session.SessionID, session.Requests)
 		}
@@ -775,16 +754,10 @@ func (am *AuthManager) isRequestPending(requestID string) bool {
 	am.mu.RLock()
 	defer am.mu.RUnlock()
 
-	// Check alpacon user requests
 	for _, session := range am.pidToSessionMap {
 		if _, exists := session.Requests[requestID]; exists {
 			return true
 		}
-	}
-
-	// Check local user requests
-	if _, exists := am.localSudoRequests[requestID]; exists {
-		return true
 	}
 
 	return false
@@ -802,7 +775,6 @@ func (am *AuthManager) Stop() {
 func (am *AuthManager) cleanupTimeoutRequest(requestID string, approved bool, reason string) {
 	am.mu.Lock()
 
-	// 1. Alpacon user
 	for _, session := range am.pidToSessionMap {
 		if req, exists := session.Requests[requestID]; exists {
 			delete(session.Requests, requestID)
@@ -813,17 +785,6 @@ func (am *AuthManager) cleanupTimeoutRequest(requestID string, approved bool, re
 			}
 			return
 		}
-	}
-
-	// 2. Local user
-	if req, exists := am.localSudoRequests[requestID]; exists {
-		delete(am.localSudoRequests, requestID)
-		am.mu.Unlock()
-		if req.Connection != nil {
-			am.sendSudoApprovalResponse(req.Connection, SudoApprovalRequest{RequestID: requestID}, approved, reason)
-			_ = req.Connection.Close()
-		}
-		return
 	}
 
 	am.mu.Unlock()

--- a/pkg/runner/auth_manager_completion_test.go
+++ b/pkg/runner/auth_manager_completion_test.go
@@ -1,0 +1,54 @@
+package runner
+
+import (
+	"testing"
+	"time"
+)
+
+// The channel must come from newCompletionChannel, not from the test: a channel
+// the test allocates itself would keep passing after the production capacity is
+// dropped, pinning nothing.
+func TestNewCompletionChannel_SurvivesSignalBeforeReceive(t *testing.T) {
+	am := newTestAuthManager()
+	ch := am.newCompletionChannel("req-1")
+
+	// The websocket read loop can process the response while the waiter is still
+	// inside sendSudoRequestWithRetry, before it reaches its select.
+	am.signalCompletion("req-1")
+
+	select {
+	case <-ch:
+	default:
+		t.Fatal("completion signal was dropped before the waiter received it")
+	}
+}
+
+// signalCompletion runs on the websocket read loop, so it must never wait for a
+// receiver, not even when the buffer already holds a signal.
+func TestSignalCompletion_DoesNotBlockWhenAlreadySignaled(t *testing.T) {
+	am := newTestAuthManager()
+	am.newCompletionChannel("req-1")
+	am.signalCompletion("req-1")
+
+	returned := make(chan struct{})
+	go func() {
+		am.signalCompletion("req-1")
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("signalCompletion blocked on a full buffer")
+	}
+}
+
+// The timeout path removes the channel, so a response arriving afterwards reaches
+// signalCompletion with nothing registered.
+func TestSignalCompletion_UnknownRequestIsNoop(t *testing.T) {
+	am := newTestAuthManager()
+	am.newCompletionChannel("req-1")
+	am.removeCompletionChannel("req-1")
+
+	am.signalCompletion("req-1")
+}

--- a/pkg/runner/auth_manager_testing.go
+++ b/pkg/runner/auth_manager_testing.go
@@ -9,7 +9,6 @@ package runner
 func NewEmptyAuthManager() *AuthManager {
 	return &AuthManager{
 		pidToSessionMap:    make(map[int]*SessionInfo),
-		localSudoRequests:  make(map[string]*SudoRequest),
 		completionChannels: make(map[string]chan struct{}),
 	}
 }

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -13,7 +13,6 @@ import (
 func newTestAuthManager() *AuthManager {
 	return &AuthManager{
 		pidToSessionMap:    make(map[int]*SessionInfo),
-		localSudoRequests:  make(map[string]*SudoRequest),
 		completionChannels: make(map[string]chan struct{}),
 	}
 }

--- a/pkg/runner/auth_manager_tracker_test.go
+++ b/pkg/runner/auth_manager_tracker_test.go
@@ -7,14 +7,9 @@ import (
 	"time"
 )
 
-// newTestAuthManager returns an AuthManager with only the fields that the
-// tracker tests need populated. It intentionally does not start the
-// socket listener, so tests stay fast and isolated.
+// The shipped helper already builds exactly what these tests need.
 func newTestAuthManager() *AuthManager {
-	return &AuthManager{
-		pidToSessionMap:    make(map[int]*SessionInfo),
-		completionChannels: make(map[string]chan struct{}),
-	}
+	return NewEmptyAuthManager()
 }
 
 // TestAddPIDCommandMapping_RegistersCommandKind verifies that Commands


### PR DESCRIPTION
## Background

`AuthManager.localSudoRequests` has no write path. When it was introduced (5589152) it held sudo requests from non-Websh (local) users while the agent waited for a server decision. b5c7de9 then changed local requests to be answered synchronously inside `handleSudoApprovalRequest`, on the grounds that alpacon-server rejects them anyway, and deleted the registration while leaving the lookups behind. 47bbe5c later added one more read of the now-empty map in `isRequestPending`.

The map is therefore always empty, so the local branches in `HandleSudoApprovalResponse`, `isRequestPending`, and `cleanupTimeoutRequest` can never match. Reading the code suggests local requests are tracked as pending, which misrepresents what actually happens (an immediate synchronous answer).

Reviewing the completion channel on the way out surfaced a second, unrelated defect in the same function, which this PR also fixes. Review then added a regression test and two small cleanups. Each part is described separately below.

## Changes

### Removing the dead map

Removed the `localSudoRequests` field, its two initialization sites, and all four places that read it.

- `HandleSudoApprovalResponse`: the "2. find in local user requests" block and the debug log that dumped the whole map
- `isRequestPending`: the local-request lookup branch
- `cleanupTimeoutRequest`: the "2. Local user" block
- The initialization in the `NewEmptyAuthManager` and `newTestAuthManager` helpers

The `// 1. Alpacon user` / `// 2. Local user` numbering comments went with them, since only one branch remains in each function.

`handleSudoApprovalRequest` also allocated `completionChan` at the top of the function even though the local path returns before ever using it. The allocation now happens where the channel is registered.

This part changes no behavior. Local sudo is still decided synchronously according to the `blockLocalSudo` policy, and Alpacon-user requests still register in `SessionInfo.Requests`.

### Fixing the dropped completion signal

`completionChan` was unbuffered while `signalCompletion` sends on it with a non-blocking `select`, so the signal is dropped whenever `HandleSudoApprovalResponse` runs before the waiter reaches its `select`. That window is not just the few instructions after the channel is registered: it spans the blocking REST call in `sendSudoRequestWithRetry`, so a response arriving on the websocket read loop while that call is in flight is lost.

The channel is now buffered with capacity 1, so the first signal always lands. This matches the other two non-blocking send sites in the tree, both already buffered-of-1 (`pkg/runner/client.go:76`, `pkg/pluginclient/client.go:215`); `completionChan` was the only outlier. `close(ch)` was rejected as an alternative because `removeCompletionChannel` and the timeout path can reach the same request, so a second close would panic.

Copilot raised this on the moved allocation line. The defect predates this PR: only the position of `make(...)` changed, not its buffering.

The `default` branch in `signalCompletion` was commented as "Channel already signaled or closed". Nothing in the tree closes a completion channel, and a send on a closed channel panics rather than taking `default`, so half of that comment described an unreachable case. It now states what capacity 1 actually makes the branch mean: a signal is already buffered.

### Responding to review

The buffering fix now has a regression test in `pkg/runner/auth_manager_completion_test.go`. Review was right that the property which regressed is testable even though the race is not. The test suggested in review allocated the channel itself, so it would have kept passing once the production capacity was dropped, pinning nothing. The allocation moved into a `newCompletionChannel` helper instead, so the test exercises the channel `handleSudoApprovalRequest` actually gets. Confirmed by temporarily restoring the unbuffered channel: the new test fails, and passes again once the capacity is back.

Two further tests cover the surrounding contract: that `signalCompletion` never blocks on a full buffer, since it runs on the websocket read loop, and that a signal for an already-removed request is a no-op, which the timeout path can cause.

`newTestAuthManager` now delegates to `NewEmptyAuthManager()`. The two helpers were byte-identical, which is why the dead-field deletion above had to be made twice.

## Safety

This touches the sudo approval path, so the authorization logic was checked separately from the cleanup. The branches that decide approval (the `blockLocalSudo` check and the session lookup in `pkg/runner/auth_manager.go:384-402`) are unchanged, and everything removed is a lookup against a map that is always empty.

The dropped-signal fix does not change any approval outcome either. When the signal is lost, `HandleSudoApprovalResponse` has already written the response to the PAM client (`auth_manager.go:566`) and closed the connection (`:577`); at the 30s timeout `isRequestPending` returns false because the response handler removed the entry, so the timeout branch takes its no-op path. The cost is a goroutine and a map entry that linger for 30 seconds, not a wrong decision. The fix removes that lingering.

One narrow window stays open, raised in review: the request becomes findable by `HandleSudoApprovalResponse` when it is registered into `SessionInfo.Requests`, a few lines before the completion channel is registered. A response landing in that gap is still dropped. It is only reachable from a stale or duplicated `request_id`, since the request has not been sent to the server yet, and closing it properly means restructuring the critical section. Tracked in #395.

## Tests

- `go build ./...` and `go vet ./...` pass
- `go test ./... -p 1` passes (45 packages); `go test ./pkg/runner/ -p 1` re-run after each commit
- The removal adds no tests: it deletes unreachable branches, so there is no new behavior to verify, and no test covered the three functions to begin with.
- Three tests added in `pkg/runner/auth_manager_completion_test.go`. An end-to-end reproduction of the dropped signal remains impractical, needing a live Unix socket, a server round trip, and a won race inside `sendSudoRequestWithRetry`, but the property that regressed is checkable on its own. An earlier revision of this section called the fix untestable, which conflated the race with the property.
- The regression test was verified to fail without the fix, not just to pass with it: reverting the capacity to `make(chan struct{})` makes `TestNewCompletionChannel_SurvivesSignalBeforeReceive` fail.
- CI was green on 24878c6 across all 24 checks, covering the distro build-and-test jobs, golangci-lint, govulncheck, CodeQL, and the go.mod tidy check. The run for the two review-response commits on top is in flight as this is written.
- Locally, `golangci-lint run ./pkg/runner/...` reports `commit_types.go:154 field expireDate is unused`. That finding is present on main as well and is unrelated to this change. The local version is v2.12.2 while CI pins v2.9.0.

## Follow-ups

Three items raised in review are tracked separately rather than folded in here, so this PR keeps its no-behavior-change, no-API-change scope.

- #394: remove the write-only `SudoRequest.RequestID` field, which is the same dead-field class this PR deletes but changes an exported type
- #395: register the request and its completion channel in one critical section, closing the narrow window described under Safety
- #396: the retry-failure path sends two responses and closes the connection twice; predates this PR and needs the PAM client's read behavior confirmed first

## Checklist

- [x] Traced the code paths for every change: the removal and the two cleanups are behavior-preserving, and the buffering fix affects only cleanup timing
- [x] No remaining references to the removed symbol (`grep -rn localSudoRequests`)
- [x] Checked the rest of the tree for the same unbuffered-plus-non-blocking-send pattern; no other occurrence
- [x] Build, vet, and the full test suite pass
- [x] The regression test was verified to fail without the fix
