### PR TITLE
refactor(runner): drop redundant SudoRequest.RequestID field

### DIFF
--- a/pkg/runner/auth_manager.go
+++ b/pkg/runner/auth_manager.go
@@ -56,7 +56,6 @@ func (s *SessionInfo) effectiveKind() string {
 }
 
 type SudoRequest struct {
-	RequestID  string
 	Connection net.Conn
 }
 
@@ -426,7 +425,6 @@ func (am *AuthManager) handleSudoApprovalRequest(data []byte, unixConn net.Conn)
 	}
 
 	session.Requests[sudoApprovalReq.RequestID] = &SudoRequest{
-		RequestID:  sudoApprovalReq.RequestID,
 		Connection: unixConn,
 	}
 	am.mu.Unlock()


### PR DESCRIPTION
## Background

`SudoRequest` values are only ever reached through `SessionInfo.Requests`, a `map[string]*SudoRequest` that is already keyed by the request ID. The struct nevertheless carried a `RequestID` field holding the same value, and no code ever read it back off the struct. The same identifier existed in both the map key and the map value, leaving it ambiguous which one was authoritative.

## Changes

Removed the `RequestID` field from `SudoRequest` and dropped the corresponding assignment at its single construction site, `handleSudoApprovalRequest` (`pkg/runner/auth_manager.go:427`). `SudoRequest` now holds only `Connection net.Conn`.

To correlate a pending sudo request with its ID, use the `session.Requests` map key rather than a field on the value. `cleanupTimeoutRequest` (`pkg/runner/auth_manager.go:784`) already follows this: it passes the `requestID` parameter it used for the map lookup, not a field off the struct.

Collapsing the `SudoRequest` wrapper entirely into `map[string]net.Conn` was considered and rejected. It falls outside this branch's scope, and it would touch four files including `pkg/runner/pty.go` and the tests for little gain.

## Safety

`SudoRequest` has no JSON tags and is never serialized, so the wire format exchanged with alpacon-server is unaffected. The protocol-facing `SudoApprovalRequest.RequestID` and `SudoApprovalResponse.RequestID` fields are unchanged.

A repository-wide `git grep` across all file types confirms no remaining reader of the removed field: every surviving `SudoRequest` reference is the type definition, a map declaration or initialization, the construction site, or a local variable, and the only field access is `req.Connection`. Every surviving `RequestID` reference belongs to `SudoApprovalRequest` or `SudoApprovalResponse`. No Markdown, script, or config file mentions the field.

## Testing

- `go build ./pkg/runner/` passes
- `go vet ./pkg/runner/` passes
- `go test ./pkg/runner/ -p 1` passes (35.3s)

The sudo approval flow was not exercised manually on a real host.

Closes #394
